### PR TITLE
fix(systest): make R10 audit round-trip deterministic and daemon-managed

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -65,8 +65,12 @@ Prerequisites (the scenario fail-fasts with the exact remediation if missing):
 
 1. A reachable Docker daemon (`docker info`).
 2. A host-side codex login: `codex login` writes `~/.codex/auth.json`.
-3. A running Aileron daemon if you want the R10 audit assertion to read real
-   records (`AILERON_STATE_DIR` defaults to `~/.aileron`).
+3. The Aileron daemon binary (`aileron-server`) resolvable next to `aileron` or
+   on PATH. The scenario manages the daemon lifecycle itself through the CLI: it
+   runs `aileron daemon start` before the launch (idempotent — it reuses a daemon
+   you already have running) and `aileron daemon stop` on exit only if it started
+   one. R10 then asserts the audit round-trip against that daemon (state dir
+   `~/.aileron`). `task build` produces `aileron-server` alongside `aileron`.
 
 The simplest path is the Taskfile target:
 
@@ -95,8 +99,10 @@ AILERON_STATE_DIR="$HOME/.aileron" \
 Point `WORKSPACE` at any writable, empty temp directory. On Windows use a path
 under `%TEMP%`; the directory is bind-mounted into the container and seeded with
 the run sentinel. `EXPECTED_IMAGE` overrides the default expected image ref.
-`AILERON_STATE_DIR` is optional: when unset the R10 audit assertion is skipped
-with a logged note.
+`AILERON_STATE_DIR` should point at the daemon state dir (`~/.aileron`, the
+daemon's only state dir) so R10 reads the audit file the daemon writes; when
+unset the R10 audit assertion is skipped with a logged note. The Taskfile target
+sets it for you.
 
 The driver is its own nested Go module outside `./test/system/lib/...`, so the
 standard `go test ./test/system/lib/...` coverage and vet CI job never compiles
@@ -144,17 +150,25 @@ session id at runtime, so the exact name is discovered, not predicted).
   `/home/agent/workspace/.aileron-systest-sentinel`; the test reads
   `<workspace>/.aileron-systest-sentinel` on the host and asserts byte-exact
   equality. The `<runid>` is fresh each run, so a stale file cannot pass.
-- **R10 — audit round-trip (authored; deterministic where the daemon logs).**
-  The agent calls the built-in `http_request` MCP tool against the daemon's
-  own `${AILERON_URL}/healthz`. That routes through the daemon's `/comms/http`
-  handler, which appends a message audit entry to today's audit JSONL
+- **R10 — audit round-trip (daemon-backed, session-scoped).**
+  The agent calls the built-in `http_request` MCP tool with method GET against a
+  **concrete** daemon health URL. The scenario resolves that URL from
+  `aileron daemon start` (the daemon issues the outbound fetch itself, from the
+  host, so the URL must be host-reachable — its own gateway is, e.g.
+  `http://127.0.0.1:60036/healthz`). Nothing in the path expands a
+  `${AILERON_URL}` placeholder: the agent passes the `url` tool argument verbatim
+  (`cmd/aileron-mcp`), and the daemon fetches that exact string
+  (`internal/app/handlers_comms.go`), so a literal placeholder yields an invalid
+  request and no audit record (the original prompt's bug). The request routes
+  through the daemon's `/comms/http` handler, which appends an
+  `"event":"http_request_sent"` audit record carrying the launch's
+  `session_id` to today's audit JSONL
   (`internal/audit/local.go` `MessageEntry`, written by
-  `handlers_comms.go logCommsEvent`). The R10 jq assertion is **conditional**:
-  it runs only when `AILERON_STATE_DIR` points at a daemon state dir (it
-  defaults to `~/.aileron`), and it is skipped with a logged note when that
-  dir is unset, so a run without a daemon does not fail on a missing audit
-  trail. When enabled, the test jq-asserts today's audit file has event
-  records for this run window.
+  `handlers_comms.go logCommsEvent`). R10 polls today's audit file for an
+  `http_request_sent` record matching **this run's session id**
+  (`aileron-sbx-<sessionID>`), so it asserts the test's own round-trip rather
+  than any unrelated event line. It is skipped with a logged note only when
+  `AILERON_STATE_DIR` is unset.
 
   When the daemon's OpenTelemetry tracing is enabled, the richer span record
   carrying `aileron.action.name` lands separately under
@@ -201,8 +215,9 @@ Prerequisites (the scenario fail-fasts with the exact remediation if missing):
    vault holds the entry (`aileron vault list --scope agent` prints
    `agents/claude/oauth`). Run `aileron launch claude` once and complete the
    in-flow login (or `claude /login`) to populate it.
-3. A running Aileron daemon if you want the R10 audit assertion to read real
-   records (`AILERON_STATE_DIR` defaults to `~/.aileron`).
+3. The Aileron daemon binary (`aileron-server`) resolvable next to `aileron` or
+   on PATH; the scenario starts/stops the daemon through the CLI for the R10
+   round-trip exactly as the codex scenario does (state dir `~/.aileron`).
 
 The simplest path is the Taskfile target:
 

--- a/test/system/lib/audit.go
+++ b/test/system/lib/audit.go
@@ -74,3 +74,56 @@ func AssertAuditHasEvents(jsonl []byte, auditPath string) error {
 	}
 	return Fail(fmt.Sprintf("R10 no event records in %s for this run", auditPath))
 }
+
+// CountAuditEventsForSession counts audit records whose "event" equals wantEvent
+// and whose "session_id" equals wantSession. This is the session-scoped R10
+// check: it proves THIS launch's session produced the expected comms event
+// (e.g. "http_request_sent"), rather than counting any unrelated event record in
+// the shared daily audit file (which can hold thousands of lines from other
+// daemon activity). Empty/non-JSON lines are skipped. A read error is returned;
+// zero matches is (0, nil). When wantSession is empty, the session_id is not
+// constrained (any record with the matching event counts).
+func CountAuditEventsForSession(jsonl []byte, wantEvent, wantSession string) (int, error) {
+	count := 0
+	scanner := bufio.NewScanner(bytes.NewReader(jsonl))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec struct {
+			Event     string `json:"event"`
+			SessionID string `json:"session_id"`
+		}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Event != wantEvent {
+			continue
+		}
+		if wantSession != "" && rec.SessionID != wantSession {
+			continue
+		}
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// AssertAuditHasEventForSession is the session-scoped R10 decision wrapper: it
+// returns nil when the audit JSONL contains at least one record with
+// event==wantEvent and session_id==wantSession, and otherwise the R10 diagnostic
+// naming the event, session, and file. A read error is surfaced as non-nil too.
+func AssertAuditHasEventForSession(jsonl []byte, wantEvent, wantSession, auditPath string) error {
+	count, err := CountAuditEventsForSession(jsonl, wantEvent, wantSession)
+	if err != nil {
+		return Fail(fmt.Sprintf("R10 could not parse audit file %s: %v", auditPath, err))
+	}
+	if count > 0 {
+		return nil
+	}
+	return Fail(fmt.Sprintf("R10 no %q audit record for session %s in %s (the agent's http_request round-trip did not reach the daemon)", wantEvent, wantSession, auditPath))
+}

--- a/test/system/lib/audit_test.go
+++ b/test/system/lib/audit_test.go
@@ -78,3 +78,59 @@ func TestAssertAuditHasEventsNoRecords(t *testing.T) {
 		}
 	}
 }
+
+func TestCountAuditEventsForSessionMatchesEventAndSession(t *testing.T) {
+	jsonl := []byte(strings.Join([]string{
+		`{"event":"http_request_sent","session_id":"sess-A"}`, // counts
+		`{"event":"http_request_sent","session_id":"sess-B"}`, // wrong session: skipped
+		`{"event":"message_sent","session_id":"sess-A"}`,      // wrong event: skipped
+		`{"event":"http_request_sent"}`,                       // no session_id: skipped (session constrained)
+		`{"event":"http_request_sent","session_id":"sess-A"}`, // counts
+		``,         // empty: skipped
+		`not json`, // malformed: skipped
+	}, "\n") + "\n")
+	got, err := systestlib.CountAuditEventsForSession(jsonl, "http_request_sent", "sess-A")
+	if err != nil {
+		t.Fatalf("CountAuditEventsForSession returned error %v; want nil", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d; want 2 (only http_request_sent records for sess-A)", got)
+	}
+}
+
+func TestCountAuditEventsForSessionEmptySessionIgnoresSession(t *testing.T) {
+	// An empty wantSession constrains only the event, not the session_id.
+	jsonl := []byte(strings.Join([]string{
+		`{"event":"http_request_sent","session_id":"sess-A"}`,
+		`{"event":"http_request_sent","session_id":"sess-B"}`,
+	}, "\n") + "\n")
+	got, err := systestlib.CountAuditEventsForSession(jsonl, "http_request_sent", "")
+	if err != nil {
+		t.Fatalf("CountAuditEventsForSession returned error %v; want nil", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d; want 2 (both events, session unconstrained)", got)
+	}
+}
+
+func TestAssertAuditHasEventForSessionHappyPath(t *testing.T) {
+	jsonl := []byte(`{"event":"http_request_sent","session_id":"sess-A"}` + "\n")
+	if err := systestlib.AssertAuditHasEventForSession(jsonl, "http_request_sent", "sess-A", "/state/audit/x.jsonl"); err != nil {
+		t.Errorf("returned error %v; want nil for a matching record", err)
+	}
+}
+
+func TestAssertAuditHasEventForSessionMissing(t *testing.T) {
+	// The session's event is absent (only another session's record present).
+	jsonl := []byte(`{"event":"http_request_sent","session_id":"other"}` + "\n")
+	const path = "/state/audit/audit-2026-06-24.jsonl"
+	err := systestlib.AssertAuditHasEventForSession(jsonl, "http_request_sent", "sess-A", path)
+	if err == nil {
+		t.Fatal("returned nil; want the R10 missing-record diagnostic")
+	}
+	for _, sub := range []string{"R10", "http_request_sent", "sess-A", path} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err.Error(), sub)
+		}
+	}
+}

--- a/test/system/lib/daemon.go
+++ b/test/system/lib/daemon.go
@@ -1,0 +1,29 @@
+// Pure parsing for the daemon-lifecycle CLI calls the scenario driver makes
+// (`aileron daemon start/status/stop`). Kept here, in the GO_TEST_PACKAGES lib,
+// so the parse logic is unit-tested in CI while the impure exec.Command plumbing
+// stays in the by-hand scenario driver.
+package systestlib
+
+import "strings"
+
+// ParseDaemonStartURL extracts the daemon URL from `aileron daemon start` output,
+// whose success line is "Aileron daemon running at <url>" (idempotent — it prints
+// the same line for an already-running daemon). Returns "" if no such line is
+// present.
+func ParseDaemonStartURL(out string) string {
+	const marker = "running at "
+	for _, line := range strings.Split(out, "\n") {
+		if i := strings.Index(line, marker); i >= 0 {
+			return strings.TrimSpace(line[i+len(marker):])
+		}
+	}
+	return ""
+}
+
+// DaemonStatusRunning reports whether `aileron daemon status` output indicates a
+// running daemon. Status prints "Aileron daemon is running." when up and
+// "Aileron daemon is not running." when down; the substring "daemon is running"
+// matches only the former (the latter contains "daemon is not running").
+func DaemonStatusRunning(out string) bool {
+	return strings.Contains(out, "daemon is running")
+}

--- a/test/system/lib/daemon_test.go
+++ b/test/system/lib/daemon_test.go
@@ -1,0 +1,41 @@
+// Contract tests for the daemon-CLI output parsers used by the scenario driver.
+package systestlib_test
+
+import (
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestParseDaemonStartURL(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"start line", "Aileron daemon running at http://127.0.0.1:60036\n", "http://127.0.0.1:60036"},
+		{"trailing whitespace", "Aileron daemon running at http://127.0.0.1:60036   \n", "http://127.0.0.1:60036"},
+		{"amid other lines", "starting...\nAileron daemon running at http://127.0.0.1:7777\nready\n", "http://127.0.0.1:7777"},
+		{"no url line", "some unrelated output\n", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := systestlib.ParseDaemonStartURL(c.out); got != c.want {
+				t.Errorf("ParseDaemonStartURL(%q) = %q; want %q", c.out, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDaemonStatusRunning(t *testing.T) {
+	if !systestlib.DaemonStatusRunning("Aileron daemon is running.\n  URL: http://x\n") {
+		t.Error("running status not detected as running")
+	}
+	if systestlib.DaemonStatusRunning("Aileron daemon is not running.\nHint: ...\n") {
+		t.Error("not-running status wrongly detected as running")
+	}
+	if systestlib.DaemonStatusRunning("") {
+		t.Error("empty output wrongly detected as running")
+	}
+}

--- a/test/system/lib/runner.go
+++ b/test/system/lib/runner.go
@@ -153,17 +153,25 @@ func BuildExecArgs(cfg AgentConfig, prompt string) []string {
 	return args
 }
 
-// BuildPrompt assembles the deterministic two-step agent prompt, byte-for-byte
-// faithful to codex.sh's EXEC_PROMPT: (1) write the exact sentinel string (no
-// newline, nothing else) to <WorkspaceContainerPath>/<SentinelName>, and (2)
-// call the aileron http_request tool GET ${AILERON_URL}/healthz so a daemon-side
-// audit record lands for the run (R10). sentinel is the per-run token from
-// Sentinel(runID). The ${AILERON_URL} is left literal so the container's shell/
-// agent expands it inside the sandbox, matching the bash.
-func BuildPrompt(cfg AgentConfig, sentinel string) string {
+// BuildPrompt assembles the deterministic two-step agent prompt: (1) write the
+// exact sentinel string (no newline, nothing else) to
+// <WorkspaceContainerPath>/<SentinelName> (R9), and (2) call the aileron
+// http_request tool GET <healthURL> so a daemon-side audit record lands for the
+// run (R10). sentinel is the per-run token from Sentinel(runID).
+//
+// healthURL MUST be a fully-resolved absolute URL (e.g.
+// http://127.0.0.1:60036/healthz), NOT a `${AILERON_URL}` placeholder. Nothing
+// in the path expands shell-style placeholders: the agent passes the url tool
+// argument verbatim (cmd/aileron-mcp), and the daemon issues the outbound fetch
+// against that exact string (internal/app/handlers_comms.go). A literal
+// placeholder therefore produces an invalid request and no audit record, which
+// is why the original `${AILERON_URL}/healthz` prompt never produced an R10
+// record. The caller resolves the running daemon's host URL (via
+// `aileron daemon start`) and passes <daemonURL>/healthz here.
+func BuildPrompt(cfg AgentConfig, sentinel, healthURL string) string {
 	return fmt.Sprintf(
 		"Do exactly two things and then stop. "+
 			"1) Write the exact text %s (no newline, nothing else) to the file %s/%s. "+
-			"2) Call the aileron http_request tool with method GET and url ${AILERON_URL}/healthz.",
-		sentinel, cfg.WorkspaceContainerPath, cfg.SentinelName)
+			"2) Call the aileron http_request tool with method GET and url %s.",
+		sentinel, cfg.WorkspaceContainerPath, cfg.SentinelName, healthURL)
 }

--- a/test/system/lib/runner_test.go
+++ b/test/system/lib/runner_test.go
@@ -129,7 +129,8 @@ func TestBuildExecArgsClaude(t *testing.T) {
 func TestBuildPromptClaude(t *testing.T) {
 	cfg := systestlib.ClaudeConfig("")
 	sentinel := systestlib.Sentinel("17-42-abc")
-	prompt := systestlib.BuildPrompt(cfg, sentinel)
+	const healthURL = "http://127.0.0.1:60036/healthz"
+	prompt := systestlib.BuildPrompt(cfg, sentinel, healthURL)
 
 	if !strings.Contains(prompt, sentinel) {
 		t.Errorf("prompt missing the sentinel token %q:\n%s", sentinel, prompt)
@@ -138,8 +139,11 @@ func TestBuildPromptClaude(t *testing.T) {
 	if !strings.Contains(prompt, wantPath) {
 		t.Errorf("prompt missing the sentinel file path %q:\n%s", wantPath, prompt)
 	}
-	if !strings.Contains(prompt, "${AILERON_URL}/healthz") {
-		t.Errorf("prompt missing the healthz URL (literal ${AILERON_URL}):\n%s", prompt)
+	if !strings.Contains(prompt, healthURL) {
+		t.Errorf("prompt missing the resolved healthz URL %q:\n%s", healthURL, prompt)
+	}
+	if strings.Contains(prompt, "${AILERON_URL}") {
+		t.Errorf("prompt still contains the unexpanded ${AILERON_URL} placeholder (nothing expands it):\n%s", prompt)
 	}
 }
 
@@ -190,7 +194,8 @@ func TestBuildExecArgsDoesNotAliasBatchFlags(t *testing.T) {
 func TestBuildPrompt(t *testing.T) {
 	cfg := systestlib.CodexConfig("")
 	sentinel := systestlib.Sentinel("17-42-abc")
-	prompt := systestlib.BuildPrompt(cfg, sentinel)
+	const healthURL = "http://127.0.0.1:60036/healthz"
+	prompt := systestlib.BuildPrompt(cfg, sentinel, healthURL)
 
 	// Side effect 1: write the exact sentinel to the workspace sentinel file.
 	if !strings.Contains(prompt, sentinel) {
@@ -200,12 +205,17 @@ func TestBuildPrompt(t *testing.T) {
 	if !strings.Contains(prompt, wantPath) {
 		t.Errorf("prompt missing the sentinel file path %q:\n%s", wantPath, prompt)
 	}
-	// Side effect 2: call the http_request tool GET ${AILERON_URL}/healthz.
+	// Side effect 2: call the http_request tool GET <resolved healthz URL>. The
+	// URL must be concrete (no ${AILERON_URL} placeholder), since nothing in the
+	// agent/tool/daemon path expands shell-style placeholders.
 	if !strings.Contains(prompt, "http_request") {
 		t.Errorf("prompt missing the http_request instruction:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "${AILERON_URL}/healthz") {
-		t.Errorf("prompt missing the healthz URL (literal ${AILERON_URL}):\n%s", prompt)
+	if !strings.Contains(prompt, healthURL) {
+		t.Errorf("prompt missing the resolved healthz URL %q:\n%s", healthURL, prompt)
+	}
+	if strings.Contains(prompt, "${AILERON_URL}") {
+		t.Errorf("prompt still contains the unexpanded ${AILERON_URL} placeholder (nothing expands it):\n%s", prompt)
 	}
 	if !strings.Contains(prompt, "method GET") {
 		t.Errorf("prompt missing the GET method:\n%s", prompt)

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	systestlib "github.com/ALRubinger/aileron/test/system/lib"
@@ -20,6 +21,16 @@ const sbxPrefix = "aileron-sbx-"
 // after a graceful SIGINT (so the launcher's `docker stop` handler can tear the
 // sandbox down) before escalating to SIGKILL.
 const reapGracePeriod = 10 * time.Second
+
+// r10PollTimeout is how long the R10 assertion polls the audit file for this
+// run's http_request_sent record. The daemon writes it from a background
+// goroutine (handlers_comms.executeApprovedCommsHTTP), so it can lag the launch
+// exit; poll rather than read once.
+const r10PollTimeout = 20 * time.Second
+
+// r10Event is the comms audit event the daemon logs for a forwarded http_request
+// (internal/app/handlers_comms.go logCommsEvent("http_request_sent", ...)).
+const r10Event = "http_request_sent"
 
 // env holds the validated environment the scenario reads, mirroring the bash
 // `: "${VAR:?...}"` preconditions. AILERON_SYSTEST_LIB is intentionally absent:
@@ -87,7 +98,30 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	// Per-run sentinel (R9): a fresh token so a stale workspace file can't pass.
 	runID := systestlib.NewRunID()
 	sentinel := systestlib.Sentinel(runID)
-	prompt := systestlib.BuildPrompt(cfg, sentinel)
+
+	// --- daemon lifecycle (R10 prerequisite) -------------------------------
+	// Drive the daemon through the CLI exactly as a user would: ensure one is
+	// running (`aileron daemon start` is idempotent and prints its host URL),
+	// and stop it on exit ONLY if this run started it — never clobber a daemon
+	// the operator already had up. `aileron launch` would auto-spawn one too,
+	// but starting it here gives us the concrete host URL the agent's R10
+	// http_request must target (the daemon issues that fetch from the host, so
+	// the URL must be host-reachable; its own gateway is). AILERON_URL inside the
+	// container is host.docker.internal-based and is NOT what the daemon can
+	// fetch, and nothing expands a `${AILERON_URL}` placeholder, so we resolve a
+	// real URL here and bake it into the prompt.
+	daemonWasRunning := daemonRunning(e.aileronBin)
+	daemonURL, err := daemonStart(e.aileronBin)
+	if err != nil {
+		return fmt.Errorf("starting aileron daemon for R10: %w", err)
+	}
+	if !daemonWasRunning {
+		defer daemonStop(e.aileronBin)
+	}
+	healthURL := strings.TrimRight(daemonURL, "/") + "/healthz"
+	logf("%s scenario: daemon at %s (started-by-test=%v)", cfg.Name, daemonURL, !daemonWasRunning)
+
+	prompt := systestlib.BuildPrompt(cfg, sentinel, healthURL)
 	execArgs := systestlib.BuildExecArgs(cfg, prompt)
 
 	logf("%s scenario: runid=%s workspace=%s image=%s", cfg.Name, runID, e.workspace, cfg.ExpectedImage)
@@ -255,8 +289,15 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	}
 	logf("ok: R7a post-`--` exec args forwarded to %s", cfg.Name)
 
-	// --- R10 round-trip audit (conditional on AILERON_STATE_DIR) -----------
-	if err := assertAuditR10(e.stateDir); err != nil {
+	// --- R10 round-trip audit: this run's session produced http_request_sent --
+	// The session id is the container-name suffix (aileron-sbx-<sessionID>); the
+	// launcher sets it as AILERON_SESSION_ID, which the daemon records on the
+	// comms audit entry, so we can assert THIS run's record rather than any
+	// unrelated event in the shared daily file.
+	sessionID := strings.TrimPrefix(container, sbxPrefix)
+	if err := assertAuditR10(e.stateDir, sessionID); err != nil {
+		logf("launch log follows:")
+		dumpFile(launchLog)
 		return err
 	}
 
@@ -264,26 +305,64 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	return nil
 }
 
-// assertAuditR10 performs the conditional R10 audit assertion: when stateDir is
-// set, read today's audit JSONL and assert it has at least one event record;
-// when unset, skip with a logged note (matching the bash). The audit filename is
-// audit-YYYY-MM-DD.jsonl per internal/audit/local.go.
-func assertAuditR10(stateDir string) error {
+// assertAuditR10 performs the session-scoped R10 audit assertion: when stateDir
+// is set, poll today's audit JSONL for a "http_request_sent" record carrying
+// this run's sessionID, proving the agent's forwarded http_request reached the
+// daemon and was audited. When stateDir is unset, skip with a logged note. The
+// audit filename is audit-YYYY-MM-DD.jsonl per internal/audit/local.go.
+//
+// The daemon writes the record from a background goroutine
+// (handlers_comms.executeApprovedCommsHTTP), so it can land slightly after the
+// launch exits; poll up to r10PollTimeout before failing.
+func assertAuditR10(stateDir, sessionID string) error {
 	if stateDir == "" {
 		logf("R10 audit assertion skipped: AILERON_STATE_DIR unset (set it to the daemon state dir to enable)")
 		return nil
 	}
 	auditFile := filepath.Join(stateDir, "audit", "audit-"+time.Now().Format("2006-01-02")+".jsonl")
-	data, err := os.ReadFile(auditFile)
+	deadline := time.Now().Add(r10PollTimeout)
+	for {
+		data, readErr := os.ReadFile(auditFile)
+		if readErr == nil {
+			if n, _ := systestlib.CountAuditEventsForSession(data, r10Event, sessionID); n > 0 {
+				logf("ok: R10 audit has %q for session %s (%s)", r10Event, sessionID, auditFile)
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			// Final attempt: render the faithful diagnostic (also covers a
+			// never-created audit file via the read error inside the assert).
+			data, _ := os.ReadFile(auditFile)
+			return systestlib.AssertAuditHasEventForSession(data, r10Event, sessionID, auditFile)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// daemonRunning reports whether `aileron daemon status` says a daemon is up.
+func daemonRunning(bin string) bool {
+	out, _ := exec.Command(bin, "daemon", "status").CombinedOutput()
+	return systestlib.DaemonStatusRunning(string(out))
+}
+
+// daemonStart runs `aileron daemon start` (idempotent — returns the existing
+// daemon's URL if one is already up) and parses the host URL from its output.
+func daemonStart(bin string) (string, error) {
+	out, err := exec.Command(bin, "daemon", "start").CombinedOutput()
 	if err != nil {
-		return systestlib.Fail(fmt.Sprintf("R10 audit file not found: %s", auditFile))
+		return "", fmt.Errorf("aileron daemon start: %v: %s", err, strings.TrimSpace(string(out)))
 	}
-	if err := systestlib.AssertAuditHasEvents(data, auditFile); err != nil {
-		return err
+	url := systestlib.ParseDaemonStartURL(string(out))
+	if url == "" {
+		return "", fmt.Errorf("aileron daemon start: could not parse daemon URL from output: %q", strings.TrimSpace(string(out)))
 	}
-	count, _ := systestlib.CountAuditEventRecords(data)
-	logf("ok: R10 today's audit JSONL has %d event record(s) (%s)", count, auditFile)
-	return nil
+	return url, nil
+}
+
+// daemonStop runs `aileron daemon stop`, best-effort (used in a defer for a
+// daemon this run started; teardown failures must not mask the test result).
+func daemonStop(bin string) {
+	_ = exec.Command(bin, "daemon", "stop").Run()
 }
 
 // --- live probe wrappers: gather docker facts, delegate the decision -------


### PR DESCRIPTION
## Summary

The first by-hand live run reached **R10 and failed** — zero `http_request_sent` records in `~/.aileron/audit/` despite a running daemon (1439 unrelated audit lines, none matching). Investigation found R10 was **authored but never live-verified**, with two root causes:

1. **Unexpanded URL placeholder.** The prompt told the agent to call `http_request` with url `${AILERON_URL}/healthz`, but nothing expands that placeholder — the agent passes the `url` argument verbatim (`cmd/aileron-mcp/main.go:981`) and the daemon fetches that exact string (`internal/app/handlers_comms.go:382`). The daemon tried to GET the literal `"${AILERON_URL}/healthz"`, an invalid URL, so no comms event was ever logged. `BuildPrompt` now takes a **concrete, resolved** health URL.

2. **Loose, daemon-undeterministic audit check.** "any event record > 0" would false-pass on unrelated comms and didn't manage the daemon. Replaced with a **session-scoped** assertion: poll today's audit JSONL for an `http_request_sent` record carrying **this run's session id** (the `aileron-sbx-<id>` container suffix the launcher sets as `AILERON_SESSION_ID` and the daemon records), with a poll that covers the daemon's background-goroutine write.

Per the operator's directives (keep R10 strict; system tests may require a daemon; tests should drive the daemon via the CLI as a user would), the scenario now **owns the daemon lifecycle**: `aileron daemon start` (idempotent — reuses an existing daemon) before the launch, capturing its host gateway URL for the prompt, and `aileron daemon stop` on exit **only if this run started it** (never clobbers the operator's daemon). The daemon issues the R10 fetch from the host, so the URL must be host-reachable — its own `127.0.0.1:<port>` gateway is, whereas the container's `host.docker.internal` `AILERON_URL` is not.

## Test plan

- Pure logic — `BuildPrompt`, the session-scoped audit matcher (`CountAuditEventsForSession` / `AssertAuditHasEventForSession`), and the daemon-CLI output parsers (`ParseDaemonStartURL` / `DaemonStatusRunning`) — lives in `test/system/lib` with unit tests. `go test -race ./test/system/lib/...` passes, **96.1% coverage** (CI `GO_TEST_PACKAGES`).
- `go vet` clean; the live driver **cross-compiles for darwin/linux/windows**.
- The daemon exec plumbing + polled assertion live in the by-hand driver (outside `GO_TEST_PACKAGES`, never run in CI by design). **Behavioral verification is the operator's by-hand re-run**: `task test:system:launch:codex` on a Docker + codex-auth host should now pass R7a/R8/R9/**R10**.
- README updated to the daemon-managed, concrete-URL, session-scoped R10 contract; prerequisites now state the `aileron-server` binary requirement instead of a hand-started daemon.

Found via the #1629 by-hand verification (R10 leg). Part of #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
