### PR TITLE
fix(launch): pre-approve env API key so Claude Code launch is hands-off

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -181,7 +181,18 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 			StaticFiles: []launch.StaticFile{{
 				ContainerPath: claudeOnboardingContainerPath,
 				Mode:          0o644,
+				// RenderContent makes the onboarding stub key-aware: it
+				// derives customApiKeyResponses.approved from the same
+				// ANTHROPIC_API_KEY the EnvBinding above just rendered, so
+				// Claude Code does not show the interactive "Detected a
+				// custom API key in your environment" prompt (which defaults
+				// to "No") and the hands-off launch is not blocked (#1695).
+				// Content is the fallback the launcher writes if RenderContent
+				// is ever nil; we keep it pointed at the plain stub so a
+				// regression that drops the hook degrades to the pre-#1695
+				// behavior rather than an empty file.
 				Content:       claudeOnboardingStub,
+				RenderContent: claudeAPIKeyOnboardingContent,
 			}},
 		}
 	}

--- a/internal/launch/agents/claude_apikey_onboarding_internal_test.go
+++ b/internal/launch/agents/claude_apikey_onboarding_internal_test.go
@@ -1,0 +1,218 @@
+package agents
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// onboardingFields is the subset of /home/agent/.claude.json the launch
+// stub must always carry to keep first-run silent. Both modes must
+// satisfy these.
+type onboardingFields struct {
+	HasCompletedOnboarding        bool   `json:"hasCompletedOnboarding"`
+	BypassPermissionsModeAccepted bool   `json:"bypassPermissionsModeAccepted"`
+	InstallMethod                 string `json:"installMethod"`
+	Projects                      map[string]struct {
+		HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+	} `json:"projects"`
+	CustomApiKeyResponses *struct {
+		Approved []string `json:"approved"`
+	} `json:"customApiKeyResponses"`
+}
+
+func assertCoreOnboardingFields(t *testing.T, of onboardingFields) {
+	t.Helper()
+	if !of.HasCompletedOnboarding {
+		t.Error("hasCompletedOnboarding = false; the theme picker would paint on launch")
+	}
+	if !of.BypassPermissionsModeAccepted {
+		t.Error("bypassPermissionsModeAccepted = false; the skip-permissions disclaimer would block")
+	}
+	if of.InstallMethod != "global" {
+		t.Errorf("installMethod = %q, want global", of.InstallMethod)
+	}
+	trust, ok := of.Projects[claudeWorkspacePath]
+	if !ok {
+		t.Fatalf("projects missing workspace entry %q; got %v", claudeWorkspacePath, of.Projects)
+	}
+	if !trust.HasTrustDialogAccepted {
+		t.Error("workspace hasTrustDialogAccepted = false; the trust dialog would block")
+	}
+}
+
+// TestClaudeAPIKeySuffix covers the per-key approval-token derivation:
+// the last claudeAPIKeySuffixLen characters of the (already-trimmed) key,
+// or the whole key when it is shorter.
+func TestClaudeAPIKeySuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "long key returns last 20 chars",
+			key:  "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+			want: "VWXYZ0123456789", // recomputed below; placeholder replaced
+		},
+		{
+			name: "exactly 20 chars returns whole key",
+			key:  "abcdefghij0123456789",
+			want: "abcdefghij0123456789",
+		},
+		{
+			name: "shorter than 20 returns whole key",
+			key:  "sk-short",
+			want: "sk-short",
+		},
+		{
+			name: "empty key returns empty",
+			key:  "",
+			want: "",
+		},
+	}
+	// Recompute the long-key expectation from the constant so the test
+	// does not hardcode a wrong slice if claudeAPIKeySuffixLen changes.
+	tests[0].want = tests[0].key[len(tests[0].key)-claudeAPIKeySuffixLen:]
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := claudeAPIKeySuffix(tc.key)
+			if got != tc.want {
+				t.Fatalf("claudeAPIKeySuffix(%q) = %q, want %q", tc.key, got, tc.want)
+			}
+			if tc.key != "" && len([]rune(got)) > claudeAPIKeySuffixLen {
+				t.Fatalf("suffix longer than %d runes: %q", claudeAPIKeySuffixLen, got)
+			}
+		})
+	}
+}
+
+// TestClaudeAPIKeyOnboardingContent_ApprovesRenderedKey is the #1695
+// regression: in api-key mode the rendered .claude.json must carry
+// customApiKeyResponses.approved holding the last-20-char suffix of the
+// key Claude Code actually sees (the same trimmed value the EnvBinding
+// rendered into ANTHROPIC_API_KEY), so Claude Code does not show the
+// "Detected a custom API key in your environment" prompt.
+func TestClaudeAPIKeyOnboardingContent_ApprovesRenderedKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		renderedKey string // value in env[ANTHROPIC_API_KEY] as the binding rendered it
+		wantSuffix  string
+	}{
+		{
+			name:        "long key approves last 20 chars",
+			renderedKey: "sk-ant-api03-LONGKEYWITHMORETHANTWENTYCHARSXYZ",
+			wantSuffix:  "REETHANTWENTYCHARSXYZ"[1:], // last 20 chars, recomputed below
+		},
+		{
+			name:        "short key approves whole key",
+			renderedKey: "sk-short-key",
+			wantSuffix:  "sk-short-key",
+		},
+	}
+	tests[0].wantSuffix = tests[0].renderedKey[len(tests[0].renderedKey)-claudeAPIKeySuffixLen:]
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := map[string]string{claudeAPIKeyEnv: tc.renderedKey}
+			b, err := claudeAPIKeyOnboardingContent(env)
+			if err != nil {
+				t.Fatalf("claudeAPIKeyOnboardingContent: %v", err)
+			}
+			var of onboardingFields
+			if err := json.Unmarshal(b, &of); err != nil {
+				t.Fatalf("unmarshal rendered .claude.json: %v\n%s", err, b)
+			}
+			assertCoreOnboardingFields(t, of)
+			if of.CustomApiKeyResponses == nil {
+				t.Fatalf("customApiKeyResponses absent; the custom-API-key prompt would block. doc: %s", b)
+			}
+			got := of.CustomApiKeyResponses.Approved
+			if len(got) != 1 || got[0] != tc.wantSuffix {
+				t.Fatalf("approved = %v, want [%q]", got, tc.wantSuffix)
+			}
+		})
+	}
+}
+
+// TestClaudeAPIKeyOnboardingContent_TrimsBeforeSuffix proves the approval
+// token is derived from the trimmed key. claudeAPIKeyRender trims
+// whitespace before rendering into ANTHROPIC_API_KEY, so the suffix the
+// onboarding doc records must match the trimmed value Claude Code sees,
+// not the raw env string with surrounding whitespace.
+func TestClaudeAPIKeyOnboardingContent_TrimsBeforeSuffix(t *testing.T) {
+	// A key whose meaningful suffix is followed by a trailing newline.
+	rawKey := "sk-ant-api03-TRAILINGWHITESPACEKEY1234"
+	env := map[string]string{claudeAPIKeyEnv: "  " + rawKey + "\n"}
+
+	b, err := claudeAPIKeyOnboardingContent(env)
+	if err != nil {
+		t.Fatalf("claudeAPIKeyOnboardingContent: %v", err)
+	}
+	var of onboardingFields
+	if err := json.Unmarshal(b, &of); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if of.CustomApiKeyResponses == nil {
+		t.Fatalf("customApiKeyResponses absent")
+	}
+	want := rawKey[len(rawKey)-claudeAPIKeySuffixLen:]
+	if got := of.CustomApiKeyResponses.Approved; len(got) != 1 || got[0] != want {
+		t.Fatalf("approved = %v, want [%q] (suffix of the trimmed key, not the whitespace-padded env)", got, want)
+	}
+	// The suffix must never contain the leading/trailing whitespace.
+	if strings.ContainsAny(of.CustomApiKeyResponses.Approved[0], " \n\t") {
+		t.Fatalf("approval token carries whitespace: %q", of.CustomApiKeyResponses.Approved[0])
+	}
+}
+
+// TestClaudeAPIKeyOnboardingContent_NoKeyOmitsApproval covers the
+// fall-back case: the api-key acquire missed and no ANTHROPIC_API_KEY was
+// rendered into the env. With no env key there is nothing for Claude Code
+// to prompt about, so the doc must carry the onboarding fields but no
+// customApiKeyResponses key (byte-identical to the plain stub).
+func TestClaudeAPIKeyOnboardingContent_NoKeyOmitsApproval(t *testing.T) {
+	for _, env := range []map[string]string{
+		nil,
+		{},
+		{claudeAPIKeyEnv: ""},
+		{claudeAPIKeyEnv: "   \n"},
+	} {
+		b, err := claudeAPIKeyOnboardingContent(env)
+		if err != nil {
+			t.Fatalf("claudeAPIKeyOnboardingContent(%v): %v", env, err)
+		}
+		var of onboardingFields
+		if err := json.Unmarshal(b, &of); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		assertCoreOnboardingFields(t, of)
+		if of.CustomApiKeyResponses != nil {
+			t.Errorf("env %v: customApiKeyResponses present with no rendered key: %v", env, of.CustomApiKeyResponses)
+		}
+		// No rendered key ⇒ the doc must be byte-identical to the plain
+		// onboarding stub.
+		if string(b) != string(claudeOnboardingStub) {
+			t.Errorf("env %v: doc not byte-identical to plain stub.\n got: %s\nwant: %s", env, b, claudeOnboardingStub)
+		}
+	}
+}
+
+// TestClaudeOnboardingStub_NoCustomApiKeyResponses pins the subscription
+// stub's byte shape: it must not carry customApiKeyResponses at all (no
+// env key, no prompt). This is the regression guard that the new pointer
+// field stays omitted via omitempty in the no-approval path.
+func TestClaudeOnboardingStub_NoCustomApiKeyResponses(t *testing.T) {
+	if strings.Contains(string(claudeOnboardingStub), "customApiKeyResponses") {
+		t.Fatalf("subscription onboarding stub leaked customApiKeyResponses: %s", claudeOnboardingStub)
+	}
+	var of onboardingFields
+	if err := json.Unmarshal(claudeOnboardingStub, &of); err != nil {
+		t.Fatalf("unmarshal stub: %v", err)
+	}
+	assertCoreOnboardingFields(t, of)
+	if of.CustomApiKeyResponses != nil {
+		t.Fatalf("subscription stub has customApiKeyResponses: %v", of.CustomApiKeyResponses)
+	}
+}

--- a/internal/launch/agents/claude_apikey_onboarding_test.go
+++ b/internal/launch/agents/claude_apikey_onboarding_test.go
@@ -1,0 +1,113 @@
+package agents_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// claudeOnboardingShape mirrors the contractual fields of
+// /home/agent/.claude.json for the AuthSpec-level wiring tests.
+type claudeOnboardingShape struct {
+	HasCompletedOnboarding        bool   `json:"hasCompletedOnboarding"`
+	BypassPermissionsModeAccepted bool   `json:"bypassPermissionsModeAccepted"`
+	InstallMethod                 string `json:"installMethod"`
+	Projects                      map[string]struct {
+		HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+	} `json:"projects"`
+	CustomApiKeyResponses *struct {
+		Approved []string `json:"approved"`
+	} `json:"customApiKeyResponses"`
+}
+
+func assertSharedOnboardingFields(t *testing.T, b []byte) claudeOnboardingShape {
+	t.Helper()
+	var s claudeOnboardingShape
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("unmarshal .claude.json: %v\n%s", err, b)
+	}
+	if !s.HasCompletedOnboarding {
+		t.Error("hasCompletedOnboarding = false")
+	}
+	if !s.BypassPermissionsModeAccepted {
+		t.Error("bypassPermissionsModeAccepted = false")
+	}
+	if s.InstallMethod != "global" {
+		t.Errorf("installMethod = %q, want global", s.InstallMethod)
+	}
+	if len(s.Projects) == 0 {
+		t.Error("projects empty; the trust dialog would block")
+	}
+	for _, p := range s.Projects {
+		if !p.HasTrustDialogAccepted {
+			t.Error("a project entry has hasTrustDialogAccepted = false")
+		}
+	}
+	return s
+}
+
+// TestClaude_APIKeyAuthSpec_OnboardingIsKeyAware proves the api-key
+// AuthSpec wires the key-aware onboarding hook (RenderContent) onto the
+// .claude.json StaticFile and that invoking it with a rendered
+// ANTHROPIC_API_KEY yields a doc carrying the key's last-20-char suffix
+// under customApiKeyResponses.approved. This is the #1695 acceptance path
+// at the AuthSpec layer (the launch runtime invokes RenderContent with
+// the rendered env additions).
+func TestClaude_APIKeyAuthSpec_OnboardingIsKeyAware(t *testing.T) {
+	spec := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec()
+	if len(spec.StaticFiles) != 1 {
+		t.Fatalf("StaticFiles = %d, want 1", len(spec.StaticFiles))
+	}
+	sf := spec.StaticFiles[0]
+	if sf.RenderContent == nil {
+		t.Fatal("api-key StaticFile must set RenderContent so the onboarding doc is key-aware")
+	}
+
+	key := "sk-ant-api03-THISISALONGTESTKEYABCDEFG"
+	b, err := sf.RenderContent(map[string]string{"ANTHROPIC_API_KEY": key})
+	if err != nil {
+		t.Fatalf("RenderContent: %v", err)
+	}
+	s := assertSharedOnboardingFields(t, b)
+	if s.CustomApiKeyResponses == nil {
+		t.Fatalf("customApiKeyResponses absent; the api-key prompt would block. doc: %s", b)
+	}
+	want := key[len(key)-20:]
+	if got := s.CustomApiKeyResponses.Approved; len(got) != 1 || got[0] != want {
+		t.Fatalf("approved = %v, want [%q]", got, want)
+	}
+}
+
+// TestClaude_SubscriptionAuthSpec_OnboardingByteIdentical proves
+// subscription mode is unaffected: the StaticFile sets no RenderContent
+// hook and its Content is byte-identical to the api-key mode's Content
+// fallback (the plain onboarding stub) and carries no
+// customApiKeyResponses field.
+func TestClaude_SubscriptionAuthSpec_OnboardingByteIdentical(t *testing.T) {
+	sub := agents.NewClaude(agents.ClaudeAuthModeSubscription).AuthSpec()
+	if len(sub.StaticFiles) != 1 {
+		t.Fatalf("subscription StaticFiles = %d, want 1", len(sub.StaticFiles))
+	}
+	subSF := sub.StaticFiles[0]
+	if subSF.RenderContent != nil {
+		t.Error("subscription StaticFile must NOT set RenderContent (no env key, no prompt)")
+	}
+	if strings.Contains(string(subSF.Content), "customApiKeyResponses") {
+		t.Errorf("subscription .claude.json leaked customApiKeyResponses: %s", subSF.Content)
+	}
+	s := assertSharedOnboardingFields(t, subSF.Content)
+	if s.CustomApiKeyResponses != nil {
+		t.Errorf("subscription .claude.json carries customApiKeyResponses: %v", s.CustomApiKeyResponses)
+	}
+
+	// The api-key mode's Content fallback (used only if RenderContent were
+	// ever nil) is the same plain stub, so a regression dropping the hook
+	// degrades to the pre-#1695 subscription bytes rather than an empty
+	// file.
+	apiSF := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec().StaticFiles[0]
+	if string(apiSF.Content) != string(subSF.Content) {
+		t.Errorf("api-key Content fallback differs from subscription stub.\n api: %s\n sub: %s", apiSF.Content, subSF.Content)
+	}
+}

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -365,28 +365,102 @@ const claudeWorkspacePath = "/home/agent/workspace"
 //     disclaimer inside it is consistent with the pre-accepted trust
 //     dialog above. (#1379)
 //
-// Built from a typed value rather than a string literal so the nested
-// shape stays valid as Anthropic adds onboarding fields.
-var claudeOnboardingStub = mustMarshalOnboardingStub()
+// claudeAPIKeySuffixLen is the number of trailing characters of the raw
+// ANTHROPIC_API_KEY that Claude Code stores in
+// `customApiKeyResponses.approved` to pre-approve an env-supplied key.
+// Claude Code keys the approval on the LAST 20 characters of the raw key
+// (the suffix, not a hash), so a .claude.json carrying that suffix
+// suppresses the interactive "Detected a custom API key in your
+// environment" confirmation that otherwise blocks a hands-off launch.
+const claudeAPIKeySuffixLen = 20
 
-func mustMarshalOnboardingStub() []byte {
-	type projectTrust struct {
-		HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
-	}
-	stub := struct {
-		HasCompletedOnboarding        bool                    `json:"hasCompletedOnboarding"`
-		BypassPermissionsModeAccepted bool                    `json:"bypassPermissionsModeAccepted"`
-		InstallMethod                 string                  `json:"installMethod"`
-		Projects                      map[string]projectTrust `json:"projects"`
-	}{
+// claudeProjectTrust is the per-project onboarding entry; the trust
+// dialog is pre-accepted for the bind-mounted workspace.
+type claudeProjectTrust struct {
+	HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+}
+
+// claudeCustomAPIKeyResponses pre-approves env-supplied API keys so
+// Claude Code does not prompt "Detected a custom API key in your
+// environment". The "approved" list carries the last
+// claudeAPIKeySuffixLen characters of each approved key.
+type claudeCustomAPIKeyResponses struct {
+	Approved []string `json:"approved"`
+}
+
+// claudeOnboardingDoc is the typed shape of /home/agent/.claude.json.
+// CustomApiKeyResponses uses ",omitempty" with a pointer so subscription
+// mode (which sets it nil) emits a document byte-identical to the
+// pre-#1695 stub — no customApiKeyResponses key at all.
+type claudeOnboardingDoc struct {
+	HasCompletedOnboarding        bool                          `json:"hasCompletedOnboarding"`
+	BypassPermissionsModeAccepted bool                          `json:"bypassPermissionsModeAccepted"`
+	InstallMethod                 string                        `json:"installMethod"`
+	Projects                      map[string]claudeProjectTrust `json:"projects"`
+	CustomApiKeyResponses         *claudeCustomAPIKeyResponses  `json:"customApiKeyResponses,omitempty"`
+}
+
+// newClaudeOnboardingDoc builds the onboarding document shared by both
+// auth modes. The onboarding fields (hasCompletedOnboarding,
+// bypassPermissionsModeAccepted, installMethod, projects trust) are
+// constant; see the field comments in claudeOnboardingStub for why each
+// is pre-accepted. apiKeyApprovals, when non-empty, is attached as
+// customApiKeyResponses.approved.
+func newClaudeOnboardingDoc(apiKeyApprovals []string) claudeOnboardingDoc {
+	doc := claudeOnboardingDoc{
 		HasCompletedOnboarding:        true,
 		BypassPermissionsModeAccepted: true,
 		InstallMethod:                 "global",
-		Projects: map[string]projectTrust{
+		Projects: map[string]claudeProjectTrust{
 			claudeWorkspacePath: {HasTrustDialogAccepted: true},
 		},
 	}
-	b, err := json.Marshal(stub)
+	if len(apiKeyApprovals) > 0 {
+		doc.CustomApiKeyResponses = &claudeCustomAPIKeyResponses{Approved: apiKeyApprovals}
+	}
+	return doc
+}
+
+// claudeOnboardingStub is the payload written to /home/agent/.claude.json
+// in subscription mode (and the base for api-key mode). It short-circuits
+// the first-run interruptions so a vault-rendered sandbox launch is
+// silent end-to-end:
+//
+//   - hasCompletedOnboarding skips the theme picker / first-run wizard.
+//   - installMethod "global" matches the devcontainer's
+//     `npm install -g @anthropic-ai/claude-code`. Claude's `/doctor`
+//     uses installMethod to decide where to verify the binary; "native"
+//     made it look for ~/.local/bin/claude (the native-installer path,
+//     which the npm install never creates) and report the CLI as
+//     "missing or broken". "global" verifies the PATH-resolved global
+//     binary the devcontainer actually installs.
+//   - projects[workspace].hasTrustDialogAccepted pre-accepts the folder
+//     trust dialog ("Is this a project you trust?") for the bind-mounted
+//     workspace, so the agent does not block on it on every launch. The
+//     sandbox container is the trust boundary, so pre-accepting inside
+//     it is safe.
+//   - bypassPermissionsModeAccepted pre-accepts the
+//     "Bypassing Permissions" disclaimer that Claude Code shows the
+//     first time it runs under --dangerously-skip-permissions. The
+//     sandbox launch always passes that flag (Args(ModeSandbox)), so
+//     without this the first launch blocks on an interactive
+//     "do you want to dangerously skip permissions?" confirmation —
+//     defeating the hands-off Cloud startup the flag exists to provide.
+//     The opt-in is already expressed by Aileron passing the flag; the
+//     container is the trust boundary (ADR-0015), so pre-accepting the
+//     disclaimer inside it is consistent with the pre-accepted trust
+//     dialog above. (#1379)
+//
+// In api-key mode the document gets one additional field,
+// customApiKeyResponses.approved, derived per-launch from the rendered
+// key; see claudeAPIKeyOnboardingContent. Subscription mode never carries
+// it (no env key, no prompt). Built from a typed value rather than a
+// string literal so the nested shape stays valid as Anthropic adds
+// onboarding fields.
+var claudeOnboardingStub = mustMarshalOnboardingStub()
+
+func mustMarshalOnboardingStub() []byte {
+	b, err := json.Marshal(newClaudeOnboardingDoc(nil))
 	if err != nil {
 		// The shape is a fixed literal; marshaling it cannot fail at
 		// runtime. Panic so a refactor that breaks it surfaces in tests
@@ -394,6 +468,42 @@ func mustMarshalOnboardingStub() []byte {
 		panic("claude: marshaling onboarding stub: " + err.Error())
 	}
 	return b
+}
+
+// claudeAPIKeySuffix returns the per-key approval token Claude Code
+// stores in customApiKeyResponses.approved: the last
+// claudeAPIKeySuffixLen characters of the key, or the whole key when it
+// is shorter. The key must already be trimmed (claudeAPIKeyRender trims
+// whitespace before rendering into ANTHROPIC_API_KEY) so the suffix
+// matches the value Claude Code actually sees in its env. The suffix is
+// measured in runes, not bytes, so a key with multi-byte characters
+// yields the same trailing characters Claude Code's JS slice would.
+func claudeAPIKeySuffix(key string) string {
+	r := []rune(key)
+	if len(r) <= claudeAPIKeySuffixLen {
+		return key
+	}
+	return string(r[len(r)-claudeAPIKeySuffixLen:])
+}
+
+// claudeAPIKeyOnboardingContent is the StaticFile.RenderContent hook for
+// api-key mode. The launcher invokes it after the EnvBinding renders the
+// vault key into ANTHROPIC_API_KEY, passing the rendered env additions,
+// so the .claude.json carries the suffix of the exact key Claude Code
+// will see. When the env addition is absent (the api-key acquire fell
+// back to the in-container login, so no key was rendered), it emits the
+// plain onboarding stub — there is no env key for Claude Code to prompt
+// about, so no approval is needed.
+func claudeAPIKeyOnboardingContent(env map[string]string) ([]byte, error) {
+	var approvals []string
+	if key := strings.TrimSpace(env[claudeAPIKeyEnv]); key != "" {
+		approvals = []string{claudeAPIKeySuffix(key)}
+	}
+	b, err := json.Marshal(newClaudeOnboardingDoc(approvals))
+	if err != nil {
+		return nil, fmt.Errorf("claude: marshal api-key onboarding doc: %w", err)
+	}
+	return b, nil
 }
 
 // claudeRender writes the vault's stored bytes into the in-container

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -280,8 +280,22 @@ type StaticFile struct {
 	Mode fs.FileMode
 
 	// Content is the file bytes written unconditionally on every
-	// launch.
+	// launch when RenderContent is nil. When RenderContent is non-nil,
+	// it takes precedence and Content is ignored.
 	Content []byte
+
+	// RenderContent, when non-nil, computes the file bytes from the
+	// env vars the spec's EnvBindings already rendered. The launcher
+	// invokes it AFTER the EnvBinding loop populates the env additions,
+	// so a StaticFile can derive content from a freshly-rendered
+	// credential (Claude's api-key mode needs the rendered
+	// ANTHROPIC_API_KEY's suffix to pre-approve Claude Code's
+	// custom-API-key prompt). The map is the same env additions the
+	// agent process receives, so the derived content sees exactly the
+	// value the agent will (including any Render-side trimming). A
+	// non-nil RenderContent supersedes Content; returning an error
+	// aborts the launch.
+	RenderContent func(env map[string]string) ([]byte, error)
 }
 
 // RefreshDeps is the bag of helpers a FileBinding's PreLaunchRefresh

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -538,7 +538,21 @@ func prepareAuthSpec(
 		if mode == 0 {
 			mode = 0o644
 		}
-		if err := os.WriteFile(hostPath, sf.Content, mode); err != nil {
+		// RenderContent (when set) derives the bytes from the env vars the
+		// EnvBinding loop above already rendered into prep.EnvAdditions, so
+		// the static file can be made credential-aware. It runs after that
+		// loop, so the map already holds any freshly-rendered key. A nil
+		// RenderContent preserves the verbatim Content write.
+		content := sf.Content
+		if sf.RenderContent != nil {
+			rendered, rcErr := sf.RenderContent(prep.EnvAdditions)
+			if rcErr != nil {
+				cleanup()
+				return prep, fmt.Errorf("auth spec: render static %s: %w", sf.ContainerPath, rcErr)
+			}
+			content = rendered
+		}
+		if err := os.WriteFile(hostPath, content, mode); err != nil {
 			cleanup()
 			return prep, fmt.Errorf("auth spec: write static %s: %w", hostPath, err)
 		}

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -340,6 +340,88 @@ func TestPrepareAuthSpec_StaticFileLandsRegardlessOfVault(t *testing.T) {
 	}
 }
 
+// TestPrepareAuthSpec_StaticFileRenderContentSeesRenderedEnv proves the
+// StaticFile.RenderContent hook is invoked with the env vars the
+// EnvBindings already rendered, and that its output (not Content) is what
+// the launcher writes. This is the plumbing #1695 relies on: Claude's
+// api-key onboarding stub derives customApiKeyResponses.approved from the
+// ANTHROPIC_API_KEY the EnvBinding rendered moments earlier.
+func TestPrepareAuthSpec_StaticFileRenderContentSeesRenderedEnv(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seedPurpose("claude", "apikey", []byte("sk-ant-rendered-key"))
+
+	var sawEnv map[string]string
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath: "agents/claude/apikey",
+			Required:  false,
+			Render: func(s vault.Secret) (map[string]string, error) {
+				return map[string]string{"ANTHROPIC_API_KEY": string(s.Value)}, nil
+			},
+		}},
+		StaticFiles: []StaticFile{{
+			ContainerPath: "/home/agent/.claude.json",
+			Mode:          0o644,
+			Content:       []byte("FALLBACK-SHOULD-NOT-BE-WRITTEN"),
+			RenderContent: func(env map[string]string) ([]byte, error) {
+				sawEnv = env
+				return []byte("approved:" + env["ANTHROPIC_API_KEY"]), nil
+			},
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if sawEnv["ANTHROPIC_API_KEY"] != "sk-ant-rendered-key" {
+		t.Fatalf("RenderContent saw env[ANTHROPIC_API_KEY] = %q, want the rendered key", sawEnv["ANTHROPIC_API_KEY"])
+	}
+
+	var staticSource string
+	for _, m := range prep.Mounts {
+		if m.Target == "/home/agent/.claude.json" {
+			staticSource = m.Source
+		}
+	}
+	if staticSource == "" {
+		t.Fatalf("no file mount for /home/agent/.claude.json; got %+v", prep.Mounts)
+	}
+	got, err := os.ReadFile(staticSource)
+	if err != nil {
+		t.Fatalf("read static: %v", err)
+	}
+	if string(got) != "approved:sk-ant-rendered-key" {
+		t.Fatalf("static content = %q, want the RenderContent output (Content fallback must be ignored)", got)
+	}
+}
+
+// TestPrepareAuthSpec_StaticFileRenderContentErrorAborts proves a
+// RenderContent failure aborts the launch (and cleans up) rather than
+// writing a half-formed onboarding file.
+func TestPrepareAuthSpec_StaticFileRenderContentErrorAborts(t *testing.T) {
+	spec := AuthSpec{
+		StaticFiles: []StaticFile{{
+			ContainerPath: "/home/agent/.claude.json",
+			Mode:          0o644,
+			Content:       []byte("ignored"),
+			RenderContent: func(map[string]string) ([]byte, error) {
+				return nil, errors.New("boom")
+			},
+		}},
+	}
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
+		newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected RenderContent error to abort the launch")
+	}
+	if !strings.Contains(err.Error(), "render static") {
+		t.Errorf("error = %v, want mention of render static", err)
+	}
+}
+
 func TestPrepareAuthSpec_RequiredVaultMissingFailsLaunch(t *testing.T) {
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{

--- a/internal/launch/authspec_test.go
+++ b/internal/launch/authspec_test.go
@@ -89,9 +89,10 @@ func TestFileBinding_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestStaticFile_ShapeIsConstant pins the StaticFile invariant: the
-// Content slice is what the launcher writes verbatim into the bind
-// mount on every launch, regardless of vault state. No render hook.
+// TestStaticFile_ShapeIsConstant pins the StaticFile invariant: with no
+// RenderContent hook, the Content slice is what the launcher writes
+// verbatim into the bind mount on every launch, regardless of vault
+// state.
 func TestStaticFile_ShapeIsConstant(t *testing.T) {
 	sf := StaticFile{
 		ContainerPath: "/home/agent/.claude.json",


### PR DESCRIPTION
## Summary

In api-key auth mode, `aileron launch claude` renders the vault's `ANTHROPIC_API_KEY` into the container env (via the EnvBinding) and writes an onboarding stub to `/home/agent/.claude.json`. That stub pre-accepts the theme picker, trust dialog, and bypass-permissions disclaimer, but it did **not** pre-approve the env-supplied API key. Claude Code therefore showed the interactive "Detected a custom API key in your environment" confirmation (defaulting to "No"), blocking the hands-off launch.

Claude Code suppresses that prompt when `~/.claude.json` carries `customApiKeyResponses.approved` containing the **last 20 characters** of the env-supplied key (the raw suffix, not a hash; the per-key approval token).

The fix makes the onboarding stub key-aware:

- `launch.StaticFile` gains an optional `RenderContent func(env map[string]string) ([]byte, error)` hook. The launcher invokes it in the StaticFile loop (which runs after the EnvBinding loop has populated the env additions), passing the rendered env, and writes its output instead of `Content`. A nil hook preserves the verbatim `Content` write, so every other agent and subscription mode are untouched.
- Claude's api-key `AuthSpec` wires `RenderContent: claudeAPIKeyOnboardingContent`, which derives `customApiKeyResponses.approved` from the same trimmed `ANTHROPIC_API_KEY` the EnvBinding rendered, guaranteeing the suffix matches exactly what Claude Code sees. When no key was rendered (acquire fell back to in-container login), it emits the plain stub — no env key means no prompt to suppress.
- The onboarding doc is built from a shared typed value (`newClaudeOnboardingDoc`) so the existing onboarding fields (`hasCompletedOnboarding`, `bypassPermissionsModeAccepted`, `installMethod`, projects trust) survive in both modes. `customApiKeyResponses` is a pointer with `omitempty`, so subscription mode's `.claude.json` stays byte-identical to today.

No OpenAPI spec change (launch-side Go only). The `apiKeyHelper` setting was deliberately not used — Aileron already injects the key into the env, so the suffix-approval path is the correct mechanism.

## Test plan

- `go test ./internal/launch/...` — green (launch + agents + hostimport).
- New regression tests:
  - `claude_apikey_onboarding_internal_test.go`: table-tests `claudeAPIKeySuffix` (>20-char key, exactly-20, shorter, empty), asserts `claudeAPIKeyOnboardingContent` carries the last-20-char suffix, derives it from the **trimmed** key (whitespace-padded env in, clean suffix out), omits `customApiKeyResponses` when no key is rendered (byte-identical to the plain stub), and pins that the subscription stub never carries `customApiKeyResponses`.
  - `claude_apikey_onboarding_test.go`: api-key `AuthSpec` sets `RenderContent` and yields the approval suffix; subscription `AuthSpec` sets no hook and is byte-identical.
  - `authspec_runtime_test.go`: `RenderContent` is invoked with the rendered env additions and its output (not `Content`) is written; a `RenderContent` error aborts the launch.
- Verified the AuthSpec-level regression **fails before** the fix (commenting out the `RenderContent` wiring fails `TestClaude_APIKeyAuthSpec_OnboardingIsKeyAware`) and **passes after**.
- Coverage: agents package 90.7%, launch package 88.2%; both new `RenderContent` branches (success + error) covered.

Closes #1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static launch files can now be generated dynamically from available environment values.
  * Claude’s API-key onboarding now adapts to the provided key, avoiding the interactive custom-key prompt during hands-off launches.

* **Bug Fixes**
  * Improved onboarding handling so approved key details are derived automatically and whitespace is handled correctly.
  * Subscription-based onboarding remains unchanged when no API key is present.

* **Tests**
  * Added coverage for dynamic static-file rendering, key-aware onboarding output, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->