### PR TITLE
fix(systest): make the claude precond vault unlock prompt visible

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -549,11 +549,21 @@ tasks:
             logincmd="claude /login"
             if [ -f "$authfile" ]; then
               :
-            elif aileron vault list --scope agent 2>/dev/null | grep -qx "agents/claude/oauth"; then
-              :
             else
-              echo "Missing claude credential: neither host file $authfile nor a vault entry (agents/claude/oauth) is present. Authenticate first with: $logincmd" >&2
-              exit 1
+              # The vault-entry check below touches the vault with stderr
+              # suppressed. When the daemon vault is locked, that touch would
+              # prompt for the passphrase on /dev/tty with the prompt text
+              # hidden, hanging the run with no visible prompt. Touch the vault
+              # VISIBLY first (stdout discarded, the passphrase prompt left on
+              # the terminal) so the operator sees and can answer it; this is a
+              # no-op when the vault is already unlocked.
+              aileron vault list >/dev/null || true
+              if aileron vault list --scope agent 2>/dev/null | grep -qx "agents/claude/oauth"; then
+                :
+              else
+                echo "Missing claude credential: neither host file $authfile nor a vault entry (agents/claude/oauth) is present. Authenticate first with: $logincmd" >&2
+                exit 1
+              fi
             fi
             ;;
           *)


### PR DESCRIPTION
## Summary

`task test:system:launch:claude` (and `task test:system`) could **hang with no visible prompt** — a terminal lock icon waiting for input the operator was never shown to enter. Cause: the claude precond verifies its vault-backed credential with

```sh
aileron vault list --scope agent 2>/dev/null | grep -qx "agents/claude/oauth"
```

When the daemon vault is locked (the codex tier starts and stops its own daemon, so the claude tier gets a fresh, locked one), that `vault list` prompts for the passphrase on `/dev/tty` — but `2>/dev/null` discards the prompt text, so the run blocks invisibly. (Confirmed: entering the passphrase at the hang lets it continue.)

**Fix:** touch the vault **visibly** first (`aileron vault list >/dev/null` — stdout discarded, the passphrase prompt left on the terminal) before the suppressed entry check. It is a no-op when the vault is already unlocked. The operator now sees and answers the prompt, then the check runs against an unlocked vault.

## Test plan

- `task --dry test:system:launch:claude` parses and shows the visible unlock before the suppressed check; the launch cmd is still `go run ./test/system/scenario claude` (no `sh`).
- `go test ./test/system/lib/ -run TestTaskfile` (the structural Taskfile regression) passes.
- Taskfile-only shell-plumbing change in the by-hand tier; **behavioral verification is the operator's re-run** of `task test:system:launch:claude` — the passphrase prompt is now visible and the run proceeds.

Found via the #1629 by-hand verification (claude leg). Part of #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
