### PR TITLE
fix(cli): attach daemon bearer token to action run requests

### DIFF
--- a/cmd/aileron/action_state.go
+++ b/cmd/aileron/action_state.go
@@ -273,6 +273,7 @@ func runActionRun(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	req.Header.Set("Content-Type", "application/json")
+	setDaemonAuthorization(req)
 	resp, err := actionsHTTPClient.Do(req)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/action_state_test.go
+++ b/cmd/aileron/action_state_test.go
@@ -403,6 +403,35 @@ func TestRunActionRun_ArgFlagsSendArgsAndRenderResult(t *testing.T) {
 	}
 }
 
+// TestRunActionRun_SendsDaemonAuthorization locks in the contract that
+// `aileron action run` attaches the daemon bearer token. The daemon's
+// local-auth middleware 401s any /v1 request lacking a valid bearer, so
+// omitting the header (the regressed behavior) made action run the lone
+// unauthenticated /v1 caller. Before the fix runActionRun issued the
+// POST with only Content-Type set and no Authorization header, so this
+// test's sawAuth assertion failed.
+func TestRunActionRun_SendsDaemonAuthorization(t *testing.T) {
+	t.Setenv("AILERON_TOKEN", "tok_action_run")
+	var sawAuth string
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(actionRunResponse{
+			AuditID: "audit-123",
+			Result:  ptrString(`{"ok":true}`),
+		})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"--arg", "team=ENG", "linear-issues-create"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if sawAuth != "Bearer tok_action_run" {
+		t.Fatalf("Authorization = %q, want bearer token", sawAuth)
+	}
+}
+
 func TestRunActionRun_RawArgsJSONPassthrough(t *testing.T) {
 	var gotBody []byte
 	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

`aileron action run` built `POST /v1/actions/{name}/run`, set only `Content-Type`, then called `actionsHTTPClient.Do(req)` without attaching the daemon bearer token. Its sibling paths (`action list`/`show` at `action_state.go:115`/`:392` and `skill_launch.go:163`) all attach the token via `setDaemonAuthorization`, so action run was the lone unauthenticated `/v1` caller and the daemon's local-auth middleware 401s it.

The fix inserts `setDaemonAuthorization(req)` before the `Do` call.

## Test plan

- Added `TestRunActionRun_SendsDaemonAuthorization` (mirrors `TestFetchAuditSendsDaemonAuthorization`): sets `AILERON_TOKEN`, captures the `Authorization` header in the fake daemon handler, asserts it equals `Bearer <token>`.
- Verified the test fails before the fix (`Authorization = "", want bearer token`) and passes after.
- `go test ./cmd/aileron/` passes; `go build ./...` and `go vet` clean.

Closes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Action runs now include the required authorization header when sent to the daemon, helping requests succeed as expected.
  * Added coverage to confirm the action run request carries the correct bearer token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->