### PR TITLE
docs(skill-install): mark agentskills.io slug install unsupported

### DIFF
--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -35,7 +35,7 @@ Aileron shallow-clones the repository, reads the `SKILL.md` at its root, and ins
 
 A git-URL install requires the `git` binary on your `PATH`. `aileron skill install` runs host-side, so it is unrestricted by the sandbox egress boundary. If `git` is missing the install fails with the underlying clone error.
 
-> Installing by an [agentskills.io](https://agentskills.io) registry slug is not wired yet. Use a local path or a git URL for now.
+> Installing by an [agentskills.io](https://agentskills.io) registry slug is not supported. agentskills.io is a format spec, not a registry, so a slug has no canonical location to resolve against. Install from a local path or a git URL instead.
 
 ## Action requirements and graceful degrade
 

--- a/internal/flightplan/store/source.go
+++ b/internal/flightplan/store/source.go
@@ -12,12 +12,14 @@ import (
 )
 
 // ErrSlugNotWired is returned when an agentskills.io slug install is
-// attempted. The slug source is a seam in v0: there is no pinned
-// agentskills.io wire contract in the repo yet, so the concrete fetch is
-// deferred to a named follow-up rather than invented here. See issue #1583.
+// attempted. Slug install is intentionally unsupported: agentskills.io is a
+// format spec, not a registry, so a slug resolves to no canonical location.
+// The only implementable shape would be GitHub-as-registry, which is pure
+// sugar over the git-URL source that already covers distribution. Decided
+// won't-do in #1583; revisit only if a real agentskills.io registry ships.
 var ErrSlugNotWired = errors.New(
-	"store: installing by agentskills.io slug is not wired yet; " +
-		"use a local path or a git URL for now (tracked by #1583)")
+	"store: installing by agentskills.io slug is not supported; " +
+		"use a local path or a git URL")
 
 // SourceKind classifies an install source string.
 type SourceKind int
@@ -79,10 +81,12 @@ func runGit(ctx context.Context, args ...string) error {
 
 // slugResolver resolves an agentskills.io slug to fetched skill content on
 // disk, returning the local directory the content was fetched into. It is a
-// seam: v0 returns ErrSlugNotWired. See issue #1583 for the wire contract.
+// seam, but slug install is unsupported by decision (#1583, won't-do): the
+// resolver returns ErrSlugNotWired.
 type slugResolver func(ctx context.Context, slug, destDir string) (string, error)
 
-// notWiredSlugResolver is the v0 slug resolver.
+// notWiredSlugResolver is the slug resolver. Slug install is unsupported by
+// decision (#1583); it always returns ErrSlugNotWired.
 func notWiredSlugResolver(_ context.Context, _, _ string) (string, error) {
 	return "", ErrSlugNotWired
 }


### PR DESCRIPTION
## Summary

Follow-up to the #1583 won't-do decision. Slug install was advertised in code and docs as *"not wired yet"* / *"tracked by #1583"*, which read as "coming soon". #1583 was closed won't-do: agentskills.io is a format spec, not a registry, so a slug resolves to no canonical location, and the only implementable shape (GitHub-as-registry) is pure sugar over the git-URL source that already covers distribution.

This rewords the messaging from **"not wired yet"** to **"not supported"** so code and docs match the decision:

- `internal/flightplan/store/source.go` — `ErrSlugNotWired` message + the comments on the error, the `slugResolver` seam, and `notWiredSlugResolver`.
- `docs/src/content/docs/guides/installing-a-skill.md` — the slug note now explains *why* (format spec, not a registry) and points to local path / git URL.

No behavior change: the resolver stub still returns `ErrSlugNotWired`; the seam stays as an honest "not supported" signal in case a real agentskills.io registry ever ships.

## Test plan

- `go build ./internal/flightplan/store/` — clean.
- `go test ./internal/flightplan/store/` — pass. The existing `errors.Is(err, ErrSlugNotWired)` assertion in `install_test.go` is identity-based, so the message reword does not affect it.
- Docs note follows the writing voice (no em-dashes, one thought per sentence).

Relates to #1583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the installing guide to state that `agentskills.io` registry slug installs are not supported, and that local paths or git URLs should be used instead.
* **Bug Fixes**
  * Updated the error message shown for slug installs to give clearer guidance and remove the “not wired yet” wording.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->