### PR TITLE
fix(systest): unlock vault in foreground and approve R10 http_request via CLI

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -71,6 +71,16 @@ Prerequisites (the scenario fail-fasts with the exact remediation if missing):
    you already have running) and `aileron daemon stop` on exit only if it started
    one. R10 then asserts the audit round-trip against that daemon (state dir
    `~/.aileron`). `task build` produces `aileron-server` alongside `aileron`.
+4. An unlockable vault. Before backgrounding the launch the scenario touches the
+   vault in the foreground (`aileron vault list`), so if the daemon's vault is
+   locked you are prompted for the passphrase on your terminal — answer it and the
+   run continues. The launch needs the vault unlocked (the agent credential is
+   vault-backed); a freshly-started daemon comes up locked. Set
+   `AILERON_VAULT_PASSPHRASE` to skip the prompt.
+5. Interactive approval of one action. The R10 round-trip is approval-gated: the
+   agent's `http_request` parks a pending approval that the scenario approves for
+   you via `aileron approval approve <id>` (so this is non-interactive), then the
+   daemon performs the request and writes the audit record R10 checks.
 
 The simplest path is the Taskfile target:
 
@@ -159,10 +169,14 @@ session id at runtime, so the exact name is discovered, not predicted).
   `${AILERON_URL}` placeholder: the agent passes the `url` tool argument verbatim
   (`cmd/aileron-mcp`), and the daemon fetches that exact string
   (`internal/app/handlers_comms.go`), so a literal placeholder yields an invalid
-  request and no audit record (the original prompt's bug). The request routes
-  through the daemon's `/comms/http` handler, which appends an
-  `"event":"http_request_sent"` audit record carrying the launch's
-  `session_id` to today's audit JSONL
+  request and no audit record (the original prompt's bug). `http_request` is an
+  **approval-gated** action: the daemon parks a pending approval and its executor
+  goroutine waits for a decision, so the scenario approves it for the run via
+  `aileron approval approve <id>` (found by session through `aileron approval
+  list`) after the launch exits — the goroutine is still waiting, so approving it
+  then unblocks the fetch. The request routes through the daemon's `/comms/http`
+  handler, which appends an `"event":"http_request_sent"` audit record carrying
+  the launch's `session_id` to today's audit JSONL
   (`internal/audit/local.go` `MessageEntry`, written by
   `handlers_comms.go logCommsEvent`). R10 polls today's audit file for an
   `http_request_sent` record matching **this run's session id**

--- a/test/system/lib/approval.go
+++ b/test/system/lib/approval.go
@@ -1,0 +1,43 @@
+// Pure parsing for the `aileron approval list` output the scenario driver uses
+// to find and approve the agent's pending http_request (R10). Kept in the
+// GO_TEST_PACKAGES lib so the parse is unit-tested in CI; the impure
+// exec.Command plumbing stays in the by-hand driver.
+package systestlib
+
+import "strings"
+
+// ParseApprovalIDForSession returns the approval id of the first pending
+// approval in `aileron approval list` output whose Session matches sessionID, or
+// "" if none. The list format prints each approval as a two-space-indented id
+// line followed by four-space-indented "Field: value" lines:
+//
+//	Pending approvals (1):
+//
+//	  act-abc123
+//	    Action:    http_request
+//	    Session:   01KVYK...
+//	    Requested: ...
+//
+// Matching by session is sufficient: a launch's session id is unique to the run,
+// and the scenario only triggers one approval (the R10 http_request).
+func ParseApprovalIDForSession(listOutput, sessionID string) string {
+	curID := ""
+	for _, line := range strings.Split(listOutput, "\n") {
+		// An id line is indented exactly two spaces (not the four-space field
+		// lines) and is a single whitespace-free token.
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") {
+			tok := strings.TrimSpace(line)
+			if tok != "" && !strings.ContainsAny(tok, " \t") {
+				curID = tok
+				continue
+			}
+		}
+		trimmed := strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(trimmed, "Session:"); ok {
+			if strings.TrimSpace(rest) == sessionID && curID != "" {
+				return curID
+			}
+		}
+	}
+	return ""
+}

--- a/test/system/lib/approval_test.go
+++ b/test/system/lib/approval_test.go
@@ -1,0 +1,60 @@
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+const sampleApprovalList = `Pending approvals (2):
+
+  act-aaa111
+    Action:    send_message
+    Session:   other-session
+    Requested: 2026-06-24T10:00:00Z
+
+  act-bbb222
+    Action:    http_request
+    Session:   01KVYK-target
+    Requested: 2026-06-24T10:00:01Z
+    Args:
+      method: GET
+      url: http://127.0.0.1:60036/healthz
+
+Approve with: aileron approval approve <id>
+Deny with:    aileron approval deny <id> [--reason "..."]`
+
+func TestParseApprovalIDForSession(t *testing.T) {
+	if got := systestlib.ParseApprovalIDForSession(sampleApprovalList, "01KVYK-target"); got != "act-bbb222" {
+		t.Errorf("ParseApprovalIDForSession = %q; want act-bbb222", got)
+	}
+	// The other session's approval resolves to its own id.
+	if got := systestlib.ParseApprovalIDForSession(sampleApprovalList, "other-session"); got != "act-aaa111" {
+		t.Errorf("ParseApprovalIDForSession(other) = %q; want act-aaa111", got)
+	}
+}
+
+func TestParseApprovalIDForSessionNoMatch(t *testing.T) {
+	if got := systestlib.ParseApprovalIDForSession(sampleApprovalList, "absent-session"); got != "" {
+		t.Errorf("ParseApprovalIDForSession(absent) = %q; want empty", got)
+	}
+	if got := systestlib.ParseApprovalIDForSession("No pending approvals.\n", "any"); got != "" {
+		t.Errorf("ParseApprovalIDForSession(empty queue) = %q; want empty", got)
+	}
+}
+
+func TestParseApprovalIDForSessionDoesNotMisreadFieldLines(t *testing.T) {
+	// A four-space-indented "Session:" line must not be mistaken for an id, and
+	// the id must come from the two-space-indented line above it.
+	out := strings.Join([]string{
+		"Pending approvals (1):",
+		"",
+		"  act-xyz",
+		"    Action:    http_request",
+		"    Session:   sess-1",
+	}, "\n")
+	if got := systestlib.ParseApprovalIDForSession(out, "sess-1"); got != "act-xyz" {
+		t.Errorf("got %q; want act-xyz", got)
+	}
+}

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,6 +32,12 @@ const r10PollTimeout = 20 * time.Second
 // r10Event is the comms audit event the daemon logs for a forwarded http_request
 // (internal/app/handlers_comms.go logCommsEvent("http_request_sent", ...)).
 const r10Event = "http_request_sent"
+
+// approvalPollTimeout is how long approveSessionHTTPRequest polls `aileron
+// approval list` for this session's pending http_request before failing. The
+// approval is registered as the agent calls the tool, so it is normally present
+// by the time the launch exits; the window only covers a brief lag.
+const approvalPollTimeout = 15 * time.Second
 
 // env holds the validated environment the scenario reads, mirroring the bash
 // `: "${VAR:?...}"` preconditions. AILERON_SYSTEST_LIB is intentionally absent:
@@ -120,6 +127,19 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	}
 	healthURL := strings.TrimRight(daemonURL, "/") + "/healthz"
 	logf("%s scenario: daemon at %s (started-by-test=%v)", cfg.Name, daemonURL, !daemonWasRunning)
+
+	// Unlock the daemon vault before backgrounding the launch. A freshly-started
+	// daemon comes up with a locked vault, and `aileron launch` needs it unlocked
+	// (the agent credential is vault-backed). The launch runs in the background
+	// with redirected stdio, so its own passphrase prompt cannot reach the
+	// terminal; instead we touch the vault here in the FOREGROUND, where the
+	// prompt reaches the operator's terminal (`aileron vault list` triggers the
+	// run() vault state-machine — ensureVaultUnlocked — which prompts when locked
+	// and is a no-op when already unlocked). The operator running by hand answers
+	// the prompt; the launch then proceeds against an unlocked daemon.
+	if err := ensureVaultUnlocked(e.aileronBin); err != nil {
+		return err
+	}
 
 	prompt := systestlib.BuildPrompt(cfg, sentinel, healthURL)
 	execArgs := systestlib.BuildExecArgs(cfg, prompt)
@@ -242,7 +262,9 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 			return err
 		}
 	} else {
-		return systestlib.Fail(fmt.Sprintf("never observed a running %s* container during the launch", sbxPrefix))
+		logf("launch log follows:")
+		dumpFile(launchLog)
+		return systestlib.Fail(fmt.Sprintf("never observed a running %s* container during the launch (see launch log above)", sbxPrefix))
 	}
 
 	// --- wait for the launch to finish, then assert its exit code (R8.6) ----
@@ -295,6 +317,22 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	// comms audit entry, so we can assert THIS run's record rather than any
 	// unrelated event in the shared daily file.
 	sessionID := strings.TrimPrefix(container, sbxPrefix)
+
+	// R10 prerequisite — approve the agent's pending http_request via the CLI.
+	// http_request is an approval-gated action: the daemon parks a pending
+	// approval and its executor goroutine waits (effectively forever) for a
+	// decision, then performs the outbound fetch and writes the
+	// http_request_sent audit record. The agent's MCP client surfaces the
+	// 202-pending as a tool failure and the agent moves on, but the daemon
+	// goroutine is still waiting — so approving the pending request here, exactly
+	// as a user would (`aileron approval approve <id>`), unblocks the round-trip
+	// and produces the audit record R10 asserts.
+	if err := approveSessionHTTPRequest(e.aileronBin, sessionID); err != nil {
+		logf("launch log follows:")
+		dumpFile(launchLog)
+		return err
+	}
+
 	if err := assertAuditR10(e.stateDir, sessionID); err != nil {
 		logf("launch log follows:")
 		dumpFile(launchLog)
@@ -363,6 +401,53 @@ func daemonStart(bin string) (string, error) {
 // daemon this run started; teardown failures must not mask the test result).
 func daemonStop(bin string) {
 	_ = exec.Command(bin, "daemon", "stop").Run()
+}
+
+// ensureVaultUnlocked touches the daemon vault in the FOREGROUND so its
+// passphrase prompt (when locked) reaches the operator's terminal, before the
+// backgrounded launch needs the vault. `aileron vault list` runs through run()'s
+// vault state-machine (ensureVaultUnlocked): it prompts on /dev/tty when the
+// vault is locked and is a silent pass-through when already unlocked. stdout is
+// discarded (the secret listing is irrelevant); stdin and stderr stay attached
+// to the terminal so the prompt is visible and answerable. The launch is
+// backgrounded with redirected stdio and cannot prompt, so this must happen
+// here.
+func ensureVaultUnlocked(bin string) error {
+	logf("ensuring the Aileron daemon vault is unlocked (enter your passphrase if prompted)...")
+	cmd := exec.Command(bin, "vault", "list")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = io.Discard
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("unlocking the daemon vault (run `%s vault list` and enter the passphrase): %w", bin, err)
+	}
+	return nil
+}
+
+// approveSessionHTTPRequest approves the agent's pending http_request approval
+// for sessionID via the CLI, exactly as a user would. http_request is
+// approval-gated; the daemon parks a pending approval whose executor goroutine
+// waits (effectively forever) for a decision, so the approval is still pending
+// after the launch exits and approving it here produces the http_request_sent
+// audit record. It polls `aileron approval list` briefly because the approval
+// registers as the agent calls the tool. A missing approval is a hard error:
+// R10 requires the round-trip, so none means the agent never called the tool.
+func approveSessionHTTPRequest(bin, sessionID string) error {
+	deadline := time.Now().Add(approvalPollTimeout)
+	for {
+		out, _ := exec.Command(bin, "approval", "list").CombinedOutput()
+		if id := systestlib.ParseApprovalIDForSession(string(out), sessionID); id != "" {
+			if aerr := exec.Command(bin, "approval", "approve", id).Run(); aerr != nil {
+				return fmt.Errorf("approving http_request approval %s: %w", id, aerr)
+			}
+			logf("ok: approved pending http_request %s for session %s", id, sessionID)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return systestlib.Fail(fmt.Sprintf("R10 no pending http_request approval for session %s found via `aileron approval list` (the agent did not call the http_request tool)", sessionID))
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 // --- live probe wrappers: gather docker facts, delegate the decision -------


### PR DESCRIPTION
## Summary

The live codex run got past R9/R7a and surfaced two more layers behind R10, both latent because the launch tiers had never been executed before:

1. **Daemon-start regression (no container).** A freshly-started daemon comes up with a **locked vault**, and `aileron launch` needs it unlocked (the agent credential is vault-backed). The launch runs backgrounded with redirected stdio, so its own `Vault passphrase:` prompt can't reach the terminal → the container is never created (`never observed a running aileron-sbx-* container`). **Fix:** touch the vault in the **foreground** (`aileron vault list`) before backgrounding the launch, so the `ensureVaultUnlocked` prompt reaches the operator's terminal (no-op when already unlocked; `AILERON_VAULT_PASSPHRASE` skips it). Also **dump the launch log** on the discovery-failure path, the diagnostics gap that hid this.

2. **R10 is approval-gated.** `http_request` parks a pending approval whose daemon executor goroutine waits (`commsApprovalWait` is effectively infinite) for a decision before fetching and writing `http_request_sent`. The agent's MCP client surfaces the 202-pending as a tool failure and the agent moves on, but the daemon goroutine keeps waiting — so the scenario now **approves the request after the launch** via `aileron approval approve <id>` (found by session through `aileron approval list`), exactly as a user would, unblocking the round-trip so the session-scoped R10 poll finds the record.

Both changes honor the operator's directives: keep R10 strict, the test may require a daemon, and it drives the daemon/approval **through the CLI as a user would** (the passphrase prompt is interactive by design, since these run by hand).

## Test plan

- Pure parsing (`ParseApprovalIDForSession`) is in `test/system/lib` with unit tests. `go test -race ./test/system/lib/...` passes, **96.4% coverage** (CI `GO_TEST_PACKAGES`).
- `go vet` clean; the live driver **cross-compiles for darwin/linux/windows**.
- Vault-unlock and approval exec plumbing live in the by-hand driver (outside `GO_TEST_PACKAGES`, never run in CI by design). **Behavioral verification is the operator's by-hand re-run** of `task test:system:launch:codex` on a Docker + codex-auth host: you answer the vault passphrase prompt once, and R10 should pass via the auto-approved round-trip.
- README updated with the unlock-prompt and approval steps.

Found via the #1629 by-hand verification (R10 leg). Part of #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
