### PR TITLE
fix(launch): banner asserts Claude auth mode only when a credential was rendered

### DIFF
--- a/internal/launch/claude_auth_banner.go
+++ b/internal/launch/claude_auth_banner.go
@@ -30,22 +30,39 @@ type claudeAuthModeReader interface {
 	AuthModeDisplay() AuthModeDisplay
 }
 
-// claudeAuthBannerLine renders the active-mode banner line for the given
-// display mode. The copy is byte-exact per feedback #1331 Q4.
-func claudeAuthBannerLine(mode AuthModeDisplay) string {
+// claudeAuthBannerLine renders the banner line for the given display mode.
+//
+// renderedCredential reports whether a credential was actually seeded into the
+// container for this launch (authPrep.RenderedAnyCredential). The banner may
+// only assert an active auth mode when that is true: in API-key mode the
+// EnvBinding is Required=false, so a vault miss with a declined/failed
+// host-paste acquire leaves the container with no ANTHROPIC_API_KEY and Claude
+// Code falls back to in-container login (#1693). When nothing was rendered the
+// truthful line is that authentication happens inside the container, for both
+// modes. The active-mode copy is byte-exact per feedback #1331 Q4.
+func claudeAuthBannerLine(mode AuthModeDisplay, renderedCredential bool) string {
+	if !renderedCredential {
+		return "Claude auth: will authenticate inside the container"
+	}
 	if mode == AuthModeDisplayAPIKey {
 		return "Claude auth mode: API key"
 	}
 	return "Claude auth mode: subscription (Pro/Max)"
 }
 
-// printClaudeAuthBanner emits exactly one active-mode banner line to w when
-// the launch is a sandbox launch (sandboxEnabled) of the claude agent and
-// the agent exposes its mode via claudeAuthModeReader. On host launch the
-// auth mode is inert (the launcher never materializes AuthSpec there), so no
-// banner is printed to avoid a false signal (P0). Non-claude agents and
-// agents that do not expose a mode are silently skipped.
-func printClaudeAuthBanner(w io.Writer, agent Agent, sandboxEnabled bool) {
+// printClaudeAuthBanner emits exactly one banner line to w when the launch is a
+// sandbox launch (sandboxEnabled) of the claude agent and the agent exposes its
+// mode via claudeAuthModeReader. On host launch the auth mode is inert (the
+// launcher never materializes AuthSpec there), so no banner is printed to avoid
+// a false signal (P0). Non-claude agents and agents that do not expose a mode
+// are silently skipped.
+//
+// renderedCredential (authPrep.RenderedAnyCredential) gates the active-mode
+// claim: the banner asserts "API key" / "subscription (Pro/Max)" only when a
+// credential was actually rendered for this launch; otherwise it prints a
+// truthful in-container-login line so the banner never disagrees with the
+// container's real auth state (#1693).
+func printClaudeAuthBanner(w io.Writer, agent Agent, sandboxEnabled, renderedCredential bool) {
 	if !sandboxEnabled || agent == nil || agent.Name() != "claude" {
 		return
 	}
@@ -53,5 +70,5 @@ func printClaudeAuthBanner(w io.Writer, agent Agent, sandboxEnabled bool) {
 	if !ok {
 		return
 	}
-	fmt.Fprintln(w, claudeAuthBannerLine(reader.AuthModeDisplay()))
+	fmt.Fprintln(w, claudeAuthBannerLine(reader.AuthModeDisplay(), renderedCredential))
 }

--- a/internal/launch/claude_auth_banner_test.go
+++ b/internal/launch/claude_auth_banner_test.go
@@ -37,7 +37,9 @@ func TestPrintClaudeAuthBanner_SandboxClaude(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: tc.mode}, true)
+			// renderedCredential=true: a credential was actually seeded,
+			// so the banner is allowed to assert the active mode.
+			printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: tc.mode}, true, true)
 			got := strings.TrimRight(buf.String(), "\n")
 			if got != tc.want {
 				t.Errorf("banner = %q, want %q", got, tc.want)
@@ -50,11 +52,36 @@ func TestPrintClaudeAuthBanner_SandboxClaude(t *testing.T) {
 	}
 }
 
+// TestPrintClaudeAuthBanner_NoCredentialRendered is the #1693 regression
+// guard: when no credential was seeded into the container (vault miss +
+// declined/failed host acquire → in-container login fallback), the banner must
+// NOT assert an active auth mode for either display mode. Instead it prints a
+// truthful in-container-login line. Before the fix this printed
+// "Claude auth mode: API key" unconditionally, contradicting the container's
+// actual unauthenticated state.
+func TestPrintClaudeAuthBanner_NoCredentialRendered(t *testing.T) {
+	for _, mode := range []AuthModeDisplay{AuthModeDisplayAPIKey, AuthModeDisplaySubscription} {
+		var buf bytes.Buffer
+		printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: mode}, true, false)
+		got := strings.TrimRight(buf.String(), "\n")
+		if strings.Contains(got, "Claude auth mode:") {
+			t.Errorf("mode=%d: banner asserted an active mode with no credential rendered: %q", mode, got)
+		}
+		if got != "Claude auth: will authenticate inside the container" {
+			t.Errorf("mode=%d: banner = %q, want in-container-login line", mode, got)
+		}
+		// Still exactly one line.
+		if n := strings.Count(buf.String(), "\n"); n != 1 {
+			t.Errorf("mode=%d: banner emitted %d newlines, want exactly 1: %q", mode, n, buf.String())
+		}
+	}
+}
+
 // TestPrintClaudeAuthBanner_HostSuppressed is the P0 false-signal guard: on
 // host launch (sandboxEnabled=false) the mode is inert, so no banner.
 func TestPrintClaudeAuthBanner_HostSuppressed(t *testing.T) {
 	var buf bytes.Buffer
-	printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: AuthModeDisplayAPIKey}, false)
+	printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: AuthModeDisplayAPIKey}, false, true)
 	if buf.Len() != 0 {
 		t.Errorf("host launch emitted a banner: %q", buf.String())
 	}
@@ -64,7 +91,7 @@ func TestPrintClaudeAuthBanner_HostSuppressed(t *testing.T) {
 // non-claude agent never gets the banner even on the sandbox path.
 func TestPrintClaudeAuthBanner_NonClaudeSkipped(t *testing.T) {
 	var buf bytes.Buffer
-	printClaudeAuthBanner(&buf, claudeModeAgent{name: "codex", mode: AuthModeDisplayAPIKey}, true)
+	printClaudeAuthBanner(&buf, claudeModeAgent{name: "codex", mode: AuthModeDisplayAPIKey}, true, true)
 	if buf.Len() != 0 {
 		t.Errorf("non-claude agent emitted a banner: %q", buf.String())
 	}
@@ -75,7 +102,7 @@ func TestPrintClaudeAuthBanner_NonClaudeSkipped(t *testing.T) {
 // fails and the banner is silently skipped rather than panicking.
 func TestPrintClaudeAuthBanner_ClaudeWithoutReaderSkipped(t *testing.T) {
 	var buf bytes.Buffer
-	printClaudeAuthBanner(&buf, emptyClaudeAgent{}, true)
+	printClaudeAuthBanner(&buf, emptyClaudeAgent{}, true, true)
 	if buf.Len() != 0 {
 		t.Errorf("claude agent without AuthModeDisplay emitted a banner: %q", buf.String())
 	}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -830,7 +830,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		// because the auth mode is inert on host launch (AuthSpec is only
 		// materialized under sandbox), so emitting it there would be a false
 		// signal (P0). Non-claude agents are a no-op.
-		printClaudeAuthBanner(os.Stderr, config.Agent, sandboxEnabled)
+		printClaudeAuthBanner(os.Stderr, config.Agent, sandboxEnabled, authPrep.RenderedAnyCredential)
 
 		// User-level GitHub injection runs on every sandbox launch,
 		// independent of the per-agent AuthSpec: it probes the


### PR DESCRIPTION
## Summary

The launch auth banner (`internal/launch/claude_auth_banner.go`, printed at `launcher.go:833`) emitted `Claude auth mode: API key` (or `subscription (Pro/Max)`) unconditionally from the agent's *intended* mode, with no regard for whether a credential was actually seeded into the container.

In API-key mode the `EnvBinding` at `agents/claude/apikey` is `Required=false`. On a vault miss the host-paste acquirer can be declined/cancelled/fail-validation, in which case `authspec_runtime.go` logs "falling back to in-container login", adds **no** env var, and leaves `authPrep.RenderedAnyCredential=false`. The container then starts with no `ANTHROPIC_API_KEY` and Claude Code is unauthenticated, yet the banner still asserted "API key" — the mismatch reported in #1693.

This threads the already-available `authPrep.RenderedAnyCredential` signal into `printClaudeAuthBanner`:

- Active-mode line (`Claude auth mode: API key` / `subscription (Pro/Max)`) is printed **only** when a credential was actually rendered for this launch.
- When nothing was rendered (vault miss + declined/failed host acquire → in-container login fallback, for both modes), it prints a truthful `Claude auth: will authenticate inside the container` line instead.

Scope is the signature/call-site of `printClaudeAuthBanner` plus the `launcher.go` call passing `authPrep.RenderedAnyCredential`. No OpenAPI change (launch-only).

## Test plan

- New regression test `TestPrintClaudeAuthBanner_NoCredentialRendered`: with `renderedCredential=false`, the banner must NOT assert an active mode for either display mode and must print the in-container-login line. Verified it **fails before** the fix and **passes after**.
- Existing `rendered=true` cases (`SandboxClaude` subscription/api-key), host-suppressed, non-claude, and no-reader cases remain green (updated to pass the new `renderedCredential` arg).
- `go vet ./launch/...` clean; full `go test ./launch/...` green.

Closes #1693

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Claude authentication banner so it now reflects whether credentials were actually provided.
  * When no credential is available, the banner correctly tells users authentication will happen inside the container instead of showing an active auth mode.
  * When a credential is present, the banner continues to show the appropriate authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->