### PR TITLE
fix(mcp): treat comms 202 pending-approval as a non-error result

### DIFF
--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -928,19 +928,14 @@ func (s *server) draftReply(args map[string]any) toolResult {
 		return errorResult("message_id and body are required")
 	}
 
-	resp, err := s.commsPOST(s.commsEndpoint("draft"), map[string]string{
+	pending, err := s.commsPOST(s.commsEndpoint("draft"), map[string]string{
 		"reply_to": messageID,
 		"body":     body,
 	})
 	if err != nil {
 		return errorResult(err.Error())
 	}
-	if !resp.OK {
-		return errorResult(resp.Error)
-	}
-	return toolResult{
-		Content: []toolContent{{Type: "text", Text: "Draft submitted for user review."}},
-	}
+	return pendingApprovalResult(pending)
 }
 
 func (s *server) sendMessage(args map[string]any) toolResult {
@@ -956,7 +951,7 @@ func (s *server) sendMessage(args map[string]any) toolResult {
 		return errorResult("service, channel, and body are required")
 	}
 
-	resp, err := s.commsPOST(s.commsEndpoint("send"), map[string]string{
+	pending, err := s.commsPOST(s.commsEndpoint("send"), map[string]string{
 		"service": service,
 		"channel": channel,
 		"body":    body,
@@ -964,12 +959,7 @@ func (s *server) sendMessage(args map[string]any) toolResult {
 	if err != nil {
 		return errorResult(err.Error())
 	}
-	if !resp.OK {
-		return errorResult(resp.Error)
-	}
-	return toolResult{
-		Content: []toolContent{{Type: "text", Text: "Message sent successfully."}},
-	}
+	return pendingApprovalResult(pending)
 }
 
 func (s *server) httpRequest(args map[string]any) toolResult {
@@ -997,32 +987,23 @@ func (s *server) httpRequest(args map[string]any) toolResult {
 		payload["headers"] = headers
 	}
 
-	resp, err := s.commsPOST(s.commsEndpoint("http"), payload)
+	pending, err := s.commsPOST(s.commsEndpoint("http"), payload)
 	if err != nil {
 		return errorResult(err.Error())
 	}
-	if !resp.OK {
-		return errorResult(resp.Error)
-	}
-	// Response body is in the first message's Body field; the daemon
-	// stamps the upstream HTTP status code into Id.
-	if len(resp.Messages) > 0 {
-		return toolResult{
-			Content: []toolContent{{Type: "text", Text: resp.Messages[0].Body}},
-		}
-	}
-	return toolResult{
-		Content: []toolContent{{Type: "text", Text: "Request completed (no response body)."}},
-	}
+	// The HTTP call is approval-gated: the daemon answers 202 and runs
+	// the request server-side once the user approves. The upstream
+	// response body is carried on the approval result, retrieved later
+	// via check_action_status — not returned synchronously here.
+	return pendingApprovalResult(pending)
 }
 
-// --- Comms wire shapes (mirrors internal/api/openapi.yaml CommsToolResponse) ---
-
-type commsToolResponse struct {
-	OK       bool           `json:"ok"`
-	Error    string         `json:"error,omitempty"`
-	Messages []commsMessage `json:"messages,omitempty"`
-}
+// --- Comms wire shapes (mirrors internal/api/openapi.yaml) ---
+//
+// The approval-gated POST endpoints (/comms/send, /comms/draft,
+// /comms/http) return a 202 ActionRunPendingResponse, decoded via the
+// shared [actionRunPendingResponse] type. Only the read path
+// (/comms/messages) returns a synchronous body, modeled here.
 
 type readMessagesResponse struct {
 	Messages []commsMessage `json:"messages"`
@@ -1072,18 +1053,25 @@ func (s *server) commsGET(endpoint string, out any) error {
 	return nil
 }
 
-// commsPOST issues a POST with the JSON-encoded body and returns the
-// parsed CommsToolResponse. The daemon's send-shaped endpoints always
-// return 200 — the verdict rides in `ok` + `error` — so a non-200
-// here means the call never reached the queue.
-func (s *server) commsPOST(endpoint string, body any) (commsToolResponse, error) {
+// commsPOST issues a POST with the JSON-encoded body against one of the
+// daemon's approval-gated comms endpoints (/comms/send, /comms/draft,
+// /comms/http) and returns the 202 ActionRunPendingResponse. Those
+// endpoints register a pending approval and answer 202 immediately — the
+// dispatch happens server-side once the user approves, and the outcome
+// is reached later via the check_action_status tool
+// (GET /v1/action-approvals/{id}/result). This mirrors the
+// /v1/actions/{name}/run 202 branch in [runActionInner]: the pending
+// state is a successful result, not a failure. Any non-202 status,
+// transport error, or decode failure is a real error and surfaces as
+// one so the agent sees the call never reached the queue.
+func (s *server) commsPOST(endpoint string, body any) (actionRunPendingResponse, error) {
 	data, err := json.Marshal(body)
 	if err != nil {
-		return commsToolResponse{}, fmt.Errorf("encoding request: %w", err)
+		return actionRunPendingResponse{}, fmt.Errorf("encoding request: %w", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
 	if err != nil {
-		return commsToolResponse{}, fmt.Errorf("comms request: %w", err)
+		return actionRunPendingResponse{}, fmt.Errorf("comms request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if s.aileronToken != "" {
@@ -1091,18 +1079,35 @@ func (s *server) commsPOST(endpoint string, body any) (commsToolResponse, error)
 	}
 	resp, err := s.commsHTTPClient.Do(req)
 	if err != nil {
-		return commsToolResponse{}, fmt.Errorf("daemon unreachable: %w", err)
+		return actionRunPendingResponse{}, fmt.Errorf("daemon unreachable: %w", err)
 	}
 	defer resp.Body.Close()
 	rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if resp.StatusCode != http.StatusOK {
-		return commsToolResponse{}, fmt.Errorf("daemon returned %s: %s", resp.Status, strings.TrimSpace(string(rawBody)))
+	if resp.StatusCode != http.StatusAccepted {
+		return actionRunPendingResponse{}, fmt.Errorf("daemon returned %s: %s", resp.Status, strings.TrimSpace(string(rawBody)))
 	}
-	var out commsToolResponse
+	var out actionRunPendingResponse
 	if err := json.Unmarshal(rawBody, &out); err != nil {
-		return commsToolResponse{}, fmt.Errorf("decoding response: %w", err)
+		return actionRunPendingResponse{}, fmt.Errorf("decoding pending response: %w", err)
 	}
 	return out, nil
+}
+
+// pendingApprovalResult turns a 202 ActionRunPendingResponse into the
+// successful tool result the agent sees. The daemon's `message` is the
+// human-readable instruction the LLM is meant to surface verbatim; pass
+// it through unchanged. When the daemon omits it (older builds), fall
+// back to a minimal instruction naming the approval id so the agent can
+// still reach the outcome via check_action_status. Mirrors the 202
+// branch of [runActionInner].
+func pendingApprovalResult(pending actionRunPendingResponse) toolResult {
+	text := pending.Message
+	if text == "" {
+		text = "Approval requested. Approval id: " + pending.ApprovalID
+	}
+	return toolResult{
+		Content: []toolContent{{Type: "text", Text: text}},
+	}
 }
 
 // --- Action discovery / execution against the Aileron daemon ---

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -1088,6 +1088,21 @@ func TestReadMessages_PassesQueryFilters(t *testing.T) {
 	}
 }
 
+// writePendingApproval encodes the 202 ActionRunPendingResponse the
+// daemon returns for an approval-gated comms POST. It is the real
+// contract for /comms/send, /comms/draft, and /comms/http (the daemon
+// always answers 202 — see internal/app/handlers_comms.go) — never a
+// 200 with an `ok`/`error` body.
+func writePendingApproval(w http.ResponseWriter, approvalID, message string) {
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(actionRunPendingResponse{
+		Status:     "pending_approval",
+		ApprovalID: approvalID,
+		ReviewURL:  "http://review/" + approvalID,
+		Message:    message,
+	})
+}
+
 func TestSendMessage_WithDaemon(t *testing.T) {
 	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/comms/send") {
@@ -1098,24 +1113,47 @@ func TestSendMessage_WithDaemon(t *testing.T) {
 		if body["service"] != "slack" || body["channel"] != "#x" || body["body"] != "hi" {
 			t.Errorf("body = %v", body)
 		}
-		_ = json.NewEncoder(w).Encode(commsToolResponse{OK: true})
+		writePendingApproval(w, "appr-send", "Approval needed for send_message. Visit http://review/appr-send to approve.")
+	}))
+	got := s.sendMessage(map[string]any{"service": "slack", "channel": "#x", "body": "hi"})
+	if got.IsError {
+		t.Fatalf("202 pending_approval must not be an error result, got: %s", got.Content[0].Text)
+	}
+	if !strings.Contains(got.Content[0].Text, "Approval needed for send_message") {
+		t.Errorf("expected the pending-approval message verbatim, got %q", got.Content[0].Text)
+	}
+}
+
+// TestSendMessage_PendingMessageFallback covers the older-daemon case
+// where the 202 omits `message`: the wrapper still returns a non-error
+// result naming the approval id so the agent can poll check_action_status.
+func TestSendMessage_PendingMessageFallback(t *testing.T) {
+	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writePendingApproval(w, "appr-77", "")
 	}))
 	got := s.sendMessage(map[string]any{"service": "slack", "channel": "#x", "body": "hi"})
 	if got.IsError {
 		t.Fatalf("unexpected error: %s", got.Content[0].Text)
 	}
+	if !strings.Contains(got.Content[0].Text, "appr-77") {
+		t.Errorf("expected approval id in fallback message, got %q", got.Content[0].Text)
+	}
 }
 
-func TestSendMessage_DaemonDenies(t *testing.T) {
+// TestSendMessage_DaemonError verifies a genuine non-202 (the request
+// never reached the queue, e.g. a 400 no_listener) still surfaces as an
+// error result, not the pending path.
+func TestSendMessage_DaemonError(t *testing.T) {
 	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(commsToolResponse{OK: false, Error: "user denied"})
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"no_listener","message":"no listener for service: slack"}`))
 	}))
 	got := s.sendMessage(map[string]any{"service": "slack", "channel": "#x", "body": "hi"})
 	if !got.IsError {
-		t.Fatal("expected error when daemon denies send")
+		t.Fatal("expected error result on non-202 from daemon")
 	}
-	if !strings.Contains(got.Content[0].Text, "user denied") {
-		t.Errorf("expected daemon's error text in result, got %q", got.Content[0].Text)
+	if !strings.Contains(got.Content[0].Text, "no_listener") {
+		t.Errorf("expected daemon's error body in result, got %q", got.Content[0].Text)
 	}
 }
 
@@ -1124,21 +1162,25 @@ func TestDraftReply_WithDaemon(t *testing.T) {
 		if !strings.HasSuffix(r.URL.Path, "/comms/draft") {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(commsToolResponse{OK: true})
+		writePendingApproval(w, "appr-draft", "Approval needed for draft_reply. Visit http://review/appr-draft to approve.")
 	}))
 	got := s.draftReply(map[string]any{"message_id": "1", "body": "hi"})
 	if got.IsError {
-		t.Fatalf("unexpected error: %s", got.Content[0].Text)
+		t.Fatalf("202 pending_approval must not be an error result, got: %s", got.Content[0].Text)
+	}
+	if !strings.Contains(got.Content[0].Text, "Approval needed for draft_reply") {
+		t.Errorf("expected the pending-approval message verbatim, got %q", got.Content[0].Text)
 	}
 }
 
-func TestDraftReply_DaemonDenies(t *testing.T) {
+func TestDraftReply_DaemonError(t *testing.T) {
 	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(commsToolResponse{OK: false, Error: "discarded"})
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":"action_approvals_disabled"}`))
 	}))
 	got := s.draftReply(map[string]any{"message_id": "1", "body": "hi"})
 	if !got.IsError {
-		t.Fatal("expected error when daemon discards draft")
+		t.Fatal("expected error result on non-202 from daemon")
 	}
 }
 
@@ -1147,43 +1189,37 @@ func TestHttpRequest_WithDaemon(t *testing.T) {
 		if !strings.HasSuffix(r.URL.Path, "/comms/http") {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(commsToolResponse{
-			OK: true,
-			Messages: []commsMessage{
-				{ID: "200", Body: "{\"ok\":true}"},
-			},
-		})
+		writePendingApproval(w, "appr-http", "Approval needed for http_request. Visit http://review/appr-http to approve.")
 	}))
 	got := s.httpRequest(map[string]any{"method": "GET", "url": "https://example.com"})
 	if got.IsError {
-		t.Fatalf("unexpected error: %s", got.Content[0].Text)
+		t.Fatalf("202 pending_approval must not be an error result, got: %s", got.Content[0].Text)
 	}
-	if !strings.Contains(got.Content[0].Text, "ok") {
-		t.Errorf("expected response body in result, got %q", got.Content[0].Text)
+	if !strings.Contains(got.Content[0].Text, "Approval needed for http_request") {
+		t.Errorf("expected the pending-approval message verbatim, got %q", got.Content[0].Text)
 	}
 }
 
-func TestHttpRequest_DaemonDenies(t *testing.T) {
+func TestHttpRequest_DaemonError(t *testing.T) {
 	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(commsToolResponse{OK: false, Error: "url not in allowlist"})
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"url_not_allowed"}`))
 	}))
 	got := s.httpRequest(map[string]any{"method": "GET", "url": "https://blocked"})
 	if !got.IsError {
-		t.Fatal("expected error when daemon denies")
+		t.Fatal("expected error result on non-202 from daemon")
 	}
 }
 
 func TestDispatchTool_RoutesAllCommsTools(t *testing.T) {
 	s := commsServerWithFakeDaemon(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// /comms/messages is GET; the rest are POST.
+		// /comms/messages is GET (200 body); the approval-gated POSTs
+		// answer 202 ActionRunPendingResponse.
 		if strings.HasSuffix(r.URL.Path, "/comms/messages") {
 			_ = json.NewEncoder(w).Encode(readMessagesResponse{Messages: []commsMessage{}})
 			return
 		}
-		_ = json.NewEncoder(w).Encode(commsToolResponse{
-			OK:       true,
-			Messages: []commsMessage{{ID: "x", Body: "ok"}},
-		})
+		writePendingApproval(w, "appr-x", "Approval needed. Visit http://review/appr-x to approve.")
 	}))
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

The daemon's three approval-gated comms POST endpoints — `/comms/send`, `/comms/draft`, `/comms/http` — return **HTTP 202** with an `ActionRunPendingResponse` (`status=pending_approval`, `approval_id`, `review_url`, `message`) per `internal/api/openapi.yaml` and `internal/app/handlers_comms.go`. But the MCP client's shared `commsPOST` treated any non-200 as a hard error, so the real 202 was surfaced to the agent as a failed tool call (e.g. `http_request (failed)`).

This mirrors the already-correct `/v1/actions/{name}/run` 202 branch in `runActionInner`: decode the 202 into `actionRunPendingResponse` and return the daemon's `message` verbatim as a **successful, non-error** tool result. The agent reaches the eventual outcome via the existing `check_action_status` tool (`GET /v1/action-approvals/{id}/result`) — no agent-side blocking poll. This is the settled direction per the spec's explicit guidance ("the agent does not need to poll") and the established #648 convention, so no design fork.

### Changes
- `commsPOST` now returns `actionRunPendingResponse` and keys success on **202**; any other status (e.g. a `400 no_listener` that never reached the queue) still surfaces as an error so the agent sees the call failed.
- New shared `pendingApprovalResult` helper passes the pending `message` through verbatim, with an approval-id fallback for older daemons that omit it — mirroring the `runActionInner` 202 branch.
- `sendMessage` / `draftReply` / `httpRequest` return the pending result instead of fabricating synchronous "sent"/"submitted"/body text.
- Removed the now-dead `commsToolResponse` type (the 200 `ok`/`error` shape the daemon never sends on these paths).

No spec change and no new tool: the existing `actionRunPendingResponse` type and `check_action_status` tool are reused. The comms tool descriptions already say "Requires human approval" and describe the async review flow, so they remain accurate.

## Test plan
- The prior tests mocked `200 + CommsToolResponse{ok:true/false}` — a contract the daemon never fulfills for these paths — and thus encoded the bug. They are rewritten to mock `202 + ActionRunPendingResponse`.
- New/updated regression tests assert a 202 yields a **non-error** tool result carrying the approval `message` (and an approval-id fallback when `message` is empty). Verified these **fail before** the fix (the old code returned `daemon returned 202 Accepted: ...` as an error) and **pass after**.
- Added `*_DaemonError` tests asserting a genuine non-202 (400/503) still surfaces as an error result with the daemon's body.
- `go build ./cmd/aileron-mcp/...`, `go test -count=1 ./cmd/aileron-mcp/... ./internal/app/...`, and `go vet` all green.
- CodeRabbit review run on the diff: one "major" suggestion to hard-reject 202 bodies with a missing `status`/`approval_id`. Declined to keep parity with the cited `runActionInner` precedent (which also does not validate and relies on the spec-pinned contract + the message fallback); adding strict validation only on the comms path would be an inconsistent, out-of-scope divergence.

Closes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comms actions now return a pending-approval status instead of appearing to complete immediately.
  * When approval is pending, the response now includes clearer next-step guidance, including an approval ID when available.
  * Requests that fail to reach the expected approval flow now surface errors more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->