### PR TITLE
fix(cli): attach daemon bearer token to audit list/show requests

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -4114,7 +4114,12 @@ func fetchAuditList(q auditListQuery) (*auditListWire, error) {
 	}
 	u.RawQuery = qs.Encode()
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(u.String())
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	setDaemonAuthorization(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -4136,7 +4141,12 @@ func fetchAuditGet(auditID string) (*auditEventWire, int, error) {
 		return nil, 0, err
 	}
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(base + "/audit/" + url.PathEscape(auditID))
+	req, err := http.NewRequest(http.MethodGet, base+"/audit/"+url.PathEscape(auditID), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	setDaemonAuthorization(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -1824,6 +1824,53 @@ func TestBindingDoRequestSendsDaemonAuthorization(t *testing.T) {
 	}
 }
 
+// TestFetchAuditSendsDaemonAuthorization locks in the contract that
+// both audit fetchers attach the daemon bearer token. The daemon's
+// local-auth middleware 401s any /v1 request lacking a valid bearer,
+// so omitting the header (the regressed behavior) made `aileron audit
+// list`/`show` fail with "missing or invalid daemon token". Before the
+// fix these fetchers issued a bare client.Get with no Authorization
+// header and this test's sawAuth assertions failed.
+func TestFetchAuditSendsDaemonAuthorization(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		t.Setenv("AILERON_TOKEN", "tok_audit_list")
+		var sawAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sawAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"events":[]}`)
+		}))
+		defer srv.Close()
+		t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+		if _, err := fetchAuditList(auditListQuery{}); err != nil {
+			t.Fatalf("fetchAuditList: %v", err)
+		}
+		if sawAuth != "Bearer tok_audit_list" {
+			t.Fatalf("Authorization = %q, want bearer token", sawAuth)
+		}
+	})
+
+	t.Run("show", func(t *testing.T) {
+		t.Setenv("AILERON_TOKEN", "tok_audit_show")
+		var sawAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sawAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{}`)
+		}))
+		defer srv.Close()
+		t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+		if _, _, err := fetchAuditGet("audit-123"); err != nil {
+			t.Fatalf("fetchAuditGet: %v", err)
+		}
+		if sawAuth != "Bearer tok_audit_show" {
+			t.Fatalf("Authorization = %q, want bearer token", sawAuth)
+		}
+	})
+}
+
 // TestBindingAPIBaseURL_PropagatesSpawnErrorThroughCallers locks in
 // the post-#490 contract: every helper that previously dialed the
 // hardcoded `localhost:8721` fallback now propagates the spawn

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -410,19 +410,23 @@ func daemonStart(bin string) (string, error) {
 }
 
 // assertAuditListReachable runs `aileron audit list` against the live daemon
-// exactly as a user would and fails if it exits non-zero or the daemon rejects
-// the call with a 401. This is the CLI->daemon authenticated round-trip: the
-// audit endpoint is behind the local-auth middleware, so a CLI that forgets the
-// bearer token gets "missing or invalid daemon token". Empty audit output is a
-// pass — we assert reachability + auth, not contents.
+// exactly as a user would and fails if it exits non-zero. This is the
+// CLI->daemon authenticated round-trip: the audit endpoint is behind the
+// local-auth middleware, so a CLI that forgets the bearer token gets a 401
+// ("missing or invalid daemon token"), which the fetcher surfaces as an error
+// and `audit list` reports with a non-zero exit. Exit status (not a substring
+// scan of the rendered audit entries, which could legitimately contain "401")
+// is the reliable signal; the auth-error text is detected only to enrich the
+// failure diagnostic. Empty audit output on exit 0 is a pass — we assert
+// reachability + auth, not contents.
 func assertAuditListReachable(bin string) error {
 	out, err := exec.Command(bin, "audit", "list").CombinedOutput()
 	combined := strings.TrimSpace(string(out))
 	if err != nil {
-		return systestlib.Fail(fmt.Sprintf("`aileron audit list` failed (CLI->daemon auth): %v: %s", err, combined))
-	}
-	if strings.Contains(combined, "401") || strings.Contains(strings.ToLower(combined), "missing or invalid daemon token") {
-		return systestlib.Fail(fmt.Sprintf("`aileron audit list` returned a daemon auth error (CLI omitted the bearer token): %s", combined))
+		if strings.Contains(combined, "401") || strings.Contains(strings.ToLower(combined), "missing or invalid daemon token") {
+			return systestlib.Fail(fmt.Sprintf("`aileron audit list` rejected by daemon auth (CLI omitted the bearer token): %v: %s", err, combined))
+		}
+		return systestlib.Fail(fmt.Sprintf("`aileron audit list` failed (CLI->daemon round-trip): %v: %s", err, combined))
 	}
 	logf("ok: `aileron audit list` reached the daemon (CLI->daemon auth)")
 	return nil

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -129,6 +129,17 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 	healthURL := strings.TrimRight(daemonURL, "/") + "/healthz"
 	logf("%s scenario: daemon at %s (started-by-test=%v)", cfg.Name, daemonURL, !daemonWasRunning)
 
+	// --- CLI->daemon auth smoke (audit list) -------------------------------
+	// Exercise an authenticated CLI->daemon call end-to-end against the live
+	// daemon before the launch. `aileron audit list` hits /v1/audit, which the
+	// daemon's local-auth middleware 401s unless the CLI attaches the bearer
+	// token. The R10 assertion below reads the audit JSONL file directly, so it
+	// never covers this auth path — which is how a regression that dropped the
+	// Authorization header from the audit fetchers shipped unnoticed.
+	if err := assertAuditListReachable(e.aileronBin); err != nil {
+		return err
+	}
+
 	// Unlock the daemon vault before backgrounding the launch. A freshly-started
 	// daemon comes up with a locked vault, and `aileron launch` needs it unlocked
 	// (the agent credential is vault-backed). The launch runs in the background
@@ -396,6 +407,25 @@ func daemonStart(bin string) (string, error) {
 		return "", fmt.Errorf("aileron daemon start: could not parse daemon URL from output: %q", strings.TrimSpace(string(out)))
 	}
 	return url, nil
+}
+
+// assertAuditListReachable runs `aileron audit list` against the live daemon
+// exactly as a user would and fails if it exits non-zero or the daemon rejects
+// the call with a 401. This is the CLI->daemon authenticated round-trip: the
+// audit endpoint is behind the local-auth middleware, so a CLI that forgets the
+// bearer token gets "missing or invalid daemon token". Empty audit output is a
+// pass — we assert reachability + auth, not contents.
+func assertAuditListReachable(bin string) error {
+	out, err := exec.Command(bin, "audit", "list").CombinedOutput()
+	combined := strings.TrimSpace(string(out))
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("`aileron audit list` failed (CLI->daemon auth): %v: %s", err, combined))
+	}
+	if strings.Contains(combined, "401") || strings.Contains(strings.ToLower(combined), "missing or invalid daemon token") {
+		return systestlib.Fail(fmt.Sprintf("`aileron audit list` returned a daemon auth error (CLI omitted the bearer token): %s", combined))
+	}
+	logf("ok: `aileron audit list` reached the daemon (CLI->daemon auth)")
+	return nil
 }
 
 // daemonStop runs `aileron daemon stop`, best-effort (used in a defer for a


### PR DESCRIPTION
## Summary

`aileron audit list` and `aileron audit show` failed with a 401 (`missing or invalid daemon token`). The two audit HTTP fetchers in `cmd/aileron/main.go` (`fetchAuditList` ~L4090, `fetchAuditGet` ~L4133) issued a bare `client.Get(...)` with no `Authorization` header. They were the only authenticated CLI->daemon helpers that bypassed `setDaemonAuthorization`. The daemon's `localDaemonAuthMiddleware` 401s any `/v1/*` request lacking a valid bearer, and `bindingAPIBaseURL()` returns a base ending in `/v1`, so the fetchers hit `/v1/audit` and `/v1/audit/{id}` unauthenticated.

Fix: build an `http.Request`, call `setDaemonAuthorization(req)`, then `client.Do(req)` in both fetchers, exactly mirroring `bindingDoRequest`. No spec/OpenAPI change (audit routes already exist server-side); no backwards-compat concern.

## Test plan

- **Unit regression (`cmd/aileron/main_test.go`)**: `TestFetchAuditSendsDaemonAuthorization` stubs the daemon with an httptest server, sets `AILERON_TOKEN`, calls `fetchAuditList` and `fetchAuditGet`, and asserts the server observed `Authorization: Bearer <token>`. Verified it fails before the fix (`Authorization = ""`) and passes after. Runs in CI.
- **System scenario (`test/system/scenario/scenario.go`)**: after the live daemon is confirmed running, run `aileron audit list` and fail on non-zero exit or a 401/`missing or invalid daemon token`. The R10 assertion reads the audit JSONL file directly and never exercised the CLI->daemon auth path, which is how this regression shipped. Kept in the existing launch scenario (no new Taskfile target).
- `go test ./cmd/aileron/` green; `go vet ./test/system/scenario/` clean.

Closes #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVCpBvosQvjCbdKvLKCxZz