### PR TITLE
test(app): composed launch->gateway->Anthropic-probe regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,6 +728,25 @@ jobs:
         run: go test -tags=integration_sandbox -race -run TestSandboxMCP ./app/...
         working-directory: internal
 
+      - name: Run launch->gateway->Anthropic-probe regression guard (#1699)
+        # Composed regression for the launch -> gateway -> Anthropic-probe seam
+        # PR #1698 repaired (#1696). Renders the REAL api-key AuthSpec the
+        # launcher uses (agents.NewClaude(APIKey).AuthSpec() Render +
+        # RenderContent -> ANTHROPIC_API_KEY + the key-aware .claude.json
+        # onboarding doc), stands up the real daemon mux order (scoped /api/
+        # proxy before the webapp catch-all) against a SPEC-COMPLIANT stub
+        # Anthropic upstream (401 without x-api-key, 200 + org body with it),
+        # then points ANTHROPIC_BASE_URL at the daemon and issues Claude Code's
+        # real GET /api/oauth/profile probe with the rendered key — asserting an
+        # authenticated 200 + org object. Closes the two named weaknesses of the
+        # handler-level guard: a bare echo upstream with no auth semantics, and a
+        # literal key that never starts from the rendered launch env. Pure
+        # in-process (no Docker, no subprocess), so it never self-skips. Fails
+        # before #1698, passes after. Additive step so a failure is attributable
+        # to this specific contract.
+        run: go test -tags=integration_sandbox -race -run TestLaunchAnthropicProbe ./app/...
+        working-directory: internal
+
       - name: Run auth github route-drift guard (#1157)
         # Guards against silent drift between the CLI's HARDCODED vault path
         # in cmd/aileron/auth_github.go ("/vault/user/github/credentials") and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -429,6 +429,12 @@ tasks:
     cmds:
       - go test -tags=integration_sandbox -race -run 'TestSandboxProxyCurlIntegration|TestSandboxProxyAWSSigV4Integration' ./internal/app/...
 
+  test:integration:launch-anthropic-probe:
+    desc: "Run the composed launch->gateway->Anthropic-probe regression guard (#1699): renders the real api-key AuthSpec (ANTHROPIC_API_KEY + key-aware onboarding doc), stands up the real daemon mux order against a spec-compliant Anthropic upstream (401 without x-api-key, 200+org with it), and asserts Claude Code's GET /api/oauth/profile probe authenticates through the daemon with the rendered key. In-process, no Docker/subprocess prereqs (no self-skip). Fails before #1698, passes after."
+    dir: internal
+    cmds:
+      - go test -tags=integration_sandbox -race -run TestLaunchAnthropicProbe ./app/...
+
   test:integration:auth-github-route:
     desc: "Run the auth github route-drift guard (#1157): stands up the real daemon handler over a MemVault and asserts the CLI's hardcoded vault path still resolves to the spec-registered route. In-process, no external prereqs (no self-skip)."
     dir: cmd/aileron

--- a/internal/app/launch_anthropic_probe_integration_test.go
+++ b/internal/app/launch_anthropic_probe_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration_sandbox
+
+// Composed regression guard for the launch -> gateway -> Anthropic-probe
+// seam that #1696 (PR #1698) repaired.
+//
+// In api-key mode `aileron launch claude` points Claude Code's
+// ANTHROPIC_BASE_URL at the Aileron daemon. Claude Code's login-state
+// probe is `GET /api/oauth/profile` carrying the raw key in `x-api-key`.
+// The #1696 bug: the daemon registered no `/api/*` route, so that probe
+// fell through to the webapp catch-all and Claude Code reported "not
+// logged in". The fix (#1698) registers a scoped `/api/` reverse proxy
+// to the configured Anthropic upstream, BEFORE the webapp catch-all,
+// forwarding `x-api-key` unchanged.
+//
+// The handler-level guard
+// (TestAnthropicAPIFallthrough_ReachesUpstream in
+// handlers_gateway_test.go) pins the routing, but it has two named
+// weaknesses this composed test closes:
+//
+//  1. Its upstream is a bare echo with no auth semantics: it returns 200
+//     regardless of whether `x-api-key` is present, so it cannot tell a
+//     forwarded credential from a dropped one. This test stands up a
+//     SPEC-COMPLIANT stub Anthropic upstream that returns 401 when
+//     `x-api-key` is absent and 200 + `{"organization":{...}}` only when
+//     the key is forwarded — so an "authenticated 200 with an org body"
+//     assertion actually proves the credential rode through.
+//
+//  2. It never starts from the real rendered launch env: it hand-picks a
+//     literal `sk-ant-test-xyz`, so the ANTHROPIC_BASE_URL -> daemon and
+//     ANTHROPIC_API_KEY -> probe wiring the launcher actually produces is
+//     untested. This test drives the REAL
+//     agents.NewClaude(ClaudeAuthModeAPIKey).AuthSpec() Render +
+//     RenderContent hooks — the exact functions the launcher invokes — to
+//     render ANTHROPIC_API_KEY and the approved-suffix onboarding doc, and
+//     then uses that rendered key against the daemon.
+//
+// Composed end to end, the test renders the launch env exactly as the
+// launcher does, confirms the onboarding doc carries the suffix of the
+// rendered key (the #1695 custom-API-key pre-approval), then points
+// ANTHROPIC_BASE_URL at the daemon and issues the real
+// `GET /api/oauth/profile` probe with the rendered key. It asserts an
+// authenticated 200 + org object.
+//
+// FAIL-BEFORE / PASS-AFTER #1698: before the fix the `/api/` route does
+// not exist, so the probe falls through to the webapp catch-all and the
+// body is HTML rather than the org JSON the assertion requires.
+//
+// The test is gated behind the `integration_sandbox` build tag so it does
+// not run during the normal `task test:go` suite. It is pure in-process
+// (no Docker, no host subprocess): it composes the agents package's real
+// AuthSpec render hooks with the app package's real mux registration, so
+// there is no external prerequisite and, per repo policy, it never
+// self-skips. Run with:
+//
+//	task test:integration:launch-anthropic-probe
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// renderedClaudeAPIKeyEnv is the env var Claude Code reads its raw key
+// from. Spelled here rather than imported because the constant is
+// unexported in the agents package; the AuthSpec render output is the
+// contract we assert against.
+const renderedClaudeAPIKeyEnv = "ANTHROPIC_API_KEY"
+
+// rawTestAPIKey is the credential the test seeds into the (faked) vault.
+// It is longer than Claude Code's 20-char approval suffix so the
+// suffix-vs-whole-key branch in the onboarding render is exercised, and
+// carries a leading/trailing space the Render hook must trim so the
+// rendered env value and the onboarding suffix agree.
+const rawTestAPIKey = "  sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAA-zzzzzzzzzzzzzzzzzzzz  "
+
+// renderClaudeAPIKeyLaunchEnv drives the REAL api-key-mode AuthSpec the
+// launcher uses: it renders the EnvBinding (ANTHROPIC_API_KEY) and the
+// StaticFile (the key-aware .claude.json onboarding doc) exactly as
+// prepareAuthSpec does — EnvBinding.Render first, then
+// StaticFile.RenderContent over the resulting env additions. It returns
+// the rendered env additions and the rendered onboarding bytes so the
+// caller can assert the daemon-facing key and the onboarding suffix come
+// from one composed render, not two independently-chosen literals.
+func renderClaudeAPIKeyLaunchEnv(t *testing.T, rawKey string) (env map[string]string, onboarding []byte) {
+	t.Helper()
+
+	spec := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthSpec()
+	if len(spec.EnvBindings) != 1 {
+		t.Fatalf("api-key AuthSpec EnvBindings = %d, want 1 (the ANTHROPIC_API_KEY binding)", len(spec.EnvBindings))
+	}
+	if len(spec.StaticFiles) != 1 {
+		t.Fatalf("api-key AuthSpec StaticFiles = %d, want 1 (the .claude.json onboarding doc)", len(spec.StaticFiles))
+	}
+
+	eb := spec.EnvBindings[0]
+	if eb.Render == nil {
+		t.Fatal("api-key EnvBinding has nil Render; the launcher cannot render ANTHROPIC_API_KEY")
+	}
+	// The vault stores the raw key bytes (no envelope), as the daemon
+	// returns them; Render trims and maps to ANTHROPIC_API_KEY.
+	env, err := eb.Render(vault.Secret{Value: []byte(rawKey)})
+	if err != nil {
+		t.Fatalf("EnvBinding.Render: %v", err)
+	}
+	if _, ok := env[renderedClaudeAPIKeyEnv]; !ok {
+		t.Fatalf("rendered env = %v, want a %s entry", env, renderedClaudeAPIKeyEnv)
+	}
+
+	sf := spec.StaticFiles[0]
+	if sf.RenderContent == nil {
+		t.Fatal("api-key StaticFile has nil RenderContent; the onboarding doc cannot be made key-aware (#1695)")
+	}
+	// RenderContent runs AFTER the EnvBinding loop, over the rendered env
+	// additions — mirror that ordering exactly.
+	onboarding, err = sf.RenderContent(env)
+	if err != nil {
+		t.Fatalf("StaticFile.RenderContent: %v", err)
+	}
+	return env, onboarding
+}
+
+// assertOnboardingApprovesRenderedKey asserts the rendered .claude.json
+// carries customApiKeyResponses.approved holding the last 20 characters
+// of the rendered ANTHROPIC_API_KEY. This is the #1695 contract that
+// suppresses Claude Code's interactive "Detected a custom API key"
+// prompt; if the approval suffix drifts from the key the agent actually
+// sees, the hands-off launch blocks.
+func assertOnboardingApprovesRenderedKey(t *testing.T, renderedKey string, onboarding []byte) {
+	t.Helper()
+
+	var doc struct {
+		CustomApiKeyResponses *struct {
+			Approved []string `json:"approved"`
+		} `json:"customApiKeyResponses"`
+	}
+	if err := json.Unmarshal(onboarding, &doc); err != nil {
+		t.Fatalf("onboarding doc is not valid JSON: %v\n%s", err, onboarding)
+	}
+	if doc.CustomApiKeyResponses == nil || len(doc.CustomApiKeyResponses.Approved) != 1 {
+		t.Fatalf("onboarding customApiKeyResponses.approved missing or not length 1: %s", onboarding)
+	}
+	got := doc.CustomApiKeyResponses.Approved[0]
+
+	// Claude Code keys the approval on the LAST 20 runes of the raw key.
+	r := []rune(renderedKey)
+	want := renderedKey
+	if len(r) > 20 {
+		want = string(r[len(r)-20:])
+	}
+	if got != want {
+		t.Fatalf("onboarding approval suffix = %q, want %q (last 20 chars of the rendered key)", got, want)
+	}
+}
+
+// specCompliantAnthropicUpstream stands up a stub Anthropic upstream with
+// real auth semantics for the `/api/oauth/profile` login-state probe:
+//
+//   - No `x-api-key` header -> 401 + an error body, as Anthropic returns
+//     for an unauthenticated request. A bare-echo upstream (the
+//     handler-level guard's) cannot distinguish this from a forwarded
+//     key, so it is the weakness this stub closes.
+//   - `x-api-key` present -> 200 + `{"organization":{...}}`, the profile
+//     payload Claude Code reads to learn the signed-in org's tier.
+//
+// expectedKey, when non-empty, is additionally asserted: the forwarded
+// `x-api-key` must equal it verbatim, proving the launcher-rendered key
+// (not some rewritten value) reached upstream.
+func specCompliantAnthropicUpstream(t *testing.T, expectedKey string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		key := r.Header.Get("x-api-key")
+		if key == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"missing x-api-key"}}`))
+			return
+		}
+		if expectedKey != "" && key != expectedKey {
+			// Authenticated but with the WRONG key: a rewrite/leak would
+			// surface here. 403 so the test fails on a mismatch with a
+			// distinct status from the unauthenticated 401.
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"permission_error","message":"unexpected x-api-key"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"organization":{"organization_type":"claude_max","rate_limit_tier":"tier_4"}}`))
+	}))
+}
+
+// TestLaunchAnthropicProbe_RenderedKeyAuthenticatesThroughDaemon is the
+// composed regression: render the api-key launch env with the real
+// AuthSpec hooks, confirm the onboarding doc pre-approves the rendered
+// key, then issue the real `GET /api/oauth/profile` probe with that key
+// through the daemon's real mux order against a spec-compliant upstream,
+// asserting an authenticated 200 + org object.
+//
+// Fails before #1698 (no `/api/` route -> webapp HTML, not the org JSON);
+// passes after.
+func TestLaunchAnthropicProbe_RenderedKeyAuthenticatesThroughDaemon(t *testing.T) {
+	// (a) Render the launch env exactly as the launcher does.
+	env, onboarding := renderClaudeAPIKeyLaunchEnv(t, rawTestAPIKey)
+	renderedKey := env[renderedClaudeAPIKeyEnv]
+	if renderedKey != strings.TrimSpace(rawTestAPIKey) {
+		t.Fatalf("rendered key = %q, want the trimmed raw key %q", renderedKey, strings.TrimSpace(rawTestAPIKey))
+	}
+	assertOnboardingApprovesRenderedKey(t, renderedKey, onboarding)
+
+	// (b) Spec-compliant stub Anthropic upstream with real auth semantics,
+	// asserting the forwarded key is the launcher-rendered one verbatim.
+	upstream := specCompliantAnthropicUpstream(t, renderedKey)
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	// The real daemon mux order: scoped `/api/` proxy registered BEFORE the
+	// webapp catch-all (muxWithAPIFallthrough mirrors New()'s registration).
+	s := &apiServer{log: slog.Default()}
+	s.anthropicAPIProxy = newGatewayProxy(upstreamURL, "anthropic-api", s.log)
+	daemon := httptest.NewServer(muxWithAPIFallthrough(s))
+	t.Cleanup(daemon.Close)
+
+	// (c) Point ANTHROPIC_BASE_URL at the daemon and issue Claude Code's
+	// real login-state probe with the rendered key. The base URL is the
+	// env var Claude Code reads (agents.Claude.LLMEndpointEnv()); we follow
+	// the same join the agent does: ANTHROPIC_BASE_URL + /api/oauth/profile.
+	base := daemon.URL
+	if got := agents.NewClaude(agents.ClaudeAuthModeAPIKey).LLMEndpointEnv(); got != "ANTHROPIC_BASE_URL" {
+		t.Fatalf("Claude LLMEndpointEnv = %q, want ANTHROPIC_BASE_URL", got)
+	}
+	probeURL := strings.TrimRight(base, "/") + "/api/oauth/profile"
+
+	req, err := http.NewRequest(http.MethodGet, probeURL, nil)
+	if err != nil {
+		t.Fatalf("build probe request: %v", err)
+	}
+	req.Header.Set("x-api-key", renderedKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("probe request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("probe status = %d, want 200 (authenticated profile)\nbody: %s\n"+
+			"a 401 means the rendered key did not reach upstream; a non-JSON/HTML body means the probe fell "+
+			"through to the webapp catch-all — the #1696 bug PR #1698 fixed", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("probe Content-Type = %q, want application/json (HTML means the webapp catch-all served it, the #1696 bug)", ct)
+	}
+
+	var profile struct {
+		Organization struct {
+			OrganizationType string `json:"organization_type"`
+			RateLimitTier    string `json:"rate_limit_tier"`
+		} `json:"organization"`
+	}
+	if err := json.Unmarshal(body, &profile); err != nil {
+		t.Fatalf("profile body is not the org JSON: %v\nbody: %s", err, body)
+	}
+	if profile.Organization.OrganizationType == "" {
+		t.Fatalf("profile organization.organization_type empty; want the upstream org payload, got: %s", body)
+	}
+}
+
+// TestLaunchAnthropicProbe_UnauthenticatedProbeIs401 pins the auth
+// semantics of the spec-compliant upstream from the daemon's vantage: a
+// probe with NO `x-api-key` reaches the upstream through the real mux
+// order and gets the upstream's 401 propagated, NOT a webapp 200. This
+// proves the composed harness's authenticated-200 assertion above is
+// meaningful (the upstream really does gate on the header) and that the
+// daemon forwards an upstream 4xx rather than masking it with the webapp
+// catch-all.
+func TestLaunchAnthropicProbe_UnauthenticatedProbeIs401(t *testing.T) {
+	upstream := specCompliantAnthropicUpstream(t, "")
+	t.Cleanup(upstream.Close)
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	s := &apiServer{log: slog.Default()}
+	s.anthropicAPIProxy = newGatewayProxy(upstreamURL, "anthropic-api", s.log)
+	daemon := httptest.NewServer(muxWithAPIFallthrough(s))
+	t.Cleanup(daemon.Close)
+
+	resp, err := http.Get(strings.TrimRight(daemon.URL, "/") + "/api/oauth/profile")
+	if err != nil {
+		t.Fatalf("probe request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated probe status = %d, want 401 propagated from upstream\nbody: %s", resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an `integration_sandbox`-tagged regression test over the launch -> gateway -> Anthropic login-state-probe seam that #1696 (PR #1698) repaired. It composes the **real** launch-side AuthSpec render with the **real** daemon mux order, closing the two named weaknesses of the existing handler-level guard (`TestAnthropicAPIFallthrough_ReachesUpstream` in `internal/app/handlers_gateway_test.go`):

1. **Bare-echo upstream with no auth semantics.** The handler-level guard's upstream returns 200 regardless of whether `x-api-key` is present, so it cannot distinguish a forwarded credential from a dropped one. The new test stands up a **spec-compliant** stub Anthropic upstream that returns `401` when `x-api-key` is absent and `200 + {"organization":{...}}` only when the key is forwarded (and `403` on a key mismatch). An "authenticated 200 with org body" assertion now actually proves the credential rode through.
2. **Never starts from the rendered launch env.** The handler-level guard hand-picks a literal `sk-ant-test-xyz`, so the `ANTHROPIC_BASE_URL` -> daemon and `ANTHROPIC_API_KEY` -> probe wiring the launcher actually produces is untested. The new test drives the real `agents.NewClaude(ClaudeAuthModeAPIKey).AuthSpec()` `Render` + `RenderContent` hooks — the exact functions `prepareAuthSpec` invokes, in the same order — to render `ANTHROPIC_API_KEY` and the key-aware `.claude.json` onboarding doc, asserts the onboarding `customApiKeyResponses.approved` suffix matches the rendered key (#1695), then points `ANTHROPIC_BASE_URL` at the daemon's real mux order (scoped `/api/` proxy registered before the webapp catch-all, mirroring `New()`) and issues Claude Code's real `GET /api/oauth/profile` probe with the rendered key.

A second test (`...UnauthenticatedProbeIs401`) pins that an `x-api-key`-less probe gets the upstream's 401 propagated through the daemon (not a webapp 200), so the authenticated-200 assertion above is meaningful.

The test is **pure in-process** (no Docker, no host subprocess): it composes the `agents` package's real render hooks with the `app` package's real mux registration. Per repo policy it **never self-skips** (`t.Fatalf`, not `t.Skip`).

Wires a new `test:integration:launch-anthropic-probe` Taskfile lane and an additive step into the `integration_sandbox` CI job.

## Test plan

- `task test:integration:launch-anthropic-probe` — green (renders the env, authenticates through the daemon, asserts org JSON).
- **Fail-before / pass-after #1698 verified locally**: against a pre-fix mux (generated handlers + webapp catch-all, no `/api/` route) the probe falls through to the webapp and returns `text/html` 200 instead of the org JSON, so the new test's `Content-Type == application/json` + org-body assertions fail. With the shipped `/api/` route (PR #1698) it passes.
- `go vet -tags=integration_sandbox ./app/` clean; default (untagged) `app` gateway tests still green.

Closes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
