### PR TITLE
fix(cli): parse flags placed after positional args

### DIFF
--- a/cmd/aileron/action_state.go
+++ b/cmd/aileron/action_state.go
@@ -232,10 +232,11 @@ func runActionRun(args []string, stdout, stderr io.Writer) int {
 	rawArgs := flags.String("args", "", "Raw JSON object for action args")
 	asJSON := flags.Bool("json", false, "Print the daemon response envelope verbatim")
 	auditIDOut := flags.String("audit-id-out", "", "Write the action audit_id to this path")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 || strings.TrimSpace(flags.Arg(0)) == "" {
+	if len(positionals) != 1 || strings.TrimSpace(positionals[0]) == "" {
 		fmt.Fprintln(stderr, "usage: aileron action run <NAME> [--arg k=v ...] [--args <json>] [--json] [--audit-id-out <path>]")
 		return 1
 	}
@@ -265,7 +266,7 @@ func runActionRun(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	name := strings.TrimSpace(flags.Arg(0))
+	name := strings.TrimSpace(positionals[0])
 	body, _ := json.Marshal(actionRunRequest{Args: runArgs})
 	req, err := http.NewRequest(http.MethodPost, base+"/actions/"+url.PathEscape(name)+"/run", bytes.NewReader(body))
 	if err != nil {

--- a/cmd/aileron/flagparse.go
+++ b/cmd/aileron/flagparse.go
@@ -1,0 +1,42 @@
+package main
+
+import "flag"
+
+// parseInterspersedFlags parses args into the given FlagSet while allowing
+// flags to appear before OR after positional arguments.
+//
+// Go's stdlib flag.Parse stops scanning at the first non-flag token, so a
+// command like `aileron action run my-action --arg k=v` leaves `--arg k=v`
+// unparsed: flag.Parse treats `my-action` as the first positional and never
+// looks past it. That makes the natural `<positional> --flag` ordering fail
+// while the unnatural `--flag <positional>` ordering works, an inconsistency
+// users hit repeatedly.
+//
+// This helper restores interspersed parsing by calling fs.Parse repeatedly:
+// each pass consumes the flags up to the next positional, that positional is
+// peeled off, and the remainder is re-parsed. The collected positionals are
+// returned in their original left-to-right order. Callers should read
+// positionals from the returned slice rather than fs.Arg/fs.NArg, since the
+// FlagSet only retains the final pass's residual args.
+//
+// Repeatable flags registered with fs.Var (for example a `--arg` that
+// accumulates) work across passes because each pass calls Set for the flags
+// it sees, appending to the same destination. Scalar flags keep the last
+// value set, and a flag absent from a given pass retains its prior value.
+//
+// A `--` terminator is honored by the underlying flag.Parse: tokens after it
+// are treated as positionals on the pass that encounters it.
+func parseInterspersedFlags(fs *flag.FlagSet, args []string) ([]string, error) {
+	var positionals []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		rest := fs.Args()
+		if len(rest) == 0 {
+			return positionals, nil
+		}
+		positionals = append(positionals, rest[0])
+		args = rest[1:]
+	}
+}

--- a/cmd/aileron/flagparse_test.go
+++ b/cmd/aileron/flagparse_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/version"
+)
+
+// sliceFlag is a repeatable string flag used to assert that
+// parseInterspersedFlags accumulates a flag.Var across the positional
+// boundary (the `--arg`/`--input` shape the real subcommands use).
+type sliceFlag []string
+
+func (s *sliceFlag) String() string     { return strings.Join(*s, ",") }
+func (s *sliceFlag) Set(v string) error { *s = append(*s, v); return nil }
+
+// TestParseInterspersedFlags_BothOrders is the core regression: flags must
+// parse whether they appear before OR after the positional. Go's stdlib
+// flag.Parse stops at the first non-flag token, so the flags-after ordering
+// regressed before this helper existed.
+func TestParseInterspersedFlags_BothOrders(t *testing.T) {
+	parse := func(args []string) (string, bool, []string) {
+		fs := flag.NewFlagSet("t", flag.ContinueOnError)
+		fs.SetOutput(&bytes.Buffer{})
+		name := fs.String("name", "", "")
+		on := fs.Bool("on", false, "")
+		pos, err := parseInterspersedFlags(fs, args)
+		if err != nil {
+			t.Fatalf("parse %v: %v", args, err)
+		}
+		return *name, *on, pos
+	}
+
+	for _, tc := range []struct {
+		label string
+		args  []string
+	}{
+		{"flags-first", []string{"--name", "x", "--on", "target"}},
+		{"flags-after", []string{"target", "--name", "x", "--on"}},
+		{"interspersed", []string{"--name", "x", "target", "--on"}},
+		{"equals-after", []string{"target", "--name=x", "--on"}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			name, on, pos := parse(tc.args)
+			if name != "x" || !on {
+				t.Errorf("flags = name:%q on:%v, want x/true", name, on)
+			}
+			if len(pos) != 1 || pos[0] != "target" {
+				t.Errorf("positionals = %v, want [target]", pos)
+			}
+		})
+	}
+}
+
+// TestParseInterspersedFlags_RepeatableAccumulatesAcrossPositional locks the
+// behavior the issue calls out: a repeatable flag (flag.Var) must accumulate
+// values that appear on both sides of the positional, not reset per pass.
+func TestParseInterspersedFlags_RepeatableAccumulatesAcrossPositional(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	var args sliceFlag
+	fs.Var(&args, "arg", "repeatable")
+	pos, err := parseInterspersedFlags(fs, []string{"--arg", "a=1", "name", "--arg", "b=2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pos) != 1 || pos[0] != "name" {
+		t.Fatalf("positionals = %v, want [name]", pos)
+	}
+	if len(args) != 2 || args[0] != "a=1" || args[1] != "b=2" {
+		t.Errorf("repeatable flag = %v, want [a=1 b=2] accumulated across the positional", args)
+	}
+}
+
+// TestParseInterspersedFlags_ScalarLastWins documents that a scalar flag set
+// in a later pass keeps its last value, and one absent from a pass retains
+// its prior value.
+func TestParseInterspersedFlags_ScalarLastWins(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	v := fs.String("v", "default", "")
+	pos, err := parseInterspersedFlags(fs, []string{"name", "--v", "set"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *v != "set" {
+		t.Errorf("scalar = %q, want set", *v)
+	}
+	if len(pos) != 1 || pos[0] != "name" {
+		t.Errorf("positionals = %v", pos)
+	}
+}
+
+func TestParseInterspersedFlags_NoPositional(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	on := fs.Bool("on", false, "")
+	pos, err := parseInterspersedFlags(fs, []string{"--on"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !*on {
+		t.Error("flag not parsed")
+	}
+	if len(pos) != 0 {
+		t.Errorf("positionals = %v, want none", pos)
+	}
+}
+
+func TestParseInterspersedFlags_MultiplePositionals(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	on := fs.Bool("on", false, "")
+	pos, err := parseInterspersedFlags(fs, []string{"a", "--on", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !*on {
+		t.Error("interspersed flag not parsed")
+	}
+	if len(pos) != 2 || pos[0] != "a" || pos[1] != "b" {
+		t.Errorf("positionals = %v, want [a b] in order", pos)
+	}
+}
+
+func TestParseInterspersedFlags_UnknownFlagErrors(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	if _, err := parseInterspersedFlags(fs, []string{"name", "--nope"}); err == nil {
+		t.Error("an unknown flag after the positional must surface a parse error")
+	}
+}
+
+// TestParseInterspersedFlags_DoubleDashTerminator: tokens after `--` are
+// treated as positionals, even when they look like flags.
+func TestParseInterspersedFlags_DoubleDashTerminator(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	on := fs.Bool("on", false, "")
+	pos, err := parseInterspersedFlags(fs, []string{"--on", "--", "--looks-like-flag"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !*on {
+		t.Error("flag before -- not parsed")
+	}
+	if len(pos) != 1 || pos[0] != "--looks-like-flag" {
+		t.Errorf("positionals = %v, want [--looks-like-flag] (after --)", pos)
+	}
+}
+
+// --- Subcommand-level regressions: flags placed AFTER the positional ---
+
+// TestRunActionRun_FlagsAfterName is the confirmed bug from #1685: a flag
+// after the action name was dropped because flag.Parse stopped at the name.
+// Both orderings must now reach the daemon with identical args.
+func TestRunActionRun_FlagsAfterName(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		args  []string
+	}{
+		{"flags-before", []string{"--arg", "team=ENG", "--json", "linear-issues-create"}},
+		{"flags-after", []string{"linear-issues-create", "--arg", "team=ENG", "--json"}},
+		{"interspersed", []string{"--arg", "team=ENG", "linear-issues-create", "--json"}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			var gotPath string
+			var gotBody []byte
+			base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotBody, _ = io.ReadAll(r.Body)
+				_ = json.NewEncoder(w).Encode(actionRunResponse{AuditID: "a", Result: ptrString(`{}`)})
+			})
+			setBindingBase(t, base)
+
+			var stdout, stderr bytes.Buffer
+			if code := runActionRun(tc.args, &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+			}
+			if gotPath != "/v1/actions/linear-issues-create/run" {
+				t.Errorf("path = %q (name not parsed from %v)", gotPath, tc.args)
+			}
+			var parsed actionRunRequest
+			if err := json.Unmarshal(gotBody, &parsed); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if parsed.Args["team"] != "ENG" {
+				t.Errorf("args = %#v, want team=ENG parsed from %v", parsed.Args, tc.args)
+			}
+		})
+	}
+}
+
+// TestRunActionRun_RepeatableArgAfterName: the repeatable --arg must
+// accumulate values on both sides of the name.
+func TestRunActionRun_RepeatableArgAfterName(t *testing.T) {
+	var gotBody []byte
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(actionRunResponse{AuditID: "a", Result: ptrString(`{}`)})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"--arg", "team=ENG", "linear-issues-create", "--arg", "title=Smoke"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	var parsed actionRunRequest
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Args["team"] != "ENG" || parsed.Args["title"] != "Smoke" {
+		t.Errorf("args = %#v, want both --arg values accumulated across the name", parsed.Args)
+	}
+}
+
+// TestRunSkillFreeze_FlagsAfterName is the other confirmed #1685 case:
+// `skill freeze <name> --version v` dropped the flag. Both orders must work.
+func TestRunSkillFreeze_FlagsAfterName(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		args  func(key string) []string
+	}{
+		{"flags-before", func(key string) []string {
+			return []string{"--signing-key", key, "--version", "9.9.9", "weekly-metrics-digest"}
+		}},
+		{"flags-after", func(key string) []string {
+			return []string{"weekly-metrics-digest", "--signing-key", key, "--version", "9.9.9"}
+		}},
+		{"interspersed", func(key string) []string {
+			return []string{"--signing-key", key, "weekly-metrics-digest", "--version", "9.9.9"}
+		}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			storeDir := withTempStore(t)
+			installExample(t, storeDir)
+			stubFreezeResolvers(t, fakeFreezeDigest)
+			key := writeSigningKey(t)
+
+			var stdout, stderr bytes.Buffer
+			if code := runSkillFreeze(tc.args(key), &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Froze skill \"weekly-metrics-digest\"") {
+				t.Errorf("name not parsed from args: stdout=%q", stdout.String())
+			}
+			if !strings.Contains(stdout.String(), "Version:     9.9.9") {
+				t.Errorf("--version not parsed regardless of order: stdout=%q", stdout.String())
+			}
+		})
+	}
+}
+
+// TestRunSkillLaunch_FlagAfterName: `skill launch <name> --out-dir d` must
+// honor the flag placed after the name.
+func TestRunSkillLaunch_FlagAfterName(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {
+			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
+		},
+		"aileron:tracker.create_issue": {
+			"path": "filed_issue.json", "mimeType": "application/json", "encoding": "utf-8", "content": "{}",
+		},
+	}}
+	stubLaunchSeams(t, disp)
+	origRun := launchSeamForTest
+	launchSeamForTest = fakeCLISeam{}
+	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	outDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	// Flag AFTER the name (the regressing order).
+	code := runSkillLaunch([]string{"weekly-metrics-digest", "--out-dir", outDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Launched \"weekly-metrics-digest\"") {
+		t.Errorf("name not parsed with flag after it: stdout=%q", stdout.String())
+	}
+	// --out-dir after the name must still take effect.
+	if _, err := os.Stat(filepath.Join(outDir, "filed_issue.json")); err != nil {
+		t.Errorf("--out-dir after the name was ignored: %v", err)
+	}
+}
+
+// TestRunSandboxCheck_FlagAfterCommand: `sandbox check <command> --build=...`
+// must accept the flag after the positional command.
+func TestRunSandboxCheck_FlagAfterCommand(t *testing.T) {
+	t.Chdir(t.TempDir())
+	stubSandboxCheckSeams(t, version.Version)
+	var out, errb bytes.Buffer
+	// Flag AFTER the positional command.
+	if code := runSandboxCheck([]string{"claude", "--build=auto"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "support: ok") {
+		t.Fatalf("stdout = %q, want support: ok (command + flag both parsed)", out.String())
+	}
+}
+
+// TestRunHubSearch_FlagBeforeAndAfterQuery: the consolidated helper must keep
+// `hub search <query> --type X` working AND accept the flags-first order.
+func TestRunHubSearch_FlagBeforeAndAfterQuery(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		args  []string
+	}{
+		{"flag-after", []string{"hub", "search", "draft", "--type", "actions"}},
+		{"flag-before", []string{"hub", "search", "--type", "actions", "draft"}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			hits := 0
+			fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				if r.URL.Path != "/hub/actions" {
+					t.Errorf("expected only /hub/actions, got %q", r.URL.Path)
+				}
+				_, _ = io.WriteString(w, twoHubActionsJSON)
+			})
+			var stdout, stderr bytes.Buffer
+			if code := run(tc.args, newTestRegistry(), &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+			}
+			if hits != 1 {
+				t.Errorf("expected exactly 1 endpoint hit (query+type both parsed), got %d", hits)
+			}
+		})
+	}
+}
+
+// TestRunHubList_FlagAfterCategory: the optional positional category and the
+// --json flag must parse in either order.
+func TestRunHubList_FlagAfterCategory(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, twoHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	// category positional THEN --json.
+	if code := run([]string{"hub", "list", "actions", "--json"}, newTestRegistry(), &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d NDJSON lines, want 2 (--json after category honored):\n%s", len(lines), stdout.String())
+	}
+}
+
+// TestRunVaultPut_FlagBeforeAndAfterPath: `vault put <path> --from-file f`
+// and the flags-first order must both store the bytes.
+func TestRunVaultPut_FlagBeforeAndAfterPath(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		args  func(credFile string) []string
+	}{
+		{"path-then-flag", func(credFile string) []string {
+			return []string{"put", "agents/claude/oauth", "--from-file", credFile}
+		}},
+		{"flag-then-path", func(credFile string) []string {
+			return []string{"put", "--from-file", credFile, "agents/claude/oauth"}
+		}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			var received []byte
+			fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut || r.URL.Path != "/vault/agents/claude/credentials" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				var body agentCredentialsBody
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				received = body.Value
+				w.WriteHeader(http.StatusNoContent)
+			})
+			credFile := filepath.Join(t.TempDir(), "creds.json")
+			if err := os.WriteFile(credFile, []byte("tok"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			if code := runVault(tc.args(credFile), strings.NewReader(""), &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+			}
+			if string(received) != "tok" {
+				t.Errorf("server received %q, want tok (path+flag parsed in either order)", received)
+			}
+		})
+	}
+}
+
+// TestRunVaultDelete_FlagBeforeAndAfterPath: `vault delete <path> --yes` and
+// the flags-first order must both delete without prompting.
+func TestRunVaultDelete_FlagBeforeAndAfterPath(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		args  []string
+	}{
+		{"path-then-flag", []string{"delete", "agents/codex/oauth", "--yes"}},
+		{"flag-then-path", []string{"delete", "--yes", "agents/codex/oauth"}},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			gotDelete := false
+			fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete && r.URL.Path == "/vault/agents/codex/credentials" {
+					gotDelete = true
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			})
+			var stdout, stderr bytes.Buffer
+			// strings.NewReader("") so any (erroneous) prompt would read EOF, not "y".
+			if code := runVault(tc.args, strings.NewReader(""), &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+			}
+			if !gotDelete {
+				t.Errorf("DELETE not issued (path+--yes must parse in either order)")
+			}
+		})
+	}
+}

--- a/cmd/aileron/hub.go
+++ b/cmd/aileron/hub.go
@@ -89,16 +89,20 @@ func runHub(args []string, stdout, stderr io.Writer) int {
 // `{"suites":[...],"actions":[...],"connectors":[...]}` in combined
 // mode.
 func runHubList(args []string, stdout, stderr io.Writer) int {
-	category, rest := takePositional(args)
 	flags := flag.NewFlagSet("hub list", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	asJSON := flags.Bool("json", false, "Render entries as NDJSON (single-type) or one combined JSON object (default mode)")
-	if err := flags.Parse(rest); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 0 {
+	if len(positionals) > 1 {
 		fmt.Fprintln(stderr, "usage: aileron hub list [connectors|actions|suites] [--json]")
 		return 1
+	}
+	category := ""
+	if len(positionals) == 1 {
+		category = positionals[0]
 	}
 	switch category {
 	case "":
@@ -120,19 +124,19 @@ func runHubList(args []string, stdout, stderr io.Writer) int {
 // three catalogs and groups results by type. `--type` narrows to a
 // single catalog when the caller already knows what they want.
 func runHubSearch(args []string, stdout, stderr io.Writer) int {
-	args = reorderArgsFlagsFirst(args, map[string]bool{"type": true})
 	flags := flag.NewFlagSet("hub search", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	asJSON := flags.Bool("json", false, "Render entries as NDJSON (single-type) or one combined JSON object (default mode)")
 	typeFilter := flags.String("type", "", "Restrict search to one catalog: connectors, actions, or suites")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 {
+	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, "usage: aileron hub search <query> [--type connectors|actions|suites] [--json]")
 		return 1
 	}
-	query := flags.Arg(0)
+	query := positionals[0]
 	if strings.TrimSpace(query) == "" {
 		fmt.Fprintln(stderr, "error: query cannot be empty")
 		return 1
@@ -158,19 +162,19 @@ func runHubSearch(args []string, stdout, stderr io.Writer) int {
 // (connector → action → suite) and returning the first hit. `--type`
 // skips the dispatch and queries the named catalog directly.
 func runHubShow(args []string, stdout, stderr io.Writer) int {
-	args = reorderArgsFlagsFirst(args, map[string]bool{"type": true})
 	flags := flag.NewFlagSet("hub show", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	asJSON := flags.Bool("json", false, "Render the entry as a single JSON object")
 	typeFilter := flags.String("type", "", "Skip dispatch and query the named catalog: connectors, actions, or suites")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 {
+	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, "usage: aileron hub show <fqn> [--type connectors|actions|suites] [--json]")
 		return 1
 	}
-	fqn := flags.Arg(0)
+	fqn := positionals[0]
 	if strings.TrimSpace(fqn) == "" {
 		fmt.Fprintln(stderr, "error: fqn cannot be empty")
 		return 1
@@ -190,44 +194,6 @@ func runHubShow(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "valid values: connectors, actions, suites")
 		return 1
 	}
-}
-
-// takePositional pulls a leading non-flag argument off args and returns
-// it plus the remainder. Lets `hub list connectors --json` work as
-// expected without making `flag.Parse` stumble over the positional.
-func takePositional(args []string) (string, []string) {
-	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		return args[0], args[1:]
-	}
-	return "", args
-}
-
-// reorderArgsFlagsFirst moves every `--flag` (and its value, for
-// value-flags) ahead of any positional arguments so Go's stdlib
-// `flag.Parse` — which stops scanning at the first non-flag arg — can
-// pick up flags regardless of whether the user typed them before or
-// after the positional. valueFlags names the flags that consume a
-// following arg ("type" → `--type X`); boolean flags ("json") are
-// passed through unchanged.
-func reorderArgsFlagsFirst(args []string, valueFlags map[string]bool) []string {
-	var positional []string
-	var flagPart []string
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		if strings.HasPrefix(a, "-") {
-			flagPart = append(flagPart, a)
-			name := strings.TrimLeft(a, "-")
-			// `--flag=value` already self-contained; only consume a
-			// trailing arg when the user typed `--flag value`.
-			if !strings.Contains(name, "=") && valueFlags[name] && i+1 < len(args) {
-				flagPart = append(flagPart, args[i+1])
-				i++
-			}
-			continue
-		}
-		positional = append(positional, a)
-	}
-	return append(flagPart, positional...)
 }
 
 // --- list helpers, one per catalog ---

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -293,10 +293,11 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	node := flags.String("node", "", "Managed-toolchain escape hatch: path to a Node binary (with --devcontainer-cli)")
 	devcontainerCLI := flags.String("devcontainer-cli", "", "Managed-toolchain escape hatch: path to the @devcontainers/cli entrypoint (with --node)")
 	offline := flags.Bool("offline", false, "Resolve the managed toolchain from the warm cache with no network (run `aileron sandbox warm` first)")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() > 1 || (*agent != "" && flags.NArg() != 0) {
+	if len(positionals) > 1 || (*agent != "" && len(positionals) != 0) {
 		fmt.Fprintln(stderr, "usage: aileron sandbox check [--runtime=auto|docker] [--build=auto|always|never] [--agent=<command>] [--toolchain=managed|host-npx] [--offline] [--node=<path> --devcontainer-cli=<path>] [command]")
 		return 1
 	}
@@ -304,8 +305,8 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	command := *agent
-	if command == "" && flags.NArg() == 1 {
-		command = flags.Arg(0)
+	if command == "" && len(positionals) == 1 {
+		command = positionals[0]
 	}
 	if command == "" {
 		fmt.Fprintln(stderr, "usage: aileron sandbox check [--runtime=auto|docker] [--build=auto|always|never] [--agent=<command>] [command]")

--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -61,14 +61,15 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 func runSkillInstall(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("skill install", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 {
+	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, skillUsage)
 		return 1
 	}
-	src := flags.Arg(0)
+	src := positionals[0]
 
 	s := store.New(skillStoreDir)
 

--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -29,14 +29,15 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	signingKey := flags.String("signing-key", "", "Path to the PEM ed25519 signing key (falls back to $"+freeze.SigningKeyEnv+")")
 	version := flags.String("version", "", "Semver label recorded in the lock (for example 1.0.0)")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 {
+	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, skillUsage)
 		return 1
 	}
-	target := flags.Arg(0)
+	target := positionals[0]
 
 	raw, err := readSkillForFreeze(target)
 	if err != nil {

--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -62,14 +62,15 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	outDir := flags.String("out-dir", ".", "Directory file-target artifacts are written to")
 	var inputs inputFlag
 	flags.Var(&inputs, "input", "Launch input override as name=value; repeatable")
-	if err := flags.Parse(args); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	if flags.NArg() != 1 {
+	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, skillUsage)
 		return 1
 	}
-	name := flags.Arg(0)
+	name := positionals[0]
 
 	s := store.New(skillStoreDir)
 	id, err := resolveLaunchVersion(s, name, *version)

--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -17,44 +17,6 @@ import (
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
-// splitPathArg separates the single positional path argument (the
-// first non-flag token) from the flag tokens so the verbs accept the
-// path either before or after their flags. Go's flag package stops at
-// the first non-flag arg, so without this reorder
-// `vault put agents/x/oauth --from-file f` would never parse the flag.
-// Returns the path, the remaining flag args, and false if there is not
-// exactly one positional argument.
-func splitPathArg(args []string) (path string, flagArgs []string, ok bool) {
-	flagArgs = make([]string, 0, len(args))
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		if strings.HasPrefix(a, "-") {
-			flagArgs = append(flagArgs, a)
-			// A flag that takes a value in `--flag value` form keeps
-			// its value token attached. `--flag=value` is self-contained.
-			if !strings.Contains(a, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				// Only --from-file takes a separate value among these
-				// verbs; --yes/--json are booleans. Treat the next token
-				// as a value only for --from-file to avoid swallowing the
-				// path arg after a boolean flag.
-				if a == "--from-file" || a == "-from-file" {
-					flagArgs = append(flagArgs, args[i+1])
-					i++
-				}
-			}
-			continue
-		}
-		if path != "" {
-			return "", nil, false // more than one positional arg
-		}
-		path = a
-	}
-	if path == "" {
-		return "", nil, false
-	}
-	return path, flagArgs, true
-}
-
 // Environment variable that supplies the vault passphrase non-
 // interactively. Honored by every command that would otherwise prompt.
 // Documented in #492 item 5c as the CI / scripts escape hatch.
@@ -207,19 +169,19 @@ type userSummary struct {
 // credential files (Claude's .credentials.json, Codex's auth.json) are
 // exact-byte artifacts.
 func runVaultPut(args []string, stdout, stderr io.Writer) int {
-	pathArg, flagArgs, ok := splitPathArg(args)
-	if !ok {
-		fmt.Fprintln(stderr, "usage: aileron vault put agents/<name>/<purpose> --from-file <path>")
-		return 1
-	}
 	flags := flag.NewFlagSet("vault put", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	fromFile := flags.String("from-file", "", "Read the credential bytes verbatim from the named file")
 	flags.Bool("yes", false, "Accepted for symmetry with delete; put never prompts")
-	if err := flags.Parse(flagArgs); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	name, purpose, err := agentPathNameAndPurpose(pathArg)
+	if len(positionals) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron vault put agents/<name>/<purpose> --from-file <path>")
+		return 1
+	}
+	name, purpose, err := agentPathNameAndPurpose(positionals[0])
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -271,18 +233,18 @@ func runVaultPut(args []string, stdout, stderr io.Writer) int {
 // daemon applies no approval block for operator vault management per the
 // plan).
 func runVaultDelete(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	pathArg, flagArgs, ok := splitPathArg(args)
-	if !ok {
-		fmt.Fprintln(stderr, "usage: aileron vault delete agents/<name>/<purpose> [--yes] (exactly what vault list prints)")
-		return 1
-	}
 	flags := flag.NewFlagSet("vault delete", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	yes := flags.Bool("yes", false, "Skip the confirmation prompt")
-	if err := flags.Parse(flagArgs); err != nil {
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	name, purpose, err := agentPathNameAndPurpose(pathArg)
+	if len(positionals) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron vault delete agents/<name>/<purpose> [--yes] (exactly what vault list prints)")
+		return 1
+	}
+	name, purpose, err := agentPathNameAndPurpose(positionals[0])
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1


### PR DESCRIPTION
## Summary

Go's stdlib `flag` package stops scanning at the first non-flag token, so positional subcommands that called `flags.Parse(args)` then read `flags.Arg(0)` silently dropped any flag typed *after* the positional. `aileron action run my-action --arg k=v` failed while `aileron action run --arg k=v my-action` worked, an inconsistency users hit repeatedly (#1685).

Affected positional subcommands: `skill install`, `skill freeze`, `skill launch`, `action run`, `sandbox check`. The repo also carried two inconsistent ad-hoc workarounds that each manually enumerated value-flags: `reorderArgsFlagsFirst` (hub search/show) and `splitPathArg` (vault put/delete, hardcoded `--from-file`).

This PR adds one shared `parseInterspersedFlags` helper (`cmd/aileron/flagparse.go`): an iterative `flag.Parse` loop that peels off positionals one at a time and re-parses the remainder. It needs no value-flag map (the FlagSet already knows which flags take values) and accumulates repeatable flags (`--arg`, `--input`) across batches. The five broken subcommands now use it, and the hub + vault ad-hoc helpers are deleted and consolidated onto it so the whole CLI shares one correct behavior.

Behavioral note: flags-first ordering keeps working, and orderings that previously failed now work (e.g. `hub list --json connectors`, `vault put --from-file f agents/x/oauth`). A `--` terminator is still honored.

## Test plan

- New `cmd/aileron/flagparse_test.go`:
  - Unit tests for `parseInterspersedFlags`: flags-first / flags-after / interspersed / `--flag=value`, repeatable accumulation across the positional, scalar last-wins, no-positional, multiple-positionals, unknown-flag error, `--` terminator. Helper at 100% coverage.
  - Subcommand regression tests asserting both arg orders for the confirmed bugs `action run` and `skill freeze` (table-driven flags-before / flags-after / interspersed), plus `skill launch`, `sandbox check`, `hub search`, `hub list`, `vault put`, and `vault delete`.
- `go test ./cmd/aileron/` green; package coverage 86.2% (above the 80% bar).
- Existing hub/vault tests that exercise the flags-after order (e.g. `TestRunHub_SearchTypeFilterRestrictsToOneCatalog`) still pass against the consolidated helper.

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
