### PR TITLE
feat(flightplan): add named-transform vocabulary and html-render transform

### DIFF
--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -534,6 +534,12 @@
           "const": "transform",
           "description": "Deterministic no-LLM logic over data already in the graph."
         },
+        "transform": {
+          "type": "string",
+          "$comment": "`transform` names a member of the runtime's closed, deterministic transform vocabulary. It is NOT an llmMarker: freeze/lint.go's llmMarkers set (llm, model, prompt, completion, inference) does not include `transform`, and the registry it selects from contains only pure, no-LLM transforms, so the structural no-LLM guarantee holds. Only a transform step may carry this key; the closed additionalProperties:false shapes of action-call and llm-seam forbid it there.",
+          "description": "OPTIONAL. Names the deterministic transform to apply from the runtime's closed transform vocabulary (for example `html-render`). Absent means the identity passthrough, the v1 default, so a step that reshapes a single binding needs no name. A named transform is a pure function of the step's resolved bindings with no host, network, credential, or LLM surface.",
+          "minLength": 1
+        },
         "bindings": {
           "type": "object",
           "description": "The named inputs to the transform. Each value is a binding REFERENCE to a resolved input or a prior step output, never a value.",

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -534,6 +534,12 @@
           "const": "transform",
           "description": "Deterministic no-LLM logic over data already in the graph."
         },
+        "transform": {
+          "type": "string",
+          "$comment": "`transform` names a member of the runtime's closed, deterministic transform vocabulary. It is NOT an llmMarker: freeze/lint.go's llmMarkers set (llm, model, prompt, completion, inference) does not include `transform`, and the registry it selects from contains only pure, no-LLM transforms, so the structural no-LLM guarantee holds. Only a transform step may carry this key; the closed additionalProperties:false shapes of action-call and llm-seam forbid it there.",
+          "description": "OPTIONAL. Names the deterministic transform to apply from the runtime's closed transform vocabulary (for example `html-render`). Absent means the identity passthrough, the v1 default, so a step that reshapes a single binding needs no name. A named transform is a pure function of the step's resolved bindings with no host, network, credential, or LLM surface.",
+          "minLength": 1
+        },
         "bindings": {
           "type": "object",
           "description": "The named inputs to the transform. Each value is a binding REFERENCE to a resolved input or a prior step output, never a value.",

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -183,6 +183,54 @@ func TestDecode_UnknownStepKind(t *testing.T) {
 	}
 }
 
+func TestDecode_TransformNameCarried(t *testing.T) {
+	m := rawManifest(
+		[]any{litInput("t", "string", "<b>{{.d}}</b>")},
+		nil,
+		[]any{step(map[string]any{
+			"id": "render", "kind": "transform", "transform": "html-render",
+			"bindings": map[string]any{"template": "inputs.t"},
+			"outputs":  []any{"report"},
+		})},
+	)
+	p, err := Decode(m)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if p.Steps[0].Transform != "html-render" {
+		t.Errorf("transform name = %q, want html-render", p.Steps[0].Transform)
+	}
+}
+
+func TestDecode_TransformNameOnActionCallRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "call", "kind": "action-call",
+			"actionRef": "aileron:metrics.query_series",
+			"transform": "html-render",
+			"outputs":   []any{"x"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an action-call naming a transform must be refused")
+	} else if !strings.Contains(err.Error(), "transform") {
+		t.Errorf("error = %v, want a transform-name rejection", err)
+	}
+}
+
+func TestDecode_TransformNameOnLLMSeamRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "seam", "kind": "llm-seam",
+			"transform": "html-render",
+			"outputs":   []any{"x"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an llm-seam naming a transform must be refused")
+	}
+}
+
 func TestDecode_MalformedBinding(t *testing.T) {
 	m := rawManifest(
 		[]any{litInput("w", "number", 7)},

--- a/internal/flightplan/runtime/dto.go
+++ b/internal/flightplan/runtime/dto.go
@@ -185,6 +185,7 @@ type stepDTO struct {
 	ID                 string            `yaml:"id"`
 	Kind               string            `yaml:"kind"`
 	ActionRef          string            `yaml:"actionRef"`
+	Transform          string            `yaml:"transform"`
 	Args               map[string]string `yaml:"args"`
 	Bindings           map[string]string `yaml:"bindings"`
 	Outputs            []string          `yaml:"outputs"`
@@ -239,6 +240,15 @@ func (d stepDTO) toStep() (Step, error) {
 			return Step{}, err
 		}
 		step.Bindings = binds
+	}
+
+	// A transform name selects which deterministic transform the registry
+	// applies; it is meaningful only on a transform step. Any other kind naming
+	// a transform is a malformed step, refused rather than silently ignored.
+	if kind == KindTransform {
+		step.Transform = d.Transform
+	} else if d.Transform != "" {
+		return Step{}, decodeErrf("step %q: kind %q must not declare a transform (only a transform step names one)", d.ID, d.Kind)
 	}
 
 	// Every kind requires at least one declared output (schema stepOutputs

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -171,6 +171,45 @@ func TestMaterialize_EmptyFileMapContentStaysEmpty(t *testing.T) {
 	}
 }
 
+func TestMaterialize_HTMLRenderProducesSealedArtifact(t *testing.T) {
+	// Integration: the html-render transform's file-map entry drops straight
+	// into materialize.go unchanged, producing a sealed, writable HTML artifact
+	// whose bytes are a deterministic function of the template and data bindings.
+	p := planWithOutput(Output{
+		Name: "report.html", MimeType: "text/html", Encoding: EncodingUTF8,
+		Target: PublishFile, Path: "report.html",
+	})
+	step := Step{
+		ID: "render", Kind: KindTransform, Transform: "html-render",
+		Outputs: []string{"report"}, MaterializesOutput: "report.html",
+	}
+	reg := NewTransformRegistry()
+	outputs, err := reg.run(step, map[string]any{
+		"template": "<h1>{{ .summary.title }}</h1><ul>{{ range .summary.items }}<li>{{ . }}</li>{{ end }}</ul>",
+		"summary": map[string]any{
+			"title": "Weekly Digest",
+			"items": []any{"alpha", "beta"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("html-render: %v", err)
+	}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	want := "<h1>Weekly Digest</h1><ul><li>alpha</li><li>beta</li></ul>"
+	if string(art.Content) != want {
+		t.Errorf("content = %q, want %q", art.Content, want)
+	}
+	if art.MimeType != "text/html" {
+		t.Errorf("mimeType = %q, want text/html", art.MimeType)
+	}
+	if !art.Written || art.Path != "report.html" {
+		t.Errorf("artifact must be sealed to the declared path, got %+v", art)
+	}
+}
+
 func TestMaterialize_NonObjectCarrierRefused(t *testing.T) {
 	p := planWithOutput(Output{Name: "d.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishNone})
 	step := fileMapStep("d.csv")

--- a/internal/flightplan/runtime/plan.go
+++ b/internal/flightplan/runtime/plan.go
@@ -194,6 +194,11 @@ type Step struct {
 	ID        string
 	Kind      StepKind
 	ActionRef string
+	// Transform names the deterministic transform to apply, selected from the
+	// runtime's closed TransformRegistry. Meaningful only for KindTransform;
+	// empty means the identity passthrough (the v1 default). Never carries an
+	// LLM-backed transform: that is what KindLLMSeam is for.
+	Transform string
 	// Args binds action-call argument names to binding references.
 	Args map[string]Binding
 	// Bindings binds transform / llm-seam input names to binding references.

--- a/internal/flightplan/runtime/transform.go
+++ b/internal/flightplan/runtime/transform.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+)
 
 // Transform is one deterministic, no-LLM transform. It reshapes data already
 // in the graph and has NO host, network, credential, or LLM surface. A
@@ -30,6 +34,7 @@ func NewTransformRegistry() *TransformRegistry {
 	r := &TransformRegistry{byName: map[string]Transform{}}
 	r.byName["identity"] = identityTransform
 	r.byName["passthrough"] = identityTransform
+	r.byName["html-render"] = htmlRenderTransform
 	return r
 }
 
@@ -39,20 +44,27 @@ func (r *TransformRegistry) Register(name string, t Transform) {
 	r.byName[name] = t
 }
 
-// run executes the transform for a step. v1 transform steps do not name a
-// transform in the manifest schema (the transformStep shape carries no
-// transform name), so the runtime applies the registry's `identity` transform
-// by default: it surfaces each binding under the matching declared output
-// name, and for a single-output step with a single binding it maps that
-// binding to the output. A host may override `identity` (or register named
-// transforms) before a run to supply deterministic reshaping; the registry is
-// the single, LLM-free transform vocabulary. This keeps the worked example
-// deterministic and LLM-free while a richer named-transform vocabulary lands
-// later.
+// run executes the transform for a step. A transform step names its transform
+// via step.Transform; an unnamed step falls back to the registry's `identity`
+// transform (the v1 default), which surfaces each binding under the matching
+// declared output name, and for a single-output step with a single binding maps
+// that binding to the output. A named transform is looked up in the closed,
+// LLM-free registry; an unknown name is a hard error (the seam discipline keeps
+// the vocabulary closed rather than silently falling back). A host may override
+// `identity` or register additional deterministic transforms before a run.
 func (r *TransformRegistry) run(step Step, bindings map[string]any) (map[string]any, error) {
-	t, ok := r.byName["identity"]
+	name := step.Transform
+	if name == "" {
+		name = "identity"
+	}
+	t, ok := r.byName[name]
 	if !ok {
-		t = identityTransform
+		if name == "identity" {
+			// The identity default is always available even if a host cleared it.
+			t = identityTransform
+		} else {
+			return nil, fmt.Errorf("flightplan: step %q names transform %q, which is not registered", step.ID, name)
+		}
 	}
 	return t(bindings, step.Outputs)
 }
@@ -78,4 +90,80 @@ func identityTransform(bindings map[string]any, outputs []string) (map[string]an
 		out[name] = deepCopyValue(any(bindings))
 	}
 	return out, nil
+}
+
+// htmlRenderTemplateBinding is the binding name that designates the HTML
+// template source for the html-render transform. Every other binding is a
+// named JSON dataset injected into the template context under its binding name.
+const htmlRenderTemplateBinding = "template"
+
+// htmlRenderPathBinding is an OPTIONAL binding naming the advisory file-map
+// path. Materialization writes to the declared output's path (the file-map path
+// is advisory transport detail, #1519), so this binding only travels through
+// to the emitted entry and never decides where the artifact lands.
+const htmlRenderPathBinding = "path"
+
+// htmlRenderTransform renders a deterministic, auto-escaping HTML report from a
+// designated `template` binding plus named JSON data bindings, emitting a single
+// file-map entry {path, mimeType:"text/html", encoding:"utf-8", content} that
+// materialize.go consumes unchanged (decodeCarrier keys on `content`) to produce
+// a sealed, content-addressed HTML artifact.
+//
+// It is a pure function of its bindings: it reaches no network and no clock, and
+// Go's html/template ranges over map keys in sorted order, so the same bindings
+// always render byte-identical output. html/template auto-escapes every
+// interpolated value, so injected JSON datasets cannot break out of the HTML
+// context. This keeps the transform inside the structural no-LLM guarantee: it
+// holds no host, network, credential, or LLM surface.
+func htmlRenderTransform(bindings map[string]any, outputs []string) (map[string]any, error) {
+	if len(outputs) != 1 {
+		return nil, fmt.Errorf("html-render declares %d outputs; it produces exactly one file-map entry", len(outputs))
+	}
+
+	tmplRaw, ok := bindings[htmlRenderTemplateBinding]
+	if !ok {
+		return nil, fmt.Errorf("html-render requires a %q binding naming the HTML template source", htmlRenderTemplateBinding)
+	}
+	tmplStr, ok := tmplRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("html-render %q binding must be a string template, got %T", htmlRenderTemplateBinding, tmplRaw)
+	}
+
+	// The advisory transport path, when supplied, is a string. Materialization
+	// ignores it in favor of the declared output path.
+	var path string
+	if raw, present := bindings[htmlRenderPathBinding]; present {
+		s, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("html-render %q binding must be a string, got %T", htmlRenderPathBinding, raw)
+		}
+		path = s
+	}
+
+	// The template context is every remaining binding, keyed by its binding
+	// name, so a template reads a dataset as `.<bindingName>`.
+	data := make(map[string]any, len(bindings))
+	for name, v := range bindings {
+		if name == htmlRenderTemplateBinding || name == htmlRenderPathBinding {
+			continue
+		}
+		data[name] = v
+	}
+
+	tmpl, err := template.New("html-render").Parse(tmplStr)
+	if err != nil {
+		return nil, fmt.Errorf("html-render parse template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("html-render execute template: %w", err)
+	}
+
+	entry := map[string]any{
+		"path":     path,
+		"mimeType": "text/html",
+		"encoding": string(EncodingUTF8),
+		"content":  buf.String(),
+	}
+	return map[string]any{outputs[0]: entry}, nil
 }

--- a/internal/flightplan/runtime/transform_test.go
+++ b/internal/flightplan/runtime/transform_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +48,158 @@ func TestTransform_RegisterCustom(t *testing.T) {
 	})
 	if _, ok := reg.byName["upper"]; !ok {
 		t.Error("Register must add the transform")
+	}
+}
+
+func TestTransform_NamedLookup(t *testing.T) {
+	reg := NewTransformRegistry()
+	reg.Register("upper", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: "X"}, nil
+	})
+	// A step naming a transform selects it from the registry rather than the
+	// identity default.
+	step := Step{ID: "s", Kind: KindTransform, Transform: "upper", Outputs: []string{"out"}}
+	out, err := reg.run(step, map[string]any{"in": "y"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out["out"] != "X" {
+		t.Errorf("named transform not selected, got %v", out["out"])
+	}
+}
+
+func TestTransform_UnnamedFallsBackToIdentity(t *testing.T) {
+	reg := NewTransformRegistry()
+	// No Transform name: the identity passthrough forwards a single binding.
+	step := Step{ID: "s", Kind: KindTransform, Outputs: []string{"csv"}}
+	out, err := reg.run(step, map[string]any{"series": "data"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out["csv"] != "data" {
+		t.Errorf("unnamed step must fall back to identity, got %v", out["csv"])
+	}
+}
+
+func TestTransform_UnknownNameErrors(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Transform: "no-such-transform", Outputs: []string{"out"}}
+	if _, err := reg.run(step, map[string]any{}); err == nil {
+		t.Fatal("an unregistered transform name must be a hard error, not a silent identity fallback")
+	}
+}
+
+func TestHTMLRender_EmitsSealedFileMapEntry(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Transform: "html-render", Outputs: []string{"report"}}
+	bind := map[string]any{
+		"template": "<h1>{{ .report.title }}</h1><p>{{ .report.count }}</p>",
+		"report":   map[string]any{"title": "Weekly", "count": float64(3)},
+	}
+	out, err := reg.run(step, bind)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	entry, ok := out["report"].(map[string]any)
+	if !ok {
+		t.Fatalf("html-render must emit a file-map entry map, got %T", out["report"])
+	}
+	if entry["mimeType"] != "text/html" {
+		t.Errorf("mimeType = %v, want text/html", entry["mimeType"])
+	}
+	if entry["encoding"] != "utf-8" {
+		t.Errorf("encoding = %v, want utf-8", entry["encoding"])
+	}
+	content, _ := entry["content"].(string)
+	if content != "<h1>Weekly</h1><p>3</p>" {
+		t.Errorf("content = %q", content)
+	}
+}
+
+func TestHTMLRender_DeterministicAndPure(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Transform: "html-render", Outputs: []string{"report"}}
+	// Multiple named datasets, including a map whose key order is non-obvious,
+	// to exercise html/template's sorted-key range determinism.
+	bind := map[string]any{
+		"template": "{{ range $k, $v := .rows }}{{ $k }}={{ $v }};{{ end }}",
+		"rows":     map[string]any{"zebra": "1", "alpha": "2", "mango": "3"},
+	}
+	first, err := reg.run(step, bind)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	firstContent := first["report"].(map[string]any)["content"].(string)
+	// Sorted keys: alpha, mango, zebra.
+	if firstContent != "alpha=2;mango=3;zebra=1;" {
+		t.Errorf("html/template map range must be sorted-key deterministic, got %q", firstContent)
+	}
+	for i := 0; i < 25; i++ {
+		got, err := reg.run(step, bind)
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if got["report"].(map[string]any)["content"].(string) != firstContent {
+			t.Fatalf("html-render not deterministic on run %d", i)
+		}
+	}
+}
+
+func TestHTMLRender_AutoEscapesInjectedData(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Transform: "html-render", Outputs: []string{"report"}}
+	bind := map[string]any{
+		"template": "<div>{{ .payload }}</div>",
+		"payload":  "<script>alert('x')</script>",
+	}
+	out, err := reg.run(step, bind)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	content := out["report"].(map[string]any)["content"].(string)
+	if strings.Contains(content, "<script>") {
+		t.Errorf("html/template must auto-escape injected data, got %q", content)
+	}
+}
+
+func TestHTMLRender_MissingTemplateBindingErrors(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Transform: "html-render", Outputs: []string{"report"}}
+	if _, err := reg.run(step, map[string]any{"data": "x"}); err == nil {
+		t.Fatal("html-render without a template binding must error")
+	}
+}
+
+func TestHTMLRender_NonStringTemplateErrors(t *testing.T) {
+	if _, err := htmlRenderTransform(map[string]any{"template": 42}, []string{"report"}); err == nil {
+		t.Fatal("a non-string template binding must error")
+	}
+}
+
+func TestHTMLRender_ParseErrorReported(t *testing.T) {
+	if _, err := htmlRenderTransform(map[string]any{"template": "{{ .broken"}, []string{"report"}); err == nil {
+		t.Fatal("a malformed template must surface a parse error")
+	}
+}
+
+func TestHTMLRender_MultipleOutputsErrors(t *testing.T) {
+	if _, err := htmlRenderTransform(map[string]any{"template": "x"}, []string{"a", "b"}); err == nil {
+		t.Fatal("html-render must produce exactly one file-map entry")
+	}
+}
+
+func TestHTMLRender_AdvisoryPathBindingCarried(t *testing.T) {
+	out, err := htmlRenderTransform(map[string]any{
+		"template": "<p>{{ .d }}</p>", "path": "report.html", "d": "hi",
+	}, []string{"report"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	entry := out["report"].(map[string]any)
+	if entry["path"] != "report.html" {
+		t.Errorf("advisory path must be carried into the file-map entry, got %v", entry["path"])
+	}
+	if entry["content"].(string) != "<p>hi</p>" {
+		t.Errorf("path/template bindings must be excluded from the data context, got %q", entry["content"])
 	}
 }


### PR DESCRIPTION
## Summary

Adds an optional deterministic named-transform vocabulary so a Flight Plan can seal an HTML report artifact as a sealed, content-addressed output (per triage of #1708). Four coupled edits plus tests:

1. **Grammar** — an optional `transform` string on `transformStep` in both schema copies (`docs/schema/...` and the byte-identical embedded mirror; `TestEmbeddedSchemaMatchesDoc` guards equality). `kind` stays `transform` and `transform` is not an llmMarker, so `freeze/lint.go` still passes and the structural no-LLM guarantee holds. The closed `additionalProperties:false` shapes of action-call and llm-seam forbid the key there.
2. **Decode** — `Transform` added to `stepDTO` and the `Step` model, carried in `toStep()`; a transform name on a non-transform kind is a hard decode refusal.
3. **Registry** — `TransformRegistry.run` looks up `step.Transform`, falling back to `identity` when empty (preserves current behavior); an unknown name is a hard error rather than a silent identity fallback.
4. **Built-in `html-render`** — a pure Go `html/template` transform over a designated `template` binding plus named JSON data bindings, emitting a single `{path, mimeType:"text/html", encoding:"utf-8", content}` file-map entry that `materialize.go` consumes unchanged (`decodeCarrier` keys on `content`), dropping straight into a sealed HTML artifact. Deterministic (html/template ranges map keys in sorted order, no network/clock) and auto-escaping.

Octane consumer wiring is explicitly out of scope per the issue.

## Test plan

- `go test ./internal/flightplan/...` — all green.
- New tests: named-transform lookup + unnamed identity fallback + unknown-name error; html-render determinism (25x identical bytes), purity, auto-escaping, missing/non-string template, parse error, single-output constraint, advisory path carry; decode round-trip carrying the transform name + rejection on action-call and llm-seam; materialize integration producing a sealed `text/html` artifact written to the declared path.
- Coverage: `htmlRenderTransform` 92.6%, `run` 88.9%; runtime package ~89%.
- `gofmt -l` clean, `go vet ./internal/flightplan/...` clean.

Closes #1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
