### PR TITLE
fix(launch): make api-key Claude .claude/ dir writable

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -193,6 +193,20 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 				// behavior rather than an empty file.
 				Content:       claudeOnboardingStub,
 				RenderContent: claudeAPIKeyOnboardingContent,
+			}, {
+				// Sentinel under /home/agent/.claude/. Its only effect is to
+				// make the launcher group-mount /home/agent/.claude/ as a
+				// WRITABLE directory, matching subscription mode (whose
+				// .credentials.json FileBinding already forces that mount).
+				// Without a writable .claude/, the api-key-mode agent hits
+				// SessionStart EACCES on `mkdir .claude/session-env` and the
+				// Bypass Permissions prompt reappears because Claude cannot
+				// persist its acceptance state under .claude/ (#1700). Mode
+				// 0o644 so a host-side read is unaffected by the deferred
+				// chown; content is empty because Claude never reads it.
+				ContainerPath: claudeStateDirKeepContainerPath,
+				Mode:          0o644,
+				Content:       []byte{},
 			}},
 		}
 	}

--- a/internal/launch/agents/claude_apikey_onboarding_test.go
+++ b/internal/launch/agents/claude_apikey_onboarding_test.go
@@ -5,8 +5,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 )
+
+// onboardingStaticFile returns the /home/agent/.claude.json onboarding
+// StaticFile from an AuthSpec. Api-key mode also ships a
+// /home/agent/.claude/ writable-dir sentinel (#1700), so callers must
+// select the onboarding file by path rather than assuming it is the only
+// StaticFile.
+func onboardingStaticFile(t *testing.T, spec launch.AuthSpec) launch.StaticFile {
+	t.Helper()
+	for _, sf := range spec.StaticFiles {
+		if sf.ContainerPath == "/home/agent/.claude.json" {
+			return sf
+		}
+	}
+	t.Fatalf("no /home/agent/.claude.json StaticFile in spec; got %+v", spec.StaticFiles)
+	return launch.StaticFile{}
+}
 
 // claudeOnboardingShape mirrors the contractual fields of
 // /home/agent/.claude.json for the AuthSpec-level wiring tests.
@@ -57,10 +74,7 @@ func assertSharedOnboardingFields(t *testing.T, b []byte) claudeOnboardingShape 
 // the rendered env additions).
 func TestClaude_APIKeyAuthSpec_OnboardingIsKeyAware(t *testing.T) {
 	spec := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec()
-	if len(spec.StaticFiles) != 1 {
-		t.Fatalf("StaticFiles = %d, want 1", len(spec.StaticFiles))
-	}
-	sf := spec.StaticFiles[0]
+	sf := onboardingStaticFile(t, spec)
 	if sf.RenderContent == nil {
 		t.Fatal("api-key StaticFile must set RenderContent so the onboarding doc is key-aware")
 	}
@@ -106,7 +120,7 @@ func TestClaude_SubscriptionAuthSpec_OnboardingByteIdentical(t *testing.T) {
 	// ever nil) is the same plain stub, so a regression dropping the hook
 	// degrades to the pre-#1695 subscription bytes rather than an empty
 	// file.
-	apiSF := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec().StaticFiles[0]
+	apiSF := onboardingStaticFile(t, agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec())
 	if string(apiSF.Content) != string(subSF.Content) {
 		t.Errorf("api-key Content fallback differs from subscription stub.\n api: %s\n sub: %s", apiSF.Content, subSF.Content)
 	}

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -138,6 +138,26 @@ const claudeCredentialsContainerPath = "/home/agent/.claude/.credentials.json"
 // silent end-to-end.
 const claudeOnboardingContainerPath = "/home/agent/.claude.json"
 
+// claudeStateDirKeepContainerPath is a zero-byte sentinel placed inside
+// /home/agent/.claude/ in api-key auth mode. Its sole job is to make the
+// launcher group-mount /home/agent/.claude/ as a WRITABLE directory.
+//
+// Subscription mode gets a writable /home/agent/.claude/ for free: its
+// .credentials.json FileBinding lives under that parent, so the launcher's
+// group-mount machinery already binds the directory writable (Claude
+// rotates the OAuth file mid-session). Api-key mode has no such binding —
+// ANTHROPIC_API_KEY rides an env var and the only file it placed under the
+// home tree (.claude.json) is parented at /home/agent, which gets an
+// individual read-only file mount. That left /home/agent/.claude/ as the
+// read-only image directory, so Claude could neither `mkdir
+// .claude/session-env` (SessionStart EACCES) nor persist/read its
+// bypass-permissions acceptance, making the Bypass Permissions prompt
+// reappear every launch (#1700). A static file under .claude/ forces the
+// same writable directory mount subscription mode already gets, fixing
+// both symptoms from the one shared root cause. The file content is
+// irrelevant to Claude; we keep it empty and clearly named.
+const claudeStateDirKeepContainerPath = "/home/agent/.claude/.aileron-keep"
+
 // claudeVaultPath is the canonical vault namespace for Claude's
 // subscription-OAuth credentials per ADR-0025's `agents/<name>/<purpose>`
 // scheme. Subscription mode (Pro/Max) reads/writes the envelope here.

--- a/internal/launch/agents/claude_test.go
+++ b/internal/launch/agents/claude_test.go
@@ -2,6 +2,7 @@ package agents_test
 
 import (
 	"encoding/json"
+	"path"
 	"strings"
 	"testing"
 
@@ -137,10 +138,37 @@ func TestClaude_AuthSpec_APIKeyMode(t *testing.T) {
 	if spec.EnvBindings[0].VaultPath == "agents/claude/oauth" {
 		t.Errorf("api-key EnvBinding references the oauth slot")
 	}
-	// The onboarding StaticFile is shared so an api-key launch is silent
-	// first-run too.
-	if len(spec.StaticFiles) != 1 {
-		t.Errorf("StaticFiles = %d, want 1 (shared onboarding stub)", len(spec.StaticFiles))
+	// API-key mode ships two StaticFiles: the shared onboarding stub at
+	// /home/agent/.claude.json (silent first-run) and a sentinel under
+	// /home/agent/.claude/ whose only purpose is to force a writable
+	// .claude/ directory mount (#1700) — subscription mode gets that mount
+	// for free via its .credentials.json FileBinding, but api-key mode has
+	// no FileBinding under .claude/, so without the sentinel the agent
+	// hits EACCES on mkdir .claude/session-env and the bypass-permissions
+	// prompt reappears.
+	if len(spec.StaticFiles) != 2 {
+		t.Fatalf("StaticFiles = %d, want 2 (onboarding stub + .claude/ writable-dir sentinel)", len(spec.StaticFiles))
+	}
+	var haveOnboarding, haveKeep bool
+	for _, sf := range spec.StaticFiles {
+		switch sf.ContainerPath {
+		case "/home/agent/.claude.json":
+			haveOnboarding = true
+		case "/home/agent/.claude/.aileron-keep":
+			haveKeep = true
+			// The sentinel's parent is /home/agent/.claude/ (not
+			// /home/agent), which is exactly what triggers the writable
+			// group-dir mount in prepareAuthSpec.
+			if got := path.Dir(sf.ContainerPath); got != "/home/agent/.claude" {
+				t.Errorf("sentinel parent = %q, want /home/agent/.claude", got)
+			}
+		}
+	}
+	if !haveOnboarding {
+		t.Error("api-key StaticFiles missing the /home/agent/.claude.json onboarding stub")
+	}
+	if !haveKeep {
+		t.Error("api-key StaticFiles missing the /home/agent/.claude/ writable-dir sentinel (#1700)")
 	}
 }
 

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -564,7 +564,19 @@ func prepareAuthSpec(
 				Target:   sf.ContainerPath,
 				ReadOnly: true,
 			})
+			continue
 		}
+		// A static file under any other parent (e.g. /home/agent/.claude/)
+		// needs its parent mounted as a writable directory, not as an
+		// individual read-only file. ensureGroup defaults the group to
+		// file-mount-only (only individual file mounts cover it); clearing
+		// that flag here makes the parent-dir mount loop below emit a
+		// writable Volume for the group. Without this, an api-key-mode
+		// launch (whose AuthSpec carries no FileBinding under .claude/ to
+		// flip the flag) would leave /home/agent/.claude/ as the read-only
+		// image directory, so Claude could not mkdir .claude/session-env
+		// and the bypass-permissions acceptance could not persist (#1700).
+		fileMountOnlyGroups[containerParent] = false
 	}
 
 	// Defer the chown of the transient tree to the in-container agent

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -340,6 +340,76 @@ func TestPrepareAuthSpec_StaticFileLandsRegardlessOfVault(t *testing.T) {
 	}
 }
 
+// TestPrepareAuthSpec_StaticFileUnderSubdirMountsWritableDir is the #1700
+// regression. Claude's api-key auth mode carries no FileBinding under
+// /home/agent/.claude/ (its credential rides ANTHROPIC_API_KEY on an env
+// var). Subscription mode gets a writable /home/agent/.claude/ for free
+// because its .credentials.json FileBinding lives there and the launcher
+// group-mounts that parent writable. Without a corresponding mount in
+// api-key mode the .claude/ directory is the read-only image dir, so the
+// agent hits EACCES on `mkdir .claude/session-env` and the bypass-
+// permissions prompt reappears (it cannot persist its acceptance state
+// under .claude/).
+//
+// The contract this asserts: a StaticFile whose parent is a subdirectory
+// (not /home/agent) makes prepareAuthSpec emit a WRITABLE directory mount
+// at that parent — exactly the mount subscription mode already produces.
+// This is the mount-assembly seam the api-key sentinel StaticFile relies
+// on; the macOS-only end-to-end EACCES cannot be reproduced in a Linux CI
+// unit test, so we cover the load-bearing mount here. The test fails
+// before the fix (the group was skipped as file-mount-only, yielding no
+// .claude/ mount) and passes after.
+func TestPrepareAuthSpec_StaticFileUnderSubdirMountsWritableDir(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault — no FileBinding at all
+	// Mirror api-key mode: an env-only credential plus two StaticFiles —
+	// the onboarding stub at /home/agent/.claude.json (individual read-
+	// only file mount) and a sentinel under /home/agent/.claude/ (must
+	// force a writable dir mount).
+	spec := AuthSpec{
+		StaticFiles: []StaticFile{
+			{
+				ContainerPath: "/home/agent/.claude.json",
+				Mode:          0o644,
+				Content:       []byte(`{"hasCompletedOnboarding":true}`),
+			},
+			{
+				ContainerPath: "/home/agent/.claude/.aileron-keep",
+				Mode:          0o644,
+				Content:       []byte{},
+			},
+		},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	// The contractual mount: /home/agent/.claude/ bound WRITABLE.
+	var dirMount, fileMount bool
+	for _, m := range prep.Mounts {
+		if m.Target == "/home/agent/.claude" {
+			dirMount = true
+			if m.ReadOnly {
+				t.Errorf("/home/agent/.claude/ mount is ReadOnly; the agent must be able to mkdir .claude/session-env and persist bypass-permissions state (#1700)")
+			}
+		}
+		if m.Target == "/home/agent/.claude.json" {
+			fileMount = true
+			if !m.ReadOnly {
+				t.Errorf("/home/agent/.claude.json mount must stay ReadOnly (individual file mount)")
+			}
+		}
+	}
+	if !dirMount {
+		t.Fatalf("no /home/agent/.claude/ directory mount produced; got %+v", prep.Mounts)
+	}
+	if !fileMount {
+		t.Fatalf("no /home/agent/.claude.json file mount produced; got %+v", prep.Mounts)
+	}
+}
+
 // TestPrepareAuthSpec_StaticFileRenderContentSeesRenderedEnv proves the
 // StaticFile.RenderContent hook is invoked with the env vars the
 // EnvBindings already rendered, and that its output (not Content) is what


### PR DESCRIPTION
## Summary

In `aileron launch claude` **API-key mode**, the agent's `/home/agent/.claude/` directory was the read-only image directory, while **subscription mode** mounts it writable. The mode difference traced to one root cause: subscription mode's `.credentials.json` FileBinding is parented at `/home/agent/.claude/`, which the launcher's group-mount machinery binds *writable* (Claude rotates that file mid-session). API-key mode delivers its credential via the `ANTHROPIC_API_KEY` env var and its only home-tree file (`.claude.json`) is parented at `/home/agent`, which gets an individual read-only file mount — so nothing made `/home/agent/.claude/` writable.

On macOS the Docker Desktop file-sharing shim makes a host-backed mount agent-writable, so subscription mode worked. API-key mode produced **both** reported symptoms from this single root cause:

1. `SessionStart` EACCES on `mkdir /home/agent/.claude/session-env`.
2. The **Bypass Permissions** prompt reappeared every launch, because Claude could not persist/read its acceptance state under the unwritable `.claude/`.

The `.claude.json` onboarding stub (which carries `bypassPermissionsModeAccepted:true`) is mounted read-only identically in both modes, so it does not explain the mode difference — confirming one shared root cause, hence one PR.

### Fix

- Add a zero-byte sentinel StaticFile at `/home/agent/.claude/.aileron-keep` to the **API-key** AuthSpec (`internal/launch/agents/claude.go`, constant in `claude_auth.go`). Its only effect is to force the writable directory mount.
- Teach `prepareAuthSpec`'s StaticFile loop (`internal/launch/authspec_runtime.go`) to clear the `fileMountOnlyGroups` flag for any static file parented in a subdirectory (not `/home/agent`), so the existing group-mount loop emits `Volume{Target:/home/agent/.claude/, ReadOnly:false}` — the same mount subscription mode already produces.

**Out of scope / unchanged:** subscription mode is byte-identical (its `.claude.json` StaticFile stays an individual read-only file mount; its `.credentials.json` FileBinding already forced the writable dir). No network-policy change. Versions stay 0.0.x. The Linux `prep.ChownFn` ordering already covers the new mount; on macOS the shim makes it writable without chown.

## Test plan

- New regression test `TestPrepareAuthSpec_StaticFileUnderSubdirMountsWritableDir` at the mount-assembly layer asserts a StaticFile parented under `/home/agent/.claude/` (mirroring API-key mode) yields a **writable** `/home/agent/.claude/` directory mount and that `/home/agent/.claude.json` stays an individual read-only file mount. Verified it **fails before** the runtime fix (group skipped as file-mount-only → no `.claude/` mount) and **passes after**.
- Updated `TestClaude_AuthSpec_APIKeyMode` to pin the two-StaticFile shape and assert the `/home/agent/.claude/` sentinel's parent.
- Onboarding tests now select the `.claude.json` StaticFile by path (helper `onboardingStaticFile`) instead of index, since API-key mode now ships two StaticFiles.
- The macOS-only end-to-end EACCES cannot be reproduced in Linux CI, so the load-bearing contract (the writable mount exists) is covered at the mount-assembly layer rather than via platform-specific filesystem behavior.
- `go build ./internal/launch/...`, `go vet ./internal/launch/...`, and `go test ./internal/launch/...` all green.
- CodeRabbit review: 0 findings.

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
