### PR TITLE
fix(cli): accept 204 from the approval decide endpoint

### DIFF
--- a/cmd/aileron/approval.go
+++ b/cmd/aileron/approval.go
@@ -148,7 +148,11 @@ func runApprovalDecide(args []string, approved bool, stdout, stderr io.Writer) i
 		fmt.Fprintf(stderr, "error: approval %q is unknown or already resolved\n", id)
 		return 1
 	}
-	if resp.StatusCode != http.StatusOK {
+	// The decide endpoint returns 204 No Content on success
+	// (DecideActionApproval). Accept any 2xx — checking only for 200 misreported
+	// the canonical 204 success as an error and exited non-zero even though the
+	// approval was recorded server-side.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(stderr, "server returned %d: %s\n", resp.StatusCode, respBody)
 		return 1

--- a/cmd/aileron/approval_test.go
+++ b/cmd/aileron/approval_test.go
@@ -155,7 +155,7 @@ func TestRunApproval_ApproveSendsApprovedTrue(t *testing.T) {
 	fakeApprovalServer(t, func(w http.ResponseWriter, r *http.Request) {
 		receivedPath = r.URL.Path
 		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -184,7 +184,7 @@ func TestRunApproval_DenyWithReasonFlag(t *testing.T) {
 	}
 	fakeApprovalServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -215,7 +215,7 @@ func TestRunApproval_DenyWithPositionalReason(t *testing.T) {
 	}
 	fakeApprovalServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	})
 	var stdout, stderr bytes.Buffer
 	code := runApproval([]string{"deny", "act-test-1", "wrong-recipient"},
@@ -270,6 +270,40 @@ func TestRunApproval_ApproveAlreadyResolved(t *testing.T) {
 		t.Errorf("exit code = 0, want non-zero")
 	}
 	if !strings.Contains(stderr.String(), "unknown or already resolved") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+// TestRunApproval_ApproveAcceptsNoContent locks the fix for the 204 bug: the
+// decide endpoint returns 204 No Content on success, and the CLI must treat that
+// (and any 2xx) as success rather than misreporting it as a server error.
+func TestRunApproval_ApproveAcceptsNoContent(t *testing.T) {
+	fakeApprovalServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	var stdout, stderr bytes.Buffer
+	code := runApproval([]string{"approve", "act-test-204"}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code = %d (want 0); stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Approved act-test-204") {
+		t.Errorf("output = %q", stdout.String())
+	}
+}
+
+// TestRunApproval_ApproveServerErrorReturnsNonZero asserts the 2xx-acceptance
+// did not swallow genuine server errors: a 5xx still exits non-zero.
+func TestRunApproval_ApproveServerErrorReturnsNonZero(t *testing.T) {
+	fakeApprovalServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"code":"decide_error"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := runApproval([]string{"approve", "act-boom"}, &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("exit code = 0, want non-zero for a 500")
+	}
+	if !strings.Contains(stderr.String(), "server returned 500") {
 		t.Errorf("stderr = %q", stderr.String())
 	}
 }

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -437,8 +437,11 @@ func approveSessionHTTPRequest(bin, sessionID string) error {
 	for {
 		out, _ := exec.Command(bin, "approval", "list").CombinedOutput()
 		if id := systestlib.ParseApprovalIDForSession(string(out), sessionID); id != "" {
-			if aerr := exec.Command(bin, "approval", "approve", id).Run(); aerr != nil {
-				return fmt.Errorf("approving http_request approval %s: %w", id, aerr)
+			// Capture combined output so an approve failure surfaces the CLI's
+			// own diagnostic (e.g. "server returned …") instead of a bare exit
+			// status — being blind here cost a debugging round.
+			if aout, aerr := exec.Command(bin, "approval", "approve", id).CombinedOutput(); aerr != nil {
+				return fmt.Errorf("approving http_request approval %s: %v: %s", id, aerr, strings.TrimSpace(string(aout)))
 			}
 			logf("ok: approved pending http_request %s for session %s", id, sessionID)
 			return nil


### PR DESCRIPTION
## Summary

`aileron approval approve` / `deny` were **broken for everyone**: they POST to `/v1/action-approvals/{id}/decide`, whose handler returns **204 No Content** on success (`internal/app/handlers_action_approvals.go:100`), but the CLI checked `resp.StatusCode != http.StatusOK` (200) and treated the 204 as a server error — printing `server returned 204` and exiting non-zero, **even though the approval was recorded server-side**. Every successful approval reported failure.

The bug survived because the existing decide tests mocked **200**, a status production never returns for this endpoint — so they were testing a fiction.

**Fix:** accept any 2xx; correct the decide tests to mock the real **204** (so they now guard the contract); add explicit `ApproveAcceptsNoContent` (204 → exit 0) and `ApproveServerErrorReturnsNonZero` (500 → exit non-zero) tests.

Surfaced by the `aileron launch` system test (#1623 / #1629): its R10 step approves the agent's pending `http_request` via this CLI and failed on the bogus exit code despite the approval going through. Also hardened the systest driver to capture the approve command's combined output, so a future approve failure shows the CLI's own diagnostic instead of a bare exit status.

## Test plan

- `go test ./cmd/aileron/ -run TestRunApproval` passes; the corrected + new tests fail against the old 200-only code and pass with the fix.
- `go vet` clean; the systest driver cross-compiles for darwin/linux/windows.
- Unblocks the by-hand R10 leg: `task test:system:launch:codex` can now approve the round-trip and reach `http_request_sent`.

Found via the #1629 by-hand verification (R10 leg). Relates to #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
