### PR TITLE
fix(flightplan): bind materialized outputs to content digest in audit

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -111,9 +111,9 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "  Artifacts:")
 		for _, a := range res.Artifacts {
 			if a.Written {
-				fmt.Fprintf(stdout, "    %s -> %s\n", a.Name, a.Path)
+				fmt.Fprintf(stdout, "    %s -> %s  %s\n", a.Name, a.Path, a.Digest)
 			} else {
-				fmt.Fprintf(stdout, "    %s (retained)\n", a.Name)
+				fmt.Fprintf(stdout, "    %s (retained)  %s\n", a.Name, a.Digest)
 			}
 		}
 	}

--- a/internal/flightplan/runtime/audit.go
+++ b/internal/flightplan/runtime/audit.go
@@ -80,12 +80,20 @@ func emitAudit(ctx context.Context, sink AuditSink, st execState) []string {
 }
 
 // buildLaunchRecord builds the per-launch resolved-inputs→outputs record. It
-// references source-input reads by their resolved binding and lists the
-// materialized artifact names, never inline data.
+// references source-input reads by their resolved binding and records each
+// materialized output by name, path, and content digest, never inline data.
+// The sha256 digest is the ADR-0027 snapshot identifier: it binds the output
+// name to the exact bytes the run produced so a past launch is independently
+// verifiable (hash the loose output file, compare to the recorded digest)
+// without duplicating the dataset in the audit.
 func buildLaunchRecord(st execState) AuditRecord {
-	artifacts := make([]string, 0, len(st.artifacts))
+	artifacts := make([]map[string]any, 0, len(st.artifacts))
 	for _, a := range st.artifacts {
-		artifacts = append(artifacts, a.Name)
+		artifacts = append(artifacts, map[string]any{
+			"name":   a.Name,
+			"path":   a.Path,
+			"sha256": a.Digest,
+		})
 	}
 	sources := map[string]any{}
 	for name, sb := range st.inputs.SourceBindings {

--- a/internal/flightplan/runtime/audit_test.go
+++ b/internal/flightplan/runtime/audit_test.go
@@ -71,6 +71,44 @@ func TestApprovalDecisionAudit(t *testing.T) {
 	}
 }
 
+func TestBuildLaunchRecord_BindsOutputToDigest(t *testing.T) {
+	// The per-launch record ties each materialized output name to its content
+	// digest and path, a reference (no inline bytes) inside the ADR-0027 audit
+	// boundary. This is what makes a past launch independently verifiable.
+	st := execState{
+		inputs: ResolvedInputs{SourceBindings: map[string]SourceBinding{}},
+		artifacts: []Artifact{
+			{Name: "chains.json", Path: "chains.json", Content: []byte(`{"a":1}`), Digest: "sha256:deadbeef", Written: true},
+			{Name: "kept.json", Content: []byte(`{}`), Digest: "sha256:cafe", Written: false},
+		},
+	}
+	rec := buildLaunchRecord(st)
+	outs, ok := rec.Fields["materializedOutputs"].([]map[string]any)
+	if !ok {
+		t.Fatalf("materializedOutputs = %T, want []map[string]any", rec.Fields["materializedOutputs"])
+	}
+	if len(outs) != 2 {
+		t.Fatalf("want 2 recorded outputs, got %d", len(outs))
+	}
+	if outs[0]["name"] != "chains.json" || outs[0]["path"] != "chains.json" || outs[0]["sha256"] != "sha256:deadbeef" {
+		t.Errorf("output 0 = %v", outs[0])
+	}
+	// The retained (unwritten) output is still recorded by name + digest.
+	if outs[1]["name"] != "kept.json" || outs[1]["sha256"] != "sha256:cafe" {
+		t.Errorf("output 1 = %v", outs[1])
+	}
+	// The record references each output by name/path/sha256 only, never the
+	// dataset bytes inline (ADR-0027 boundary).
+	for _, o := range outs {
+		if len(o) != 3 {
+			t.Errorf("recorded output must carry only name/path/sha256, got %v", o)
+		}
+		if _, hasContent := o["content"]; hasContent {
+			t.Error("the launch record must not carry artifact content inline")
+		}
+	}
+}
+
 // containsValue deep-searches a JSON-shaped value for a string leaf.
 func containsValue(v any, want string) bool {
 	switch t := v.(type) {

--- a/internal/flightplan/runtime/materialize.go
+++ b/internal/flightplan/runtime/materialize.go
@@ -1,14 +1,16 @@
 package runtime
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
 
 // Artifact is one materialized output: the declared output's name, the path it
 // was written to, its mime type, and the bytes. The runtime records it in the
-// audit by name; the bytes are written to disk by the run orchestration when
-// the publish target is `file`.
+// audit by name and content digest; the bytes are written to disk by the run
+// orchestration when the publish target is `file`.
 type Artifact struct {
 	Name     string
 	Path     string
@@ -16,9 +18,25 @@ type Artifact struct {
 	// Content is the materialized utf-8 bytes. Empty for a target:none
 	// artifact (recorded but not written).
 	Content []byte
+	// Digest is the sha256 of Content, formatted `sha256:<hex>`. It is computed
+	// at construction over the exact bytes writeArtifacts lands on disk, so an
+	// operator can independently verify a loose output file against the digest
+	// recorded in the per-launch audit (ADR-0027 snapshot identifier). Empty
+	// content hashes deterministically to the sha256 of zero bytes, so the
+	// digest is always recordable — including for a target:none artifact that
+	// is retained but never written.
+	Digest string
 	// Written reports whether the artifact should be written to disk
 	// (publish target `file`) vs retained in the run record only (`none`).
 	Written bool
+}
+
+// contentDigest returns the `sha256:<hex>` digest of the materialized bytes.
+// It is the audit-safe snapshot identifier for an artifact: it references the
+// exact content without carrying it inline (ADR-0027 audit boundary).
+func contentDigest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // fileMapEntry is one entry of the typed JSON file-map transport a
@@ -96,6 +114,7 @@ func materialize(p *Plan, step Step, outputs map[string]any) (Artifact, error) {
 		Name:     out.Name,
 		MimeType: out.MimeType,
 		Content:  content,
+		Digest:   contentDigest(content),
 	}
 	if out.Target == PublishFile {
 		// The publish path comes from the declared output, not the file-map,

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -32,6 +32,84 @@ func TestMaterialize_UTF8ToDeclaredPath(t *testing.T) {
 	}
 }
 
+func TestMaterialize_DigestFileMapArtifact(t *testing.T) {
+	// A file-map artifact carries a `sha256:<hex>` digest over its exact bytes,
+	// so the recorded output is independently verifiable (ADR-0027 snapshot
+	// identifier). The expected value is the known sha256 of the content.
+	p := planWithOutput(Output{Name: "digest.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishFile, Path: "digest.csv"})
+	step := fileMapStep("digest.csv")
+	outputs := map[string]any{"file": map[string]any{
+		"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "a,b\n1,2\n",
+	}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	const want = "sha256:492d5ea496056f1a6a6592241032fab764c321596317930b4fa0e1e8bc3b7470"
+	if art.Digest != want {
+		t.Errorf("digest = %q, want %q", art.Digest, want)
+	}
+}
+
+func TestMaterialize_DigestDataResultCarrier(t *testing.T) {
+	// A plain data-result carrier (no `content` key) digests the canonical JSON
+	// bytes that land on disk, matching the exact serialized content.
+	p := planWithOutput(Output{Name: "rows.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "rows.json"})
+	step := fileMapStep("rows.json")
+	outputs := map[string]any{"file": map[string]any{"dealer": "a"}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if string(art.Content) != `{"dealer":"a"}` {
+		t.Fatalf("content = %q", art.Content)
+	}
+	const want = "sha256:464ab4c951738bc4064d5236f3111bf65fe2997e617e06cf65fb90e0dc043011"
+	if art.Digest != want {
+		t.Errorf("digest = %q, want %q", art.Digest, want)
+	}
+}
+
+func TestMaterialize_DigestEmptyContentDeterministic(t *testing.T) {
+	// A target:none artifact with empty content still carries a digest: the
+	// sha256 of zero bytes, so every materialized output is recordable.
+	p := planWithOutput(Output{Name: "empty.txt", MimeType: "text/plain", Encoding: EncodingUTF8, Target: PublishNone})
+	step := fileMapStep("empty.txt")
+	outputs := map[string]any{"file": map[string]any{"content": "", "encoding": "utf-8"}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	const want = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if art.Digest != want {
+		t.Errorf("empty-content digest = %q, want %q", art.Digest, want)
+	}
+}
+
+func TestMaterialize_DigestDetectsTamper(t *testing.T) {
+	// A one-byte change to the content produces a different digest: the
+	// acceptance's "tampered output byte fails verification".
+	p := planWithOutput(Output{Name: "d.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishFile, Path: "d.csv"})
+	step := fileMapStep("d.csv")
+	base := materializeContent(t, p, step, "a,b\n1,2\n")
+	tampered := materializeContent(t, p, step, "a,b\n1,3\n")
+	if base == tampered {
+		t.Fatal("a one-byte content change must produce a different digest")
+	}
+}
+
+// materializeContent materializes a utf-8 file-map with the given content and
+// returns its digest, so a tamper test can compare two runs.
+func materializeContent(t *testing.T, p *Plan, step Step, content string) string {
+	t.Helper()
+	outputs := map[string]any{"file": map[string]any{"encoding": "utf-8", "content": content}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize %q: %v", content, err)
+	}
+	return art.Digest
+}
+
 func TestMaterialize_Base64Refused(t *testing.T) {
 	p := planWithOutput(Output{Name: "chart.png", MimeType: "image/png", Encoding: EncodingBase64, Target: PublishFile, Path: "chart.png"})
 	step := fileMapStep("chart.png")


### PR DESCRIPTION
## Summary

Delivers the operator's required core from feedback #1709 (items #1 + #2): every materialized Flight Plan output is now bound to a content digest in the per-launch audit record, inside the ADR-0027 audit boundary.

- `Artifact` gains a `Digest` field set to `sha256:<hex>` over `Content` at construction, for **both** materialization branches (file-map entries and plain data-result carriers, #1706). Empty content hashes deterministically to the sha256 of zero bytes, so a `target:none` (retained-but-unwritten) artifact still carries a recordable digest. The digest is computed over the exact bytes `writeArtifacts` writes verbatim, so hashing a loose output file (e.g. `chains.json`) reproduces the recorded value.
- `buildLaunchRecord` now records `materializedOutputs` as a per-artifact `{name, path, sha256}` reference instead of a bare name list. This ties each output name to its content digest while staying a reference (no inline bytes), preserving the ADR-0027 "result or snapshot identifier with a summary" boundary.
- The digest rides on `RunResult.Artifacts` for free and is printed in the CLI artifact listing.

This gives independent verifiability of a past frozen-version run: hash the loose output file, compare to the digest recorded for that run. A tampered output byte fails verification.

## Test plan

Regression tests written to the contract (`go test ./flightplan/runtime/...` and `./cmd/aileron/...` both green):

- `TestMaterialize_DigestFileMapArtifact` / `TestMaterialize_DigestDataResultCarrier` — the digest equals the known sha256 of the exact materialized bytes for both branches.
- `TestMaterialize_DigestEmptyContentDeterministic` — empty content hashes to the sha256 of zero bytes (target:none is recordable).
- `TestMaterialize_DigestDetectsTamper` — a one-byte content change yields a different digest (the acceptance's "tampered output byte fails verification").
- `TestBuildLaunchRecord_BindsOutputToDigest` — the launch record emits `{name, path, sha256}` per output and carries no content inline.

## Deferred (explicitly optional in the issue)

Item #3 — a detached ed25519 signature over the output bundle/audit record — is **out of scope** here. It carries an unresolved design fork: a launch output is produced by whoever *runs* the frozen unit, not necessarily the author who signed the plan at freeze, so "author public key" attestation of a launch output conflates author-attestation with run-attestation. There is also no persisted/signed launch-audit store today (`stdoutAuditSink` is a CLI-side stub returning a placeholder id). The digest binding stands alone as a complete unit and is a prerequisite for any later signature-over-the-record work.

Closes #1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched artifacts now include content digests in CLI output, making results easier to verify.
  * Audit records now capture materialized outputs with name, path, and digest details for stronger traceability.

* **Bug Fixes**
  * Retained artifacts are now consistently included in launch reporting with their digest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->