### PR TITLE
fix(systest): drop tr/grep externals from test:system precond

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -549,7 +549,10 @@ tasks:
         # Normalize any Windows backslashes in $HOME so the path renders with a
         # single separator style (e.g. C:/Users/alr/.codex/auth.json) instead of
         # the mixed C:\Users\alr/.codex/auth.json that git-bash would print.
-        authfile="$(printf '%s' "$authfile" | tr '\\' '/')"
+        # Use go-task's embedded shell (mvdan.cc/sh) pattern-substitution builtin
+        # rather than `tr`: that Unix coreutil is not on PATH on a stock Windows
+        # host, where it failed the whole run with exit 127 (#1653).
+        authfile="${authfile//\\//}"
         vaultentry="agents/{{.AGENT}}/oauth"
         # The credential is accepted from EITHER the host file OR the vault
         # entry. The launcher's AuthSpec renders the vault credential into the
@@ -566,7 +569,20 @@ tasks:
           # terminal) so the operator sees and can answer it; this is a no-op
           # when the vault is already unlocked.
           aileron vault list >/dev/null || true
-          if aileron vault list --scope agent 2>/dev/null | grep -qx "$vaultentry"; then
+          # Whole-line membership test for $vaultentry in the vault listing,
+          # done with shell builtins (`while read` + `case`) instead of
+          # `grep -qx`: like `tr` above, grep is a Unix external not guaranteed
+          # on a stock Windows host (#1653). A here-string feeds the loop in the
+          # current shell (no pipe subshell), so $found survives; `case` matches
+          # the whole line, preserving the exact-line semantics of `grep -qx`.
+          entries="$(aileron vault list --scope agent 2>/dev/null)"
+          found=
+          while IFS= read -r line; do
+            case "$line" in
+              "$vaultentry") found=1; break ;;
+            esac
+          done <<< "$entries"
+          if [ -n "$found" ]; then
             :
           else
             echo "Missing {{.AGENT}} credential: neither host file $authfile nor a vault entry ($vaultentry) is present. Authenticate first with: $logincmd" >&2

--- a/test/system/lib/taskenv_test.go
+++ b/test/system/lib/taskenv_test.go
@@ -571,6 +571,166 @@ func TestTaskfileLaunchCmdShellFree(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// (G) _test:system:precond is free of Windows-fatal Unix externals (#1653)
+// ---------------------------------------------------------------------------
+
+// stripShellComments drops full-line `#` comments and blank lines from a shell
+// block scalar, returning only the executable lines. The precond block's own
+// prose mentions `tr` and `grep -qx` to explain why they were removed, so a
+// flat scan of the raw scalar would false-positive on the documentation; the
+// contract is about what the shell actually EXECUTES, so only code lines count.
+// A `#` that is not the first non-space token (e.g. inside a string) is left
+// intact — none of the precond's external-command shapes embed a literal `#`,
+// so this conservative line-level strip is sufficient and never hides code.
+func stripShellComments(block string) string {
+	var keep []string
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		keep = append(keep, line)
+	}
+	return strings.Join(keep, "\n")
+}
+
+// trExternalRe matches an invocation of the `tr` coreutil: `tr` as a command
+// word, i.e. at a statement boundary (start, after `|`, `;`, `&`, `(`, or
+// `$(`). Anchoring on the boundary avoids matching `tr` inside an identifier
+// (e.g. `authfile`, `entries`, `vaultentry`) while catching the real
+// `printf ... | tr '\\' '/'` shape #1653 removed.
+var trExternalRe = regexp.MustCompile(`(?:^|[|;&(])\s*tr\s`)
+
+// grepExternalRe matches an invocation of the `grep` coreutil at a statement or
+// pipeline boundary, catching `... | grep -qx ...` (the retired vault-entry
+// membership shape) without matching the word inside a comment or string.
+var grepExternalRe = regexp.MustCompile(`(?:^|[|;&(])\s*grep\s`)
+
+// TestTaskfilePrecondNoUnixExternals pins the #1653 contract: the
+// `_test:system:precond` block shells out to NO Unix-only external that a stock
+// Windows host may lack — specifically not `tr` (which failed the whole run
+// with exit 127) and not `grep` (the next such trap, called out in the issue).
+// The check is over the EXECUTED lines of the block (comments stripped), so the
+// block may still document why those externals were removed. The normalization
+// and membership-test behavior these externals previously provided is covered
+// behaviorally by TestTaskBehaviorPrecondShellBuiltins below.
+func TestTaskfilePrecondNoUnixExternals(t *testing.T) {
+	root := loadTaskfile(t)
+	task := taskNode(t, root, "_test:system:precond")
+	cmds := mapGet(task, "cmds")
+	if cmds == nil || cmds.Kind != yaml.SequenceNode {
+		t.Fatal("_test:system:precond: no cmds: sequence")
+	}
+	code := stripShellComments(strings.Join(allScalars(cmds), "\n"))
+
+	if loc := trExternalRe.FindString(code); loc != "" {
+		t.Errorf("_test:system:precond executes `tr` (Unix external, not on a stock Windows PATH — #1653); "+
+			"use go-task's shell builtin `${var//\\\\//}` instead. Matched: %q", strings.TrimSpace(loc))
+	}
+	if loc := grepExternalRe.FindString(code); loc != "" {
+		t.Errorf("_test:system:precond executes `grep` (Unix external, not on a stock Windows PATH — #1653); "+
+			"use a shell `while read`+`case` membership test instead. Matched: %q", strings.TrimSpace(loc))
+	}
+}
+
+// TestTaskBehaviorPrecondShellBuiltins pins the behavioral half of #1653: the
+// two builtins that replaced `tr` and `grep -qx` produce the correct results
+// under go-task's embedded shell, with a PATH that omits `tr` and `grep`
+// (simulating the stock Windows host where the bug manifested). This is the
+// regression proof: before the fix the precond shelled out to those externals
+// and would exit 127 under this PATH; after, the builtins resolve natively.
+func TestTaskBehaviorPrecondShellBuiltins(t *testing.T) {
+	sandbox := sandboxPATH(t)
+	taskEnvPATH := append(filterEnv(os.Environ(), "PATH"), "PATH="+sandbox)
+
+	// Sim-validity: the sandbox PATH must truly lack tr and grep, else the test
+	// proves nothing about the no-external posture.
+	t.Run("sandbox PATH excludes tr and grep", func(t *testing.T) {
+		if resolvableUnder(sandbox, "tr") {
+			t.Error("sandbox PATH unexpectedly resolves `tr`")
+		}
+		if resolvableUnder(sandbox, "grep") {
+			t.Error("sandbox PATH unexpectedly resolves `grep`")
+		}
+	})
+
+	// (1) Backslash normalization: ${authfile//\\//} turns the mixed
+	// C:\Users\alr/.codex/auth.json git-bash form into a single-separator path,
+	// exactly the substitution the retired `tr '\\' '/'` performed.
+	t.Run("backslash normalization without tr", func(t *testing.T) {
+		tf := `version: '3'
+tasks:
+  r:
+    silent: true
+    cmds:
+      - |
+        authfile='C:\Users\alr/.codex/auth.json'
+        authfile="${authfile//\\//}"
+        echo "RESOLVED=[$authfile]"
+`
+		out := runTask(t, tf, "r", taskEnvPATH)
+		got := extractBracketed(out, "RESOLVED=[", "]")
+		if want := "C:/Users/alr/.codex/auth.json"; got != want {
+			t.Errorf("normalized path = %q, want %q; output:\n%s", got, want, out)
+		}
+	})
+
+	// (2) Whole-line membership test: the while-read+case loop reports a present
+	// entry as found and a substring-only near-match as NOT found, preserving the
+	// exact-line semantics of the retired `grep -qx`.
+	t.Run("whole-line membership without grep", func(t *testing.T) {
+		tf := `version: '3'
+tasks:
+  r:
+    silent: true
+    vars:
+      TARGET: '{{.TARGET}}'
+    cmds:
+      - |
+        entries="agents/codex/oauth
+        agents/claude/oauth
+        other/thing"
+        found=
+        while IFS= read -r line; do
+          case "$line" in
+            "{{.TARGET}}") found=1; break ;;
+          esac
+        done <<< "$entries"
+        echo "RESOLVED=[${found:-none}]"
+`
+		cases := []struct {
+			target string
+			want   string
+		}{
+			{"agents/claude/oauth", "1"},     // exact present entry
+			{"agents/missing/oauth", "none"}, // absent entry
+			{"agents/claude", "none"},        // substring of a line, not a whole line
+		}
+		for _, c := range cases {
+			t.Run(c.target, func(t *testing.T) {
+				env := append(filterEnv(os.Environ(), "PATH"), "PATH="+sandbox)
+				bin := taskBin(t)
+				dir := t.TempDir()
+				path := filepath.Join(dir, "Taskfile.yml")
+				if err := os.WriteFile(path, []byte(tf), 0o600); err != nil {
+					t.Fatalf("writing temp Taskfile: %v", err)
+				}
+				cmd := exec.Command(bin, "-t", path, "r", "TARGET="+c.target)
+				cmd.Env = env
+				outB, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("`task r TARGET=%s` failed: %v\noutput:\n%s", c.target, err, outB)
+				}
+				got := extractBracketed(string(outB), "RESOLVED=[", "]")
+				if got != c.want {
+					t.Errorf("membership for %q = %q, want %q; output:\n%s", c.target, got, c.want, outB)
+				}
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // (A) behavioral: go-task env scope semantics
 // ---------------------------------------------------------------------------
 

--- a/test/system/lib/taskenv_test.go
+++ b/test/system/lib/taskenv_test.go
@@ -595,16 +595,18 @@ func stripShellComments(block string) string {
 }
 
 // trExternalRe matches an invocation of the `tr` coreutil: `tr` as a command
-// word, i.e. at a statement boundary (start, after `|`, `;`, `&`, `(`, or
-// `$(`). Anchoring on the boundary avoids matching `tr` inside an identifier
+// word, i.e. at a statement boundary: the start of any line (the `(?m)`
+// flag makes `^` match each line, not just the block start), or after `|`,
+// `;`, `&`, `(`, or `$(`. Anchoring on the boundary avoids matching `tr`
+// inside an identifier
 // (e.g. `authfile`, `entries`, `vaultentry`) while catching the real
 // `printf ... | tr '\\' '/'` shape #1653 removed.
-var trExternalRe = regexp.MustCompile(`(?:^|[|;&(])\s*tr\s`)
+var trExternalRe = regexp.MustCompile(`(?m)(?:^|[|;&(])\s*tr\s`)
 
 // grepExternalRe matches an invocation of the `grep` coreutil at a statement or
 // pipeline boundary, catching `... | grep -qx ...` (the retired vault-entry
 // membership shape) without matching the word inside a comment or string.
-var grepExternalRe = regexp.MustCompile(`(?:^|[|;&(])\s*grep\s`)
+var grepExternalRe = regexp.MustCompile(`(?m)(?:^|[|;&(])\s*grep\s`)
 
 // TestTaskfilePrecondNoUnixExternals pins the #1653 contract: the
 // `_test:system:precond` block shells out to NO Unix-only external that a stock
@@ -630,6 +632,39 @@ func TestTaskfilePrecondNoUnixExternals(t *testing.T) {
 	if loc := grepExternalRe.FindString(code); loc != "" {
 		t.Errorf("_test:system:precond executes `grep` (Unix external, not on a stock Windows PATH — #1653); "+
 			"use a shell `while read`+`case` membership test instead. Matched: %q", strings.TrimSpace(loc))
+	}
+}
+
+// TestPrecondExternalRegexSensitivity pins the matcher used by
+// TestTaskfilePrecondNoUnixExternals: it must flag a `tr`/`grep` invocation at
+// ANY statement boundary, including the start of a later line in the multiline
+// block (the `(?m)` anchoring), not only after a pipe. A line-leading external
+// is a plausible future regression shape (e.g. a bare `tr ... < file` on its
+// own line), so the guard would be hollow if it only caught the piped form.
+// Conversely it must NOT flag the substring `tr`/`grep` inside an identifier.
+func TestPrecondExternalRegexSensitivity(t *testing.T) {
+	cases := []struct {
+		name  string
+		code  string
+		re    *regexp.Regexp
+		match bool
+	}{
+		{"tr piped", "printf '%s' \"$x\" | tr '\\\\' '/'", trExternalRe, true},
+		{"tr line-leading on later line", "authfile=x\ntr 'a' 'b' < f", trExternalRe, true},
+		{"tr after semicolon", "x=1; tr a b", trExternalRe, true},
+		{"tr inside identifier authfile", "authfile=\"$HOME/x\"", trExternalRe, false},
+		{"tr inside identifier entries", "entries=\"$(cmd)\"", trExternalRe, false},
+		{"grep piped on later line", "aileron vault list >/dev/null\naileron vault list | grep -qx \"$e\"", grepExternalRe, true},
+		{"grep line-leading", "grep -q foo bar", grepExternalRe, true},
+		{"grep absent", "while IFS= read -r line; do :; done", grepExternalRe, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.re.MatchString(c.code)
+			if got != c.match {
+				t.Errorf("re.MatchString(%q) = %v, want %v", c.code, got, c.match)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

On Windows, `task test:system` aborted at `_test:system:precond` with `"tr": executable file not found in $PATH` (exit 127), failing the whole system-test run before any launch scenario executed (#1653). The precondition that exists to normalize Windows-style `$HOME` paths was itself shelling out to `tr`, a Unix coreutil not guaranteed on a stock Windows PATH. The membership check just below used `grep -qx`, the same trap waiting for the next Windows runner.

This replaces both externals with go-task embedded-shell (`mvdan.cc/sh`) builtins, so the precond runs on a stock Windows host with no external Unix binaries:

- `Taskfile.yml:555` backslash normalization: `tr '\\' '/'` → `${authfile//\\//}` parameter substitution.
- `Taskfile.yml:578` vault-entry membership: `grep -qx "$vaultentry"` → a here-string `while read` + `case` loop. `case` matches the whole line, preserving the exact-line semantics of `grep -qx` (a substring like `agents/claude` does not match the line `agents/claude/oauth`), and the here-string keeps the loop in the current shell so `$found` survives.

The `tr` at `Taskfile.yml:404` is in `test:unit` (a `go list | grep | tr` pipeline), a different target outside this issue's scope, and is already part of a Unix-pipeline that requires `grep`; it is not on the `test:system` path.

## Test plan

Added to `test/system/lib/taskenv_test.go` (the CI-safe, Windows-runnable lib tier — Go toolchain only, no Docker, no `aileron launch`):

- `TestTaskfilePrecondNoUnixExternals` (structural): strips full-line comments from the precond block (its prose still documents *why* `tr`/`grep` were removed) and asserts the executed lines invoke neither `tr` nor `grep`. Verified this FAILS against the pre-fix `| tr` / `| grep -qx` forms and PASSES on the fix.
- `TestTaskBehaviorPrecondShellBuiltins` (behavioral): drives the real `task` binary through both builtins under a PATH sandbox that omits `tr` and `grep` (the condition that produced exit 127), asserting `C:\Users\alr/.codex/auth.json` → `C:/Users/alr/.codex/auth.json` and that the membership loop matches an exact entry, rejects an absent entry, and rejects a substring-only near-match.
- `TestPrecondExternalRegexSensitivity` (matcher sensitivity): pins that the external-detection regexes flag `tr`/`grep` at any statement boundary — including a line-leading invocation on a later line of the block (`(?m)` anchoring), not only the piped form — while not flagging the substring inside identifiers like `authfile`/`entries`.

Local verification (macOS):
- `go test ./...` in `test/system/lib` — green; `gofmt -l` clean; `go vet ./...` clean.
- `task --dry test:system:launch:codex` and `:claude` — both expand and compile.

Note: the live `task test:system` end-to-end run is the by-hand static-gate tier (needs Docker + real agent auth), so it is not exercised in CI; the lib-tier tests above are the Windows-runnable regression proof.

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)