### PR TITLE
fix(systest): skip auth-file 0600 check on Windows hosts

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -151,7 +151,11 @@ session id at runtime, so the exact name is discovered, not predicted).
      `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`,
      `AILERON_TOKEN` are all set in the container.
   3. **Credentials** — `/home/agent/.codex/auth.json` exists, mode `0600`, and
-     its parent dir is a bind mount.
+     its parent dir is a bind mount. The `0600` check is skipped on a Windows
+     host: Docker Desktop shares a Windows-path bind mount through a layer that
+     does not project the host's Unix mode bits, so the file always presents as
+     `0777` in the container regardless of the host mode the launcher set. File
+     presence and the parent-dir bind mount are still checked on every host.
   4. **Daemon reachable** — `AILERON_URL` host is `host.docker.internal`
      (loopback rewrite); on Linux Docker the container's `ExtraHosts` carries
      `host.docker.internal:host-gateway`. On macOS/Windows Docker Desktop the
@@ -217,7 +221,9 @@ claude-specific bindings (issue #1477):
   agent-agnostic core (`aileron-mcp` present + executable, daemon-wiring env
   vars set).
 - **Credentials** — `/home/agent/.claude/.credentials.json`, mode `0600`, with
-  its parent dir bind-mounted writable (claude rotates the token in-session).
+  its parent dir bind-mounted writable (claude rotates the token in-session). The
+  `0600` check is skipped on a Windows host for the reason given in the codex
+  Credentials note above.
 - **Batch flag** — claude's non-interactive flag is `-p`, so the scenario
   drives `aileron launch claude -- -p "<prompt>"`.
 

--- a/test/system/lib/scenario.go
+++ b/test/system/lib/scenario.go
@@ -19,16 +19,29 @@ import (
 // ProbeCredentials re-expresses probe_credentials' decision core (R8.3). The live
 // driver supplies: authFileExists (`docker exec test -f <auth_path>` succeeded),
 // mode (`docker exec stat -c %a <auth_path>`, e.g. "600"), authDir
-// (path.Dir(authPath)), and mounts (the `{{.Type}}:{{.Destination}}` block from
-// `docker inspect`, one per line). Returns nil only when the file exists, the
-// mode is exactly "600", and some bind mount's Destination equals authDir.
-// Diagnostics mirror the shell's R8.3 wording so CI logs read the same.
-func ProbeCredentials(authFileExists bool, mode, authPath, authDir, mounts string) error {
+// (path.Dir(authPath)), mounts (the `{{.Type}}:{{.Destination}}` block from
+// `docker inspect`, one per line), and isWindowsHost (runtime.GOOS == "windows").
+// Returns nil only when the file exists, the mode is exactly "600", and some bind
+// mount's Destination equals authDir. Diagnostics mirror the shell's R8.3 wording
+// so CI logs read the same.
+//
+// The 0600 mode check is skipped on a Windows host. The launcher writes the auth
+// file 0600 on the host (authspec_runtime.go), and on Linux/macOS Docker carries
+// that bit faithfully into the bind mount. Docker Desktop on Windows shares a
+// Windows-path bind mount through a translation layer that does not project the
+// host's Unix mode bits, so the file always presents as 0777 inside the container
+// regardless of the host mode. The 0600 guarantee is therefore inexpressible for a
+// Windows-host bind mount; asserting it would fail on a host where the property is
+// simply not observable. File presence and the parent-dir bind mount are still
+// checked on every host.
+func ProbeCredentials(authFileExists bool, mode, authPath, authDir, mounts string, isWindowsHost bool) error {
 	if !authFileExists {
 		return Fail(fmt.Sprintf("R8.3 auth file %s missing in container", authPath))
 	}
-	if err := AssertEq("600", mode, fmt.Sprintf("R8.3 %s mode is 0600", authPath)); err != nil {
-		return err
+	if !isWindowsHost {
+		if err := AssertEq("600", mode, fmt.Sprintf("R8.3 %s mode is 0600", authPath)); err != nil {
+			return err
+		}
 	}
 	// The auth file's parent dir must be a bind mount. The shell matches the
 	// substring `bind:<authDir>` in the mount block; do the same but anchor each

--- a/test/system/lib/scenario_test.go
+++ b/test/system/lib/scenario_test.go
@@ -86,6 +86,7 @@ func TestProbeCredentials(t *testing.T) {
 		name           string
 		authFileExists bool
 		mode, mounts   string
+		isWindowsHost  bool
 		wantErr        bool
 		errContains    []string
 	}{
@@ -128,10 +129,44 @@ func TestProbeCredentials(t *testing.T) {
 			wantErr:        true,
 			errContains:    []string{"no bind mount"},
 		},
+		{
+			// Docker Desktop on Windows presents the bind-mounted auth file as
+			// 0777 because it does not project the host's Unix mode bits. The
+			// 0600 check is skipped, so the otherwise-passing facts still return
+			// nil rather than failing on the host-uncontrollable mode.
+			name:           "windows host skips the 0600 mode check",
+			authFileExists: true,
+			mode:           "777",
+			mounts:         okMounts,
+			isWindowsHost:  true,
+			wantErr:        false,
+		},
+		{
+			// The mode skip is Windows-only: the same 0777 mode still fails on a
+			// non-Windows host where the bit is faithfully carried.
+			name:           "non-windows host still enforces the 0600 mode check",
+			authFileExists: true,
+			mode:           "777",
+			mounts:         okMounts,
+			isWindowsHost:  false,
+			wantErr:        true,
+			errContains:    []string{"mode is 0600"},
+		},
+		{
+			// Mode is skipped on Windows, but file presence and the parent-dir
+			// bind mount are still enforced on every host.
+			name:           "windows host still requires the parent bind mount",
+			authFileExists: true,
+			mode:           "777",
+			mounts:         "bind:/home/agent/workspace\nvolume:/data",
+			isWindowsHost:  true,
+			wantErr:        true,
+			errContains:    []string{"no bind mount"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := systestlib.ProbeCredentials(tc.authFileExists, tc.mode, authPath, authDir, tc.mounts)
+			err := systestlib.ProbeCredentials(tc.authFileExists, tc.mode, authPath, authDir, tc.mounts, tc.isWindowsHost)
 			assertErr(t, err, tc.wantErr, tc.errContains)
 		})
 	}

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -533,11 +534,21 @@ func probeCredentials(container, authPath string) error {
 		mode, _ = dockerExecOutput(container, "stat", "-c", "%a", authPath)
 	}
 	mounts, _ := dockerInspect(container, `{{range .Mounts}}{{.Type}}:{{.Destination}}{{"\n"}}{{end}}`)
-	authDir := filepath.Dir(authPath)
-	if err := systestlib.ProbeCredentials(authFileExists, mode, authPath, authDir, mounts); err != nil {
+	// authPath is an in-container POSIX path; use path.Dir (forward-slash), not
+	// filepath.Dir, so the parent matches the docker-inspect mount destinations on
+	// a Windows host (where filepath.Dir would emit backslashes).
+	authDir := path.Dir(authPath)
+	isWindows := runtime.GOOS == "windows"
+	if err := systestlib.ProbeCredentials(authFileExists, mode, authPath, authDir, mounts, isWindows); err != nil {
 		return err
 	}
-	logf("ok: R8.3 auth file %s present, mode 0600, %s bind-mounted", authPath, authDir)
+	if isWindows {
+		// Docker Desktop on Windows does not project the host file's 0600 mode into
+		// the bind mount, so the mode is not asserted (see ProbeCredentials).
+		logf("ok: R8.3 auth file %s present, %s bind-mounted (mode not host-controlled on Windows)", authPath, authDir)
+	} else {
+		logf("ok: R8.3 auth file %s present, mode 0600, %s bind-mounted", authPath, authDir)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`task test:system` fails on a **Windows** host at the **R8.3** credentials probe:

```
FAIL: R8.3 /home/agent/.codex/auth.json mode is 0600
  expected: 600
  actual:   777
```

The launcher writes the agent auth file `0600` on the host (`internal/launch/authspec_runtime.go`), and on Linux/macOS Docker carries that bit faithfully into the bind mount. **Docker Desktop on Windows** shares a Windows-path bind mount through a translation layer that does **not** project the host's Unix mode bits — the file always presents as `0777` in the container regardless of the host mode. The `0600` guarantee is structurally inexpressible for a Windows-host bind mount, so the assertion can never pass there.

## Fix

- Thread `isWindowsHost` into `ProbeCredentials` and gate the exact-`0600` assertion behind a non-Windows check — mirroring the existing Linux-gated `ExtraHosts` check in `ProbeDaemonReachable`. File presence and the parent-dir bind mount are still enforced on **every** host.
- Fix a **latent Windows bug** the mode failure was masking: the driver derived the auth dir with `filepath.Dir` on an *in-container* POSIX path, which emits backslashes on Windows and would never match the forward-slash `docker inspect` mount destinations. Switched to `path.Dir`.

Linux/macOS behavior is byte-for-byte unchanged — the mode assertion runs exactly as before; only `GOOS == "windows"` relaxes it.

## Testing

- `TestProbeCredentials` extended with 3 cases: Windows skips the mode check, non-Windows still enforces it, Windows still requires the parent bind mount. Full `test/system/lib` suite green; `test/system/scenario` builds + vets clean.
- Confirmed by the reporter: **all `test:system` tests now pass on Windows**, with macOS/Linux unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)