### PR TITLE
ci(sandbox-base): assert published manifest is multi-arch (#1657)

### DIFF
--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -202,6 +202,43 @@ jobs:
               --image-name aileron-sandbox-base:smoke
           fi
 
+      # Verify the just-assembled manifest is genuinely multi-arch before the job
+      # goes green (#1657). The multi-arch base is load-bearing under the
+      # local-build model (#1451): arm64 (Apple Silicon) users build the Claude
+      # layer on top of whatever the base resolves to, so a base that silently
+      # regresses to amd64-only forces emulation or failure on arm64 hosts. A
+      # change that drops an arch (editing the compose loop to a single arch, or
+      # removing arm64 from the substrate `platforms:`) would otherwise publish a
+      # single-arch manifest with green CI. This inspects every published meta tag
+      # and fails the job unless both linux/amd64 and linux/arm64 are present.
+      - name: Assert published manifest is multi-arch
+        if: ${{ steps.publish.outputs.publish == 'true' }}
+        run: |
+          set -euo pipefail
+
+          required="linux/amd64 linux/arm64"
+          status=0
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "::group::inspect $tag"
+            platforms=$(docker buildx imagetools inspect "$tag" \
+              --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}')
+            echo "$platforms"
+            echo "::endgroup::"
+            for want in $required; do
+              if ! printf '%s\n' "$platforms" | grep -qx "$want"; then
+                echo "::error::tag $tag is missing required platform $want (got: $(printf '%s' "$platforms" | tr '\n' ' '))"
+                status=1
+              fi
+            done
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+          if [ "$status" -ne 0 ]; then
+            echo "published sandbox-base manifest is not multi-arch (amd64 + arm64); failing job"
+            exit 1
+          fi
+          echo "all published tags carry linux/amd64 and linux/arm64"
+
       # Single-arch local load of the Tier 0 Containerfile so the smoke step can
       # `docker run` it. This recipe takes the images/sandbox-base context (no
       # repo-root, no AILERON_VERSION/COMMIT build-args) and is UNBAKED (no


### PR DESCRIPTION
## Summary

Closes #1657.

`.github/workflows/sandbox-base.yml` assembles a multi-arch manifest list (`linux/amd64` + `linux/arm64`) for the published `ghcr.io/alrubinger/aileron-sandbox-base` tags by composing per-arch images and running `docker buildx imagetools create` across the per-arch digests. Nothing asserted that the assembled manifest actually carries both arches after publish.

The multi-arch base is load-bearing under the local-build model (#1451): arm64 (Apple Silicon) users build the Claude layer on top of whatever the base resolves to, so a base that silently regresses to amd64-only forces emulation or outright failure on arm64 hosts. A future change that drops an arch (collapsing the compose `for arch in amd64 arm64` loop to a single arch, or removing `arm64` from the substrate build's `platforms:`) would publish a single-arch manifest **silently**, with green CI.

This adds a publish-gated step, **Assert published manifest is multi-arch**, immediately after the manifest-assembly step. It runs `docker buildx imagetools inspect` against every published meta tag (the same `${{ steps.meta.outputs.tags }}` set the assembly loop just created) and fails the job unless the reported platforms include **both** `linux/amd64` and `linux/arm64`. The multi-arch guarantee becomes an enforced invariant instead of an unverified side effect.

## Test plan

- `actionlint .github/workflows/sandbox-base.yml` passes clean (exit 0), which also runs shellcheck over the new embedded `run:` script.
- The assertion's shell logic was exercised against a mocked `imagetools inspect` for: a proper multi-arch manifest (passes), amd64-only and arm64-only manifests (each fails with a precise `missing required platform` error), an arch superset including ppc64le (passes), multiple tags where one is single-arch (fails), and blank-line tags (skipped). All behaved as specified.
- Note: the new step is gated on `steps.publish.outputs.publish == 'true'`, which is only true on `v*` tags, `workflow_dispatch`, and merge-to-`main`. The PR-triggered run of this workflow takes the single-arch `else` (smoke-only) path, so the assertion does not execute on this PR's own CI; it activates on the next publish. Acceptance per the issue: fails fast if any assembled tag is missing an arch, passes unchanged when both are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added checks to ensure published container images include both major CPU architectures, helping prevent incomplete releases from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->