### PR TITLE
test(app): expect 2 StaticFiles in api-key AuthSpec probe

### DIFF
--- a/internal/app/launch_anthropic_probe_integration_test.go
+++ b/internal/app/launch_anthropic_probe_integration_test.go
@@ -97,8 +97,15 @@ func renderClaudeAPIKeyLaunchEnv(t *testing.T, rawKey string) (env map[string]st
 	if len(spec.EnvBindings) != 1 {
 		t.Fatalf("api-key AuthSpec EnvBindings = %d, want 1 (the ANTHROPIC_API_KEY binding)", len(spec.EnvBindings))
 	}
-	if len(spec.StaticFiles) != 1 {
-		t.Fatalf("api-key AuthSpec StaticFiles = %d, want 1 (the .claude.json onboarding doc)", len(spec.StaticFiles))
+	// Two StaticFiles in api-key mode: the key-aware .claude.json
+	// onboarding doc (the one carrying RenderContent, selected by path
+	// below) and the /home/agent/.claude/ writable-dir sentinel #1701
+	// added so that directory group-mounts writable. Assert the pair and
+	// select the onboarding doc by ContainerPath rather than index, so
+	// neither file ordering nor a future third state file silently breaks
+	// this probe.
+	if len(spec.StaticFiles) != 2 {
+		t.Fatalf("api-key AuthSpec StaticFiles = %d, want 2 (the .claude.json onboarding doc + the .claude/ writable-dir sentinel)", len(spec.StaticFiles))
 	}
 
 	eb := spec.EnvBindings[0]
@@ -115,7 +122,19 @@ func renderClaudeAPIKeyLaunchEnv(t *testing.T, rawKey string) (env map[string]st
 		t.Fatalf("rendered env = %v, want a %s entry", env, renderedClaudeAPIKeyEnv)
 	}
 
-	sf := spec.StaticFiles[0]
+	const onboardingContainerPath = "/home/agent/.claude.json"
+	onboardingIdx := -1
+	var paths []string
+	for i, candidate := range spec.StaticFiles {
+		paths = append(paths, candidate.ContainerPath)
+		if candidate.ContainerPath == onboardingContainerPath {
+			onboardingIdx = i
+		}
+	}
+	if onboardingIdx < 0 {
+		t.Fatalf("api-key AuthSpec has no StaticFile at %s; got %v", onboardingContainerPath, paths)
+	}
+	sf := spec.StaticFiles[onboardingIdx]
 	if sf.RenderContent == nil {
 		t.Fatal("api-key StaticFile has nil RenderContent; the onboarding doc cannot be made key-aware (#1695)")
 	}


### PR DESCRIPTION
## Summary

`main` is currently red: the `Integration Tests (Go)` job fails on `TestLaunchAnthropicProbe_RenderedKeyAuthenticatesThroughDaemon` with `api-key AuthSpec StaticFiles = 2, want 1`. This blocks every open PR (it surfaced while shepherding the unrelated #1703 vault-delete fix, PR #1704, whose own diff is green).

**Root cause — a semantic merge race between two PRs that were each green alone:**

- #1701 (`fix(launch): make api-key Claude .claude/ dir writable`) added a **second** StaticFile to the api-key `AuthSpec`: the `/home/agent/.claude/.aileron-keep` sentinel that forces `/home/agent/.claude/` to group-mount writable.
- #1702 (`test(app): composed launch->gateway->Anthropic-probe regression guard`), branched from a base **before** #1701 landed, asserts `len(spec.StaticFiles) == 1` and reads the onboarding doc at `StaticFiles[0]`.

Both passed CI independently. Squash-merged together onto `main`, the guard's `== 1` expectation is stale and the test fails. The product behavior (2 StaticFiles) is correct and intended.

## Fix

Update the regression guard to the post-#1701 reality:

- Expect `len(spec.StaticFiles) == 2` (onboarding doc + `.claude/` writable-dir sentinel).
- Select the `.claude.json` onboarding doc — the one carrying `RenderContent` — by `ContainerPath` instead of index `[0]`, so neither file ordering nor a future state file silently breaks the probe.

No product code changes; this only corrects the test's expectation.

## Test plan

- `go test -tags integration_sandbox -run TestLaunchAnthropicProbe_RenderedKeyAuthenticatesThroughDaemon ./internal/app/` — **PASS** (was failing on `main`).
- `go test -tags integration_sandbox -run 'Launch|Anthropic|APIKey|Probe' ./internal/app/` — **PASS**.
- `go vet -tags integration_sandbox ./internal/app/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
