### PR TITLE
fix(systest): accept vault-only credential in codex precond

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -519,11 +519,12 @@ tasks:
     desc: >-
       Fail-fast preconditions for an agent system-test scenario: Docker must be
       reachable AND the agent's credential must be resolvable. Pass
-      AGENT=codex|claude. For codex the host-side auth file the launcher's
-      AuthSpec mounts must exist. For claude the credential is vault-backed
-      (agents/claude/oauth), so the gate passes when EITHER the host file
-      exists OR the vault/daemon holds the entry. On a missing credential,
-      exits non-zero naming the remediation — never a silent skip.
+      AGENT=codex|claude. The credential is accepted from EITHER source: the
+      host-side auth file the launcher's AuthSpec mounts, OR the vault/daemon
+      entry agents/<agent>/oauth (which the launcher's AuthSpec renders into the
+      sandbox at run time, so the host file may legitimately be absent on a
+      machine where the credential lives only in the vault). On a missing
+      credential, exits non-zero naming the remediation — never a silent skip.
     vars:
       AGENT: '{{.AGENT}}'
     cmds:
@@ -535,42 +536,43 @@ tasks:
           codex)
             authfile="$HOME/.codex/auth.json"
             logincmd="codex login"
-            if [ ! -f "$authfile" ]; then
-              echo "Missing codex auth file: $authfile. Authenticate first with: $logincmd" >&2
-              exit 1
-            fi
             ;;
           claude)
-            # Claude's credential is vault-backed (agents/claude/oauth): the
-            # launcher's AuthSpec renders it into the sandbox at run time, so
-            # the host file may be absent on a machine where the credential
-            # lives only in the vault. Accept EITHER source.
             authfile="$HOME/.claude/.credentials.json"
             logincmd="claude /login"
-            if [ -f "$authfile" ]; then
-              :
-            else
-              # The vault-entry check below touches the vault with stderr
-              # suppressed. When the daemon vault is locked, that touch would
-              # prompt for the passphrase on /dev/tty with the prompt text
-              # hidden, hanging the run with no visible prompt. Touch the vault
-              # VISIBLY first (stdout discarded, the passphrase prompt left on
-              # the terminal) so the operator sees and can answer it; this is a
-              # no-op when the vault is already unlocked.
-              aileron vault list >/dev/null || true
-              if aileron vault list --scope agent 2>/dev/null | grep -qx "agents/claude/oauth"; then
-                :
-              else
-                echo "Missing claude credential: neither host file $authfile nor a vault entry (agents/claude/oauth) is present. Authenticate first with: $logincmd" >&2
-                exit 1
-              fi
-            fi
             ;;
           *)
             echo "Unknown AGENT '{{.AGENT}}' (expected codex or claude)" >&2
             exit 1
             ;;
         esac
+        # Normalize any Windows backslashes in $HOME so the path renders with a
+        # single separator style (e.g. C:/Users/alr/.codex/auth.json) instead of
+        # the mixed C:\Users\alr/.codex/auth.json that git-bash would print.
+        authfile="$(printf '%s' "$authfile" | tr '\\' '/')"
+        vaultentry="agents/{{.AGENT}}/oauth"
+        # The credential is accepted from EITHER the host file OR the vault
+        # entry. The launcher's AuthSpec renders the vault credential into the
+        # sandbox at run time, so the host file may be absent on a machine where
+        # the credential lives only in the vault (agents/<agent>/oauth).
+        if [ -f "$authfile" ]; then
+          :
+        else
+          # The vault-entry check below touches the vault with stderr
+          # suppressed. When the daemon vault is locked, that touch would
+          # prompt for the passphrase on /dev/tty with the prompt text hidden,
+          # hanging the run with no visible prompt. Touch the vault VISIBLY
+          # first (stdout discarded, the passphrase prompt left on the
+          # terminal) so the operator sees and can answer it; this is a no-op
+          # when the vault is already unlocked.
+          aileron vault list >/dev/null || true
+          if aileron vault list --scope agent 2>/dev/null | grep -qx "$vaultentry"; then
+            :
+          else
+            echo "Missing {{.AGENT}} credential: neither host file $authfile nor a vault entry ($vaultentry) is present. Authenticate first with: $logincmd" >&2
+            exit 1
+          fi
+        fi
 
   _test:system:cleanup:
     internal: true
@@ -598,8 +600,10 @@ tasks:
       into CI — v1). Runs the harness smoke self-test and the shared
       scenario-library contract tests, then the per-agent scenarios codex
       (#1476) and claude (#1477) end to end. Requires a reachable Docker daemon
-      and, per scenario, host-side agent auth — each scenario fail-fasts with
-      the exact remediation if its auth is missing, never a silent skip. To run
+      and, per scenario, an agent credential resolvable from EITHER the host
+      auth file OR the vault entry agents/<agent>/oauth — each scenario
+      fail-fasts with the exact remediation if its auth is missing from both
+      sources, never a silent skip. To run
       a single agent without the other, invoke its leaf directly
       (e.g. `task test:system:launch:claude`).
     cmds:

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -64,7 +64,11 @@ thing that needs an authenticated agent, and it is invoked manually.
 Prerequisites (the scenario fail-fasts with the exact remediation if missing):
 
 1. A reachable Docker daemon (`docker info`).
-2. A host-side codex login: `codex login` writes `~/.codex/auth.json`.
+2. A codex login resolvable by the launcher's AuthSpec. The precondition passes
+   when EITHER the host file `~/.codex/auth.json` exists OR the vault holds the
+   entry (`aileron vault list --scope agent` prints `agents/codex/oauth`), since
+   the AuthSpec renders the vault credential into the sandbox at run time. Run
+   `codex login` to write the host file, or populate the vault entry.
 3. The Aileron daemon binary (`aileron-server`) resolvable next to `aileron` or
    on PATH. The scenario manages the daemon lifecycle itself through the CLI: it
    runs `aileron daemon start` before the launch (idempotent — it reuses a daemon


### PR DESCRIPTION
## Summary

The codex branch of `_test:system:precond` in `Taskfile.yml` checked only the host file `$HOME/.codex/auth.json` and never the vault, so a machine where the codex credential lives only in the vault (`agents/codex/oauth`) fail-fasted on a credential the launcher's AuthSpec could resolve. This was asymmetric with the claude branch, which already accepted host-file-OR-vault.

This lifts the host-file-OR-vault check into one shared shape parameterized by `{{.AGENT}}` (`vaultentry="agents/{{.AGENT}}/oauth"`), so codex and claude validate identically:

- The visible-vault-touch (locked-vault passphrase prompt) and the `grep -qx` entry check now apply to both agents.
- Task `desc` for `_test:system:precond` and `test:system` now state that EITHER source is accepted, and the remediation message reads `Missing <agent> credential: neither host file ... nor a vault entry (agents/<agent>/oauth) is present`.
- Cosmetic Windows fix: `$HOME` backslashes are normalized via `tr` so the path renders as `C:/Users/alr/.codex/auth.json` instead of the mixed `C:\Users\alr/.codex/auth.json` git-bash would print.
- `test/system/README.md` codex prerequisite mirrors the claude one (EITHER host file OR vault entry).

## Test plan

- `go test ./test/system/lib/...` passes.
- `task --dry test:system:launch:codex` and `task --dry test:system:launch:claude` both compile and render the unified branch (codex now emits the `vaultentry`/visible-vault-touch/`grep -qx` block previously claude-only).
- Simulated precond run proves: a vault-only credential PASSES (codex, no host file, vault has `agents/codex/oauth`); a truly-absent credential still FAIL-FASTS with the new remediation message; a present host file passes; and the Windows path normalizes to a single separator.
- `task --list` parses the Taskfile cleanly.

This is a run-by-hand system-test harness change; no CI wiring runs these scenarios (v1, not wired into CI).

Closes #1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication checks now accept either a local auth file or the matching vault-stored credential, reducing false failures during system tests.
  * Improved handling of missing credentials with clearer guidance on how to satisfy the requirement.
  * Windows path formatting is now normalized for credential lookups.

* **Documentation**
  * Updated system test instructions to reflect the new either/or authentication requirement and remediation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->