### PR TITLE
fix(app): route Anthropic /api/* so api-key Claude Code login probe works

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -421,6 +421,15 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	}
 	openAIProxy := newGatewayProxy(gatewayCfg.OpenAIBaseURL, "openai", log)
 	anthropicProxy := newGatewayProxy(gatewayCfg.AnthropicBaseURL, "anthropic", log)
+	// Anthropic's `/api/*` surface (notably Claude Code's `GET
+	// /api/oauth/profile` login-state probe) is not part of the
+	// `/v1/messages` Messages protocol but the same upstream serves it.
+	// In api-key mode Claude Code points `ANTHROPIC_BASE_URL` at the
+	// daemon, so this probe lands here; without a route it falls through
+	// to the webapp catch-all and Claude Code reports "not logged in"
+	// (#1696). The proxy forwards path/method/body/headers unchanged, so
+	// `x-api-key` rides through to Anthropic exactly like `/v1/messages`.
+	anthropicAPIProxy := newGatewayProxy(gatewayCfg.AnthropicBaseURL, "anthropic-api", log)
 
 	// --- HTTP handler ---
 	mux := http.NewServeMux()
@@ -456,6 +465,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 		sourceRegistry:       sourceReg,
 		openAIProxy:          openAIProxy,
 		anthropicProxy:       anthropicProxy,
+		anthropicAPIProxy:    anthropicAPIProxy,
 		localDaemonToken:     cfg.LocalDaemonToken,
 		caveatIssuer:         newCaveatIssuer(cfg.CaveatSigningKey),
 		sandboxProxyStateDir: cfg.SandboxProxyStateDir,
@@ -718,6 +728,17 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	mux.HandleFunc("POST /v1/drafts/", server.handleDraftAction)
 
 	registerDocsRoutes(mux)
+
+	// Anthropic `/api/*` fall-through (#1696). Claude Code's login-state
+	// probe is `GET /api/oauth/profile`; in api-key mode it rides
+	// `ANTHROPIC_BASE_URL` to the daemon. The `/api/` prefix is entirely
+	// Anthropic's namespace (Aileron's own API lives under `/v1/`), so a
+	// scoped reverse proxy here forwards it to the configured Anthropic
+	// upstream instead of letting it fall through to the webapp catch-all
+	// below. Registered before the webapp catch-all so it wins for any
+	// `/api/*` path. `/api/` is not `/v1/`-prefixed, so it already
+	// bypasses localDaemonAuthMiddleware (which gates only `/v1/`).
+	mux.HandleFunc("/api/", server.handleAnthropicAPI)
 
 	// Local webapp (#418): mount the embedded static build at `/`
 	// as a catch-all. ServeMux gives more-specific paths their

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -72,6 +72,7 @@ type apiServer struct {
 	uiBaseURL            string                      // base URL for the web UI (for constructing unlock links)
 	openAIProxy          http.Handler                // upstream proxy for /v1/chat/completions; nil disables the endpoint
 	anthropicProxy       http.Handler                // upstream proxy for /v1/messages; nil disables the endpoint
+	anthropicAPIProxy    http.Handler                // upstream proxy for Anthropic's /api/* (e.g. /api/oauth/profile login-state probe); nil disables the route
 	auditStore           audit.EventStore            // ADR-0010 audit store; file-backed by default, MemStore in tests, Postgres post-MVP
 	auditRecorder        audit.Recorder              // ADR-0010 recorder; mints audit IDs and emits binding-lifecycle events
 	vaultLocked          bool                        // ADR-0011 gate: when true, gateway endpoints refuse to serve until the vault is unlocked

--- a/internal/app/handlers_gateway.go
+++ b/internal/app/handlers_gateway.go
@@ -55,6 +55,30 @@ func (s *apiServer) PostMessages(w http.ResponseWriter, r *http.Request) {
 	s.anthropicProxy.ServeHTTP(w, r)
 }
 
+// handleAnthropicAPI proxies Anthropic's `/api/*` surface to the
+// configured Anthropic upstream. The motivating path is Claude Code's
+// login-state probe, `GET /api/oauth/profile`: in api-key mode Claude
+// Code points `ANTHROPIC_BASE_URL` at the daemon, so this probe lands
+// here rather than at api.anthropic.com. Without this route it falls
+// through to the webapp catch-all and Claude Code reports "not logged
+// in" (#1696).
+//
+// Like PostMessages this is a transparent reverse proxy: path, method,
+// body, and headers (including `x-api-key`) are forwarded unchanged, so
+// the agent's own credential authenticates to Anthropic. The route is
+// scoped to the `/api/` prefix, which is entirely Anthropic's namespace
+// (Aileron's own API lives under `/v1/`). When no upstream is
+// configured (anthropicAPIProxy nil) the endpoint returns 503, matching
+// the gateway's not-configured contract.
+func (s *apiServer) handleAnthropicAPI(w http.ResponseWriter, r *http.Request) {
+	if s.anthropicAPIProxy == nil {
+		writeError(w, http.StatusServiceUnavailable, "gateway_not_configured",
+			"Anthropic gateway upstream is not configured")
+		return
+	}
+	s.anthropicAPIProxy.ServeHTTP(w, r)
+}
+
 // writeVaultLocked emits the canonical FailureEnvelope for "the
 // runtime can't serve this request until the vault is unlocked."
 // `binding_required` is the closest fit in ADR-0010's closed

--- a/internal/app/handlers_gateway_test.go
+++ b/internal/app/handlers_gateway_test.go
@@ -61,6 +61,19 @@ func muxFor(s *apiServer) *http.ServeMux {
 	return mux
 }
 
+// muxWithAPIFallthrough builds the mux the way New() does for the
+// Anthropic `/api/*` fall-through (#1696): the scoped `/api/` proxy
+// registered *before* the webapp catch-all at `/`. This mirrors the
+// production registration order so the test exercises the real routing
+// — both the proxy reaching upstream and the catch-all ordering.
+func muxWithAPIFallthrough(s *apiServer) *http.ServeMux {
+	mux := http.NewServeMux()
+	api.HandlerFromMux(s, mux)
+	mux.HandleFunc("/api/", s.handleAnthropicAPI)
+	mux.Handle("/", webappHandler())
+	return mux
+}
+
 // --- not-configured edge ---
 
 // ADR-0011: when vaultLocked is set, the gateway endpoints refuse to
@@ -642,5 +655,120 @@ func TestGateway_PassesThroughUnchanged_EvenWithGatedActionInstalled(t *testing.
 	resp.Body.Close()
 	if string(capturedBody) != anthropicBody {
 		t.Errorf("Anthropic gateway modified body:\n got  %s\n want %s", capturedBody, anthropicBody)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Regression (#1696): Anthropic `/api/*` fall-through route.
+//
+// In api-key mode Claude Code points ANTHROPIC_BASE_URL at the daemon.
+// `POST /v1/messages` proxies fine, but Claude Code's login-state probe
+// is `GET /api/oauth/profile`. The daemon registers no `/api/*` route,
+// so before the fix that probe fell through to the webapp catch-all
+// (`mux.Handle("/", webappHandler())`) and Claude Code reported "not
+// logged in". The fix registers a scoped `/api/` reverse proxy to the
+// configured Anthropic upstream, before the catch-all, forwarding
+// `x-api-key` unchanged.
+// ----------------------------------------------------------------------
+
+// TestAnthropicAPIFallthrough_ReachesUpstream is the core regression:
+// GET /api/oauth/profile with x-api-key must reach the configured
+// Anthropic upstream with the header forwarded — not the webapp
+// catch-all. Before the fix the request 404s / hits the webapp; after,
+// the upstream sees the verbatim path and header.
+func TestAnthropicAPIFallthrough_ReachesUpstream(t *testing.T) {
+	var captured struct {
+		method string
+		path   string
+		apiKey string
+		hit    bool
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.hit = true
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.apiKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"organization":{"organization_type":"claude_max"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	s := &apiServer{log: slog.Default()}
+	s.anthropicAPIProxy = newGatewayProxy(upstreamURL, "anthropic-api", s.log)
+	srv := httptest.NewServer(muxWithAPIFallthrough(s))
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/oauth/profile", nil)
+	req.Header.Set("x-api-key", "sk-ant-test-xyz")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !captured.hit {
+		t.Fatal("upstream was not reached: /api/oauth/profile fell through to the webapp catch-all (the #1696 bug)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if captured.method != http.MethodGet {
+		t.Errorf("upstream method = %q, want GET", captured.method)
+	}
+	if captured.path != "/api/oauth/profile" {
+		t.Errorf("upstream path = %q, want /api/oauth/profile (path must be forwarded verbatim)", captured.path)
+	}
+	if captured.apiKey != "sk-ant-test-xyz" {
+		t.Errorf("upstream x-api-key = %q, want forwarded unchanged", captured.apiKey)
+	}
+}
+
+// TestAnthropicAPIFallthrough_NotConfigured_Returns503 pins the
+// not-configured contract: with no upstream proxy the route returns 503
+// gateway_not_configured rather than 404 / webapp HTML.
+func TestAnthropicAPIFallthrough_NotConfigured_Returns503(t *testing.T) {
+	s := &apiServer{log: slog.Default()} // anthropicAPIProxy nil
+	srv := httptest.NewServer(muxWithAPIFallthrough(s))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/oauth/profile")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+	var apiErr api.Error
+	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if apiErr.Error.Code != "gateway_not_configured" {
+		t.Errorf("error.code = %q, want gateway_not_configured", apiErr.Error.Code)
+	}
+}
+
+// TestAnthropicAPIFallthrough_DoesNotShadowWebapp confirms the scoped
+// `/api/` registration leaves the webapp catch-all intact for non-/api
+// paths, so adding this route does not break the local webapp at `/`.
+func TestAnthropicAPIFallthrough_DoesNotShadowWebapp(t *testing.T) {
+	s := &apiServer{log: slog.Default()}
+	s.anthropicAPIProxy = newGatewayProxy(&url.URL{Scheme: "http", Host: "127.0.0.1:0"}, "anthropic-api", s.log)
+	srv := httptest.NewServer(muxWithAPIFallthrough(s))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("webapp root status = %d, want 200 (the /api/ route must not shadow the catch-all)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("webapp root Content-Type = %q, want text/html", ct)
 	}
 }


### PR DESCRIPTION
## Summary

In api-key mode, Claude Code points `ANTHROPIC_BASE_URL` at the Aileron daemon. `POST /v1/messages` proxies fine via the existing Anthropic gateway, but Claude Code's login-state probe is `GET /api/oauth/profile` (see `claudeProfileURL` in `internal/launch/agents/claude_auth.go`). The daemon registered **no `/api/*` route**, so that probe fell through to the webapp catch-all (`mux.Handle("/", webappHandler())` in `internal/app/app.go`) instead of reaching Anthropic — yielding "not logged in".

Routing was the only gap: `/api/` is not `/v1/`-prefixed, so it already bypasses `localDaemonAuthMiddleware` (which gates only `/v1/`), and the upstream's own `x-api-key` authenticates.

### Change
- Register a scoped `mux.HandleFunc("/api/", server.handleAnthropicAPI)` **before** the webapp catch-all.
- `handleAnthropicAPI` is a transparent reverse proxy to `gatewayCfg.AnthropicBaseURL` (a new `newGatewayProxy(...)` instance), forwarding path/method/body and headers (including `x-api-key`) unchanged — the same pass-through contract as `/v1/messages` (ADR-0008). Returns 503 `gateway_not_configured` when no upstream is configured.
- Scoped to the `/api/` prefix (entirely Anthropic's namespace, unclaimed by Aileron) rather than a blanket catch-all, since `/v1/*` is Aileron's own API namespace.
- Deliberately **no** `vaultLocked` gate: the OAuth profile probe is a read-only login-state check that resolves no connector credential, and gating it would reintroduce the "not logged in" symptom precisely when the vault is locked. Scope is routing only.

## Test plan

New regression tests in `internal/app/handlers_gateway_test.go`, exercised through a mux that mirrors the production registration order (`/api/` proxy before the webapp catch-all):

- `TestAnthropicAPIFallthrough_ReachesUpstream` — `GET /api/oauth/profile` with `x-api-key` reaches the configured Anthropic upstream with path and header forwarded verbatim. **Verified failing before the fix** (the request fell through to the webapp catch-all) and passing after.
- `TestAnthropicAPIFallthrough_NotConfigured_Returns503` — nil upstream returns 503 `gateway_not_configured`, not 404/webapp HTML.
- `TestAnthropicAPIFallthrough_DoesNotShadowWebapp` — the scoped `/api/` route leaves the webapp catch-all at `/` intact (200 text/html).

`handleAnthropicAPI` is at 100% line coverage. Full `internal/app` package tests pass; `go vet` and `gofmt` clean. OpenAPI spec untouched — `/api/*` is Anthropic's namespace, registered directly on the mux, not via the generated Aileron API handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
