### PR TITLE
fix(flightplan): materialize raw data results instead of 0-byte files

### DIFF
--- a/internal/flightplan/runtime/materialize.go
+++ b/internal/flightplan/runtime/materialize.go
@@ -48,35 +48,54 @@ func materialize(p *Plan, step Step, outputs map[string]any) (Artifact, error) {
 		return Artifact{}, fmt.Errorf("flightplan: step %q materializes undeclared output %q", step.ID, step.MaterializesOutput)
 	}
 
-	entry, err := fileMapFor(step, outputs)
+	carrier, err := carrierFor(step, outputs)
 	if err != nil {
 		return Artifact{}, fmt.Errorf("flightplan: step %q materialize %q: %w", step.ID, out.Name, err)
 	}
 
-	// Validate the encoding: v1 is utf-8 only.
-	switch entry.Encoding {
-	case "", string(EncodingUTF8):
-		// utf-8 (default) is materialized.
-	case string(EncodingBase64):
-		return Artifact{}, fmt.Errorf(
-			"flightplan: step %q output %q declares base64/binary encoding, which is deferred to the mount / run-and-collect boundary (#1510); v1 materializes utf-8 only",
-			step.ID, out.Name)
-	default:
-		return Artifact{}, fmt.Errorf("flightplan: step %q output %q has unknown file-map encoding %q", step.ID, out.Name, entry.Encoding)
+	entry, rawContent, isFileMap, err := decodeCarrier(carrier)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("flightplan: step %q materialize %q: %w", step.ID, out.Name, err)
 	}
 
-	// The mime type, when the file-map declares one, must match the declared
-	// output's mimeType so the materialized artifact matches its contract.
-	if entry.MimeType != "" && entry.MimeType != out.MimeType {
-		return Artifact{}, fmt.Errorf(
-			"flightplan: step %q output %q file-map mimeType %q does not match the declared %q",
-			step.ID, out.Name, entry.MimeType, out.MimeType)
+	var content []byte
+	if isFileMap {
+		// The carrier is a file-map entry (#1519): it carries the bytes in
+		// `content` plus its own encoding/mimeType transport detail.
+
+		// Validate the encoding: v1 is utf-8 only.
+		switch entry.Encoding {
+		case "", string(EncodingUTF8):
+			// utf-8 (default) is materialized.
+		case string(EncodingBase64):
+			return Artifact{}, fmt.Errorf(
+				"flightplan: step %q output %q declares base64/binary encoding, which is deferred to the mount / run-and-collect boundary (#1510); v1 materializes utf-8 only",
+				step.ID, out.Name)
+		default:
+			return Artifact{}, fmt.Errorf("flightplan: step %q output %q has unknown file-map encoding %q", step.ID, out.Name, entry.Encoding)
+		}
+
+		// The mime type, when the file-map declares one, must match the declared
+		// output's mimeType so the materialized artifact matches its contract.
+		if entry.MimeType != "" && entry.MimeType != out.MimeType {
+			return Artifact{}, fmt.Errorf(
+				"flightplan: step %q output %q file-map mimeType %q does not match the declared %q",
+				step.ID, out.Name, entry.MimeType, out.MimeType)
+		}
+		content = []byte(entry.Content)
+	} else {
+		// The carrier is a plain data result (no `content` key), e.g. an
+		// action-call step returning {QueryExecutionId, ResultSet}. Materialize
+		// the whole carrier as utf-8 JSON rather than extracting a missing
+		// `content` field and silently writing 0 bytes (#1706). decodeCarrier
+		// has already canonicalized it to JSON bytes.
+		content = rawContent
 	}
 
 	art := Artifact{
 		Name:     out.Name,
 		MimeType: out.MimeType,
-		Content:  []byte(entry.Content),
+		Content:  content,
 	}
 	if out.Target == PublishFile {
 		// The publish path comes from the declared output, not the file-map,
@@ -88,45 +107,83 @@ func materialize(p *Plan, step Step, outputs map[string]any) (Artifact, error) {
 	return art, nil
 }
 
-// fileMapFor extracts the file-map entry from a step's outputs. It accepts the
-// entry under the step's materializing output name (the conventional carrier),
-// or — when the step produced exactly one output — under that single output.
-// The carrier value may be a map[string]any (already decoded) or a JSON string
-// the step emitted; both decode to a fileMapEntry.
-func fileMapFor(step Step, outputs map[string]any) (fileMapEntry, error) {
+// carrierFor selects a step's carrier output value. It prefers the output whose
+// name matches the materialized output (the conventional carrier), then falls
+// back to the step's first declared output. The carrier value may be a
+// map[string]any (already decoded), a []any, a JSON string the step emitted, or
+// any other JSON-serializable result.
+func carrierFor(step Step, outputs map[string]any) (any, error) {
 	var carrier any
-	// Prefer an output whose name matches the materialized output, then fall
-	// back to the step's first declared output.
 	if c, ok := outputs[step.MaterializesOutput]; ok {
 		carrier = c
 	} else if len(step.Outputs) > 0 {
 		carrier = outputs[step.Outputs[0]]
 	}
 	if carrier == nil {
-		return fileMapEntry{}, fmt.Errorf("step produced no file-map carrier output")
+		return nil, fmt.Errorf("step produced no carrier output")
 	}
-	return decodeFileMapEntry(carrier)
+	return carrier, nil
 }
 
-// decodeFileMapEntry coerces a carrier value into a fileMapEntry. A decoded
-// map or a JSON string are both accepted; anything else is a typed error.
-func decodeFileMapEntry(carrier any) (fileMapEntry, error) {
+// decodeCarrier classifies a step's carrier output as either a file-map entry
+// or a plain data result, and returns the bytes to materialize.
+//
+// A carrier is treated as a file-map (#1519) iff it decodes to a JSON object
+// carrying a "content" key — the only field that conveys the artifact bytes.
+// In that case the typed fileMapEntry is returned (isFileMap=true) and the
+// caller validates its encoding/mimeType transport detail. Without a "content"
+// key the carrier is a plain data result (e.g. an action-call returning
+// {QueryExecutionId, ResultSet}); the whole carrier is re-serialized to
+// canonical JSON and returned as rawContent (isFileMap=false), so a
+// data-producing step materializes its result instead of silently writing 0
+// bytes (#1706).
+//
+// A carrier that decodes to a JSON object with a "content" key but is genuinely
+// a data result is the one ambiguous case; "content" is the file-map's defining
+// byte-carrying field, so it is the correct discriminator. A scalar or
+// otherwise undecodable carrier is a typed error.
+func decodeCarrier(carrier any) (entry fileMapEntry, rawContent []byte, isFileMap bool, err error) {
+	// Canonicalize the carrier to JSON bytes. A string carrier is taken as the
+	// JSON it emitted; any other value is marshaled.
 	var raw []byte
-	switch c := carrier.(type) {
-	case map[string]any:
-		b, err := json.Marshal(c)
-		if err != nil {
-			return fileMapEntry{}, err
+	if s, ok := carrier.(string); ok {
+		raw = []byte(s)
+	} else {
+		b, mErr := json.Marshal(carrier)
+		if mErr != nil {
+			return fileMapEntry{}, nil, false, fmt.Errorf("encode carrier: %w", mErr)
 		}
 		raw = b
-	case string:
-		raw = []byte(c)
+	}
+
+	// Inspect the generic shape to classify file-map vs. data result.
+	var generic any
+	if uErr := json.Unmarshal(raw, &generic); uErr != nil {
+		return fileMapEntry{}, nil, false, fmt.Errorf("decode carrier: %w", uErr)
+	}
+
+	obj, isObject := generic.(map[string]any)
+	if isObject {
+		if _, hasContent := obj["content"]; hasContent {
+			var fm fileMapEntry
+			if uErr := json.Unmarshal(raw, &fm); uErr != nil {
+				return fileMapEntry{}, nil, false, fmt.Errorf("decode file-map entry: %w", uErr)
+			}
+			return fm, nil, true, nil
+		}
+	}
+
+	// A plain data result is materialized only when it is structured (a JSON
+	// object or array). A bare scalar carrier is not a plausible artifact and
+	// signals a wiring error rather than a result to serialize.
+	switch generic.(type) {
+	case map[string]any, []any:
+		canonical, mErr := json.Marshal(generic)
+		if mErr != nil {
+			return fileMapEntry{}, nil, false, fmt.Errorf("encode data result: %w", mErr)
+		}
+		return fileMapEntry{}, canonical, false, nil
 	default:
-		return fileMapEntry{}, fmt.Errorf("file-map carrier is %T, want a {path,mimeType,encoding,content} object or its JSON", carrier)
+		return fileMapEntry{}, nil, false, fmt.Errorf("carrier is %T, want a file-map {path,mimeType,encoding,content} object or a JSON data object/array", carrier)
 	}
-	var entry fileMapEntry
-	if err := json.Unmarshal(raw, &entry); err != nil {
-		return fileMapEntry{}, fmt.Errorf("decode file-map entry: %w", err)
-	}
-	return entry, nil
 }

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -84,6 +85,89 @@ func TestMaterialize_CarrierFromJSONString(t *testing.T) {
 	}
 	if string(art.Content) != "{}" {
 		t.Errorf("content = %q", art.Content)
+	}
+}
+
+func TestMaterialize_RawDataObjectSerialized(t *testing.T) {
+	// A data-producing action-call step whose carrier is a plain object with no
+	// `content` key (e.g. the Athena connector's run_query result) must
+	// materialize the whole object as utf-8 JSON, never a 0-byte file (#1706).
+	p := planWithOutput(Output{Name: "chains.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "chains.json"})
+	step := fileMapStep("chains.json")
+	outputs := map[string]any{"file": map[string]any{
+		"QueryExecutionId": "q-123",
+		"ResultSet":        map[string]any{"rows": float64(2)},
+	}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if len(art.Content) == 0 {
+		t.Fatal("a non-file-map data result must not materialize 0 bytes")
+	}
+	if !art.Written || art.Path != "chains.json" {
+		t.Errorf("artifact = %+v", art)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(art.Content, &got); err != nil {
+		t.Fatalf("content is not valid JSON: %v (%q)", err, art.Content)
+	}
+	if got["QueryExecutionId"] != "q-123" {
+		t.Errorf("serialized result missing QueryExecutionId: %q", art.Content)
+	}
+}
+
+func TestMaterialize_RawDataArraySerialized(t *testing.T) {
+	// A data result that is a JSON array must also serialize, not error.
+	p := planWithOutput(Output{Name: "rows.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "rows.json"})
+	step := fileMapStep("rows.json")
+	outputs := map[string]any{"file": []any{
+		map[string]any{"dealer": "a"}, map[string]any{"dealer": "b"},
+	}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if string(art.Content) != `[{"dealer":"a"},{"dealer":"b"}]` {
+		t.Errorf("content = %q", art.Content)
+	}
+}
+
+func TestMaterialize_RawDataFromJSONString(t *testing.T) {
+	// A carrier emitted as a JSON string for a plain data object also serializes
+	// the underlying object (canonicalized), not the quoted string.
+	p := planWithOutput(Output{Name: "d.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "d.json"})
+	step := fileMapStep("d.json")
+	outputs := map[string]any{"file": `{"id":7,"name":"x"}`}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if len(art.Content) == 0 {
+		t.Fatal("a JSON-string data result must not materialize 0 bytes")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(art.Content, &got); err != nil {
+		t.Fatalf("content is not valid JSON: %v", err)
+	}
+	if got["name"] != "x" {
+		t.Errorf("serialized result = %q", art.Content)
+	}
+}
+
+func TestMaterialize_EmptyFileMapContentStaysEmpty(t *testing.T) {
+	// A genuine file-map that explicitly emits empty content keeps writing an
+	// empty file: the `content`-key discriminator preserves the ability to
+	// produce a deliberately-empty artifact.
+	p := planWithOutput(Output{Name: "empty.txt", MimeType: "text/plain", Encoding: EncodingUTF8, Target: PublishFile, Path: "empty.txt"})
+	step := fileMapStep("empty.txt")
+	outputs := map[string]any{"file": map[string]any{"content": "", "encoding": "utf-8"}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if len(art.Content) != 0 {
+		t.Errorf("explicit empty file-map content must stay empty, got %q", art.Content)
 	}
 }
 


### PR DESCRIPTION
## Summary

A `materializesOutput` step whose carrier output is a **plain data object** (not the file-map transport) silently wrote a **0-byte file while the launch reported success** (#1706).

`materialize()` coerced every carrier into the typed `fileMapEntry` `{path, mimeType, encoding, content}`. When the carrier was a plain JSON object — e.g. the Athena connector's `run_query` result `{QueryExecutionId, ResultSet}` — `json.Unmarshal` succeeded with `Content=""` (missing keys decode to zero values, no error), so the artifact had empty content and the runtime wrote 0 bytes with audit recorded and `Artifacts: chains.json -> chains.json` printed. No error anywhere. Hit in practice launching the `octane-dealer-dashboard` Flight Plan against real Athena: `chains.json` and `dealers.json` were written empty.

## What changed

`decodeCarrier` now **classifies** the carrier instead of blindly coercing it:

- A JSON object carrying a **`content`** key is the file-map transport (#1519). The existing encoding (utf-8 only) and mimeType validation is preserved, and `entry.Content` is written as before. `content` is the file-map's defining byte-carrying field, so its presence is the discriminator.
- Any **other** JSON object or array is a **plain data result**: the whole carrier is re-serialized to canonical utf-8 JSON and materialized, so a data-producing `action-call` step writes its result instead of nothing.
- A genuine file-map that explicitly emits empty content still writes an empty file (deliberate empty artifact preserved).
- A scalar or undecodable carrier remains a typed error.

**Invariant:** a non-file-map result with no `content` is never silently materialized as 0 bytes — it is serialized (preferred) per the issue's hard requirement.

## Test plan

- `go test ./internal/flightplan/runtime/` — green, coverage 88.9%.
- New regression tests (fail before, pass after): raw data object serialized (Athena-shaped, asserts non-zero bytes + round-trips the result), raw data array serialized, raw data emitted as a JSON string, and an explicit empty file-map staying empty.
- All pre-existing materialize tests still pass unchanged (file-map happy path, base64 refusal, mimeType mismatch, target:none, JSON-string file-map, non-object/no-carrier/malformed refusals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact output handling so structured data is now written as proper JSON instead of sometimes producing empty files.
  * Preserved intentionally empty outputs when a file-based result explicitly contains no content.
  * Tightened validation for supported output formats, helping prevent invalid data from being materialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #1706
