### PR TITLE
feat(cli): namespace aileron secret set under secret/<name> and classify it

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -303,6 +303,16 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 	}
 	name := rest[0]
 
+	// Validate the name before touching the vault. Secrets are stored
+	// under the "secret/" namespace, so the name must be a single
+	// segment: reject empty names and any name containing a '/', which
+	// would collide with structured writers (agents/…, user/…, bindings).
+	if name == "" || strings.Contains(name, "/") {
+		fmt.Fprintf(stderr, "error: secret name must be a single segment (no '/'): %q\n", name)
+		return 1
+	}
+	storedPath := "secret/" + name
+
 	// Check if this is a brand-new vault (no existing secrets).
 	vaultPath := launch.DefaultVaultPath()
 	isNewVault := true
@@ -354,13 +364,13 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	if err := v.Put(context.Background(), name, []byte(value), vault.Metadata{Type: "secret"}); err != nil {
+	if err := v.Put(context.Background(), storedPath, []byte(value), vault.Metadata{Type: "secret"}); err != nil {
 		fmt.Fprintf(stderr, "error storing secret: %v\n", err)
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "Stored secret %q\n", name)
-	fmt.Fprintf(stdout, "Use vault:%s in aileron.yaml to reference it.\n", name)
+	fmt.Fprintf(stdout, "Stored secret %q\n", storedPath)
+	fmt.Fprintf(stdout, "Use vault:%s in aileron.yaml to reference it.\n", storedPath)
 	return 0
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -2189,8 +2189,82 @@ func TestRunSecretSet_NewVault(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Stored secret") {
 		t.Error("expected success message")
 	}
+	// The reference hint and stored-path message must show the namespaced
+	// path so a regression to the bare form is caught.
+	if !strings.Contains(stdout.String(), "vault:secret/test_token") {
+		t.Errorf("expected namespaced reference hint 'vault:secret/test_token', got: %s", stdout.String())
+	}
 	if !strings.Contains(stderr.String(), "Creating a new Aileron vault") {
 		t.Error("expected new vault warning")
+	}
+
+	// The value must be stored under `secret/test_token`, not the bare
+	// name — re-open the vault and assert the namespaced entry exists with
+	// Type=="secret" and the bare key does not.
+	v, err := launch.OpenLocalVault(launch.DefaultVaultPath(), "mypass")
+	if err != nil {
+		t.Fatalf("re-open vault: %v", err)
+	}
+	got, err := v.Get(context.Background(), "secret/test_token")
+	if err != nil {
+		t.Fatalf("expected entry at secret/test_token: %v", err)
+	}
+	if string(got.Value) != "secret-value" {
+		t.Errorf("value = %q, want %q", string(got.Value), "secret-value")
+	}
+	if got.Metadata.Type != "secret" {
+		t.Errorf("metadata type = %q, want %q", got.Metadata.Type, "secret")
+	}
+	if _, err := v.Get(context.Background(), "test_token"); err == nil {
+		t.Error("expected no entry at bare key test_token")
+	}
+}
+
+func TestRunSecretSet_RejectsSlashName(t *testing.T) {
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "secrets.json")
+	origDefault := launch.DefaultVaultPath
+	launch.DefaultVaultPath = func() string { return vaultPath }
+	defer func() { launch.DefaultVaultPath = origDefault }()
+
+	// No passphrase responses: rejection must happen before any prompt.
+	restore := mockPromptPassphrase(nil)
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := runSecretSet([]string{"agents/claude/oauth"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for slash-containing name")
+	}
+	if !strings.Contains(stderr.String(), "single segment") {
+		t.Errorf("expected single-segment error, got: %s", stderr.String())
+	}
+	// Rejection happened before the vault was opened: no file was created.
+	if _, err := os.Stat(vaultPath); !os.IsNotExist(err) {
+		t.Errorf("expected no vault file, stat err = %v", err)
+	}
+}
+
+func TestRunSecretSet_RejectsEmptyName(t *testing.T) {
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "secrets.json")
+	origDefault := launch.DefaultVaultPath
+	launch.DefaultVaultPath = func() string { return vaultPath }
+	defer func() { launch.DefaultVaultPath = origDefault }()
+
+	restore := mockPromptPassphrase(nil)
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := runSecretSet([]string{""}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for empty name")
+	}
+	if !strings.Contains(stderr.String(), "single segment") {
+		t.Errorf("expected single-segment error, got: %s", stderr.String())
+	}
+	if _, err := os.Stat(vaultPath); !os.IsNotExist(err) {
+		t.Errorf("expected no vault file, stat err = %v", err)
 	}
 }
 

--- a/cmd/aileron/vault_test.go
+++ b/cmd/aileron/vault_test.go
@@ -309,7 +309,7 @@ func TestRunSecretSet_HonorsEnvPassphrase(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), `Stored secret "linear_token"`) {
+	if !strings.Contains(stdout.String(), `Stored secret "secret/linear_token"`) {
 		t.Errorf("stdout = %q; want 'Stored secret ...'", stdout.String())
 	}
 
@@ -320,7 +320,7 @@ func TestRunSecretSet_HonorsEnvPassphrase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unlock with env passphrase: %v", err)
 	}
-	got, err := v.Get(t.Context(), "linear_token")
+	got, err := v.Get(t.Context(), "secret/linear_token")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -111,7 +111,7 @@ The keyring is the v1 source of trust for connector signature verification. Ever
 
 | Command | Purpose |
 |---|---|
-| `aileron secret set [--passphrase-file <path>] <name>` | Store a secret in the encrypted vault. The first secret on a new vault prompts to create and confirm the vault passphrase. Reference the stored value as `vault:<name>` in `aileron.yaml`. |
+| `aileron secret set [--passphrase-file <path>] <name>` | Store a secret in the encrypted vault. The first secret on a new vault prompts to create and confirm the vault passphrase. Reference the stored value as `vault:secret/<name>` in `aileron.yaml`. |
 | `aileron secret list [--json]` | List stored secret names. The secret value is never printed. |
 
 ## Bindings

--- a/internal/app/handlers_local_vault_union.go
+++ b/internal/app/handlers_local_vault_union.go
@@ -17,6 +17,7 @@ import (
 const (
 	connectedAccountsVaultPrefix = "connected-accounts/"
 	llmConfigVaultPrefix         = "llm-config/"
+	secretVaultPrefix            = "secret/"
 )
 
 // Vault entry scope labels surfaced in the union view's `scope` field.
@@ -30,14 +31,15 @@ const (
 	vaultScopeBinding          = "binding"
 	vaultScopeConnectedAccount = "connected-account"
 	vaultScopeLlmConfig        = "llm-config"
+	vaultScopeSecret           = "secret"
 	vaultScopeOther            = "other"
 )
 
 // classifyVaultPath maps a raw vault path to its VaultEntry scope label and
 // reports whether it belongs to a control-plane namespace.
 //
-// The locally-owned namespaces (`agents/`, `user/`, and capability
-// bindings — which include connector credentials like
+// The locally-owned namespaces (`agents/`, `user/`, `secret/`, and
+// capability bindings — which include connector credentials like
 // `connectors/<provider>/default` and OAuth bindings like
 // `oauth2/google/...`) are always part of the union. The two tenant-keyed
 // control-plane namespaces (`connected-accounts/`, `llm-config/`) are
@@ -59,6 +61,13 @@ func classifyVaultPath(path string) (scope string, controlPlane bool) {
 		return vaultScopeConnectedAccount, true
 	case strings.HasPrefix(path, llmConfigVaultPrefix):
 		return vaultScopeLlmConfig, true
+	case strings.HasPrefix(path, secretVaultPrefix):
+		// Secrets set via `aileron secret set` are locally-owned, so they
+		// are part of the default union (controlPlane=false). This is
+		// checked before the binding grammar below because a slash-bearing
+		// secret path could otherwise match the three-segment binding
+		// shape.
+		return vaultScopeSecret, false
 	}
 	if _, _, ok := agentNameAndPurposeFromVaultPath(path); ok {
 		return vaultScopeAgent, false

--- a/internal/app/handlers_local_vault_union_test.go
+++ b/internal/app/handlers_local_vault_union_test.go
@@ -45,6 +45,13 @@ func TestClassifyVaultPath(t *testing.T) {
 		// Control-plane namespaces: classified but flagged for exclusion.
 		{"connected-accounts/usr_123/slack", vaultScopeConnectedAccount, true},
 		{"llm-config/user/usr_123", vaultScopeLlmConfig, true},
+		// Secrets set via `aileron secret set` live under `secret/` and are
+		// locally-owned (not control-plane).
+		{"secret/foo", vaultScopeSecret, false},
+		// A `secret/`-prefixed path that also looks three-segment must still
+		// classify as `secret`, proving the prefix check wins over the
+		// binding grammar.
+		{"secret/github/repo", vaultScopeSecret, false},
 		// Anything matching no known namespace must still surface as `other`
 		// rather than vanish.
 		{"weird-single-segment", vaultScopeOther, false},
@@ -68,6 +75,7 @@ func TestListVaultEntries_UnionDefaultExcludesControlPlane(t *testing.T) {
 		"user/github":                    "USERSECRET",
 		"connectors/github/default":      "CONNSECRET",
 		"oauth2/google/default":          "OAUTHSECRET",
+		"secret/my_token":                "SETSECRET",
 		"connected-accounts/usr_1/slack": "CPSECRET1",
 		"llm-config/user/usr_1":          "CPSECRET2",
 	}
@@ -105,6 +113,8 @@ func TestListVaultEntries_UnionDefaultExcludesControlPlane(t *testing.T) {
 		"user/github":               vaultScopeUser,
 		"connectors/github/default": vaultScopeBinding,
 		"oauth2/google/default":     vaultScopeBinding,
+		// Locally-owned secrets must appear in the default union view.
+		"secret/my_token": vaultScopeSecret,
 	}
 	for p, scope := range want {
 		if byPath[p] != scope {

--- a/internal/comms/listeners.go
+++ b/internal/comms/listeners.go
@@ -13,7 +13,7 @@ import (
 )
 
 // vaultPrefix marks a config value as a reference to a vault entry
-// (e.g. `vault:slack-app-token`). Tokens stored as plaintext are
+// (e.g. `vault:secret/slack-app-token`). Tokens stored as plaintext are
 // rejected at config-load time.
 const vaultPrefix = "vault:"
 

--- a/internal/launch/secrets.go
+++ b/internal/launch/secrets.go
@@ -74,7 +74,7 @@ func ValidateTokenRef(field, value string) error {
 	if value == "" || IsVaultRef(value) {
 		return nil
 	}
-	return fmt.Errorf("%s contains a plaintext token — use 'aileron secret set <name>' and reference it as 'vault:<name>' instead", field)
+	return fmt.Errorf("%s contains a plaintext token — use 'aileron secret set <name>' and reference it as 'vault:secret/<name>' instead", field)
 }
 
 // OpenVaultFunc is the function used to open the vault when vault

--- a/internal/launch/secrets_test.go
+++ b/internal/launch/secrets_test.go
@@ -124,6 +124,11 @@ func TestValidateTokenRef_Plaintext(t *testing.T) {
 	if !strings.Contains(err.Error(), "slack.bot_token") {
 		t.Errorf("expected field name in error, got %q", err.Error())
 	}
+	// The hint must point at the namespaced reference form so a regression
+	// back to the bare `vault:<name>` form is caught.
+	if !strings.Contains(err.Error(), "vault:secret/<name>") {
+		t.Errorf("expected namespaced hint 'vault:secret/<name>' in error, got %q", err.Error())
+	}
 }
 
 func TestResolveTokens_PlainValues(t *testing.T) {


### PR DESCRIPTION
## Summary

`aileron secret set <name>` stored the value at the **bare** key `<name>` with `Metadata{Type:"secret"}`. Because the key carried no prefix it could collide with structured writers (`agents/…`, `user/…`, three-segment binding names) and fell through `classifyVaultPath` to scope `"other"`. This PR namespaces stored secrets under `secret/<name>` and teaches the classifier about the new namespace.

- **Writer (`runSecretSet`, `cmd/aileron/main.go`):** stores at `secret/<name>` (keeping `Metadata{Type:"secret"}`). The name is validated **client-side, before the vault is opened**: empty names and any name containing `/` are rejected with `error: secret name must be a single segment (no '/'): …` and a non-zero exit. Success output and the reference hint now print the namespaced form `vault:secret/<name>`.
- **Reference-form hint + docs (`internal/launch/secrets.go`, `internal/comms/listeners.go`, `docs/src/content/docs/cli/index.md`):** every user-facing string that tells people how to reference a set secret now shows `vault:secret/<name>`.
- **Classifier (`internal/app/handlers_local_vault_union.go`):** adds `secretVaultPrefix = "secret/"` and `vaultScopeSecret = "secret"`, with a `case` checked **before** the binding grammar so `secret/`-prefixed paths classify as `secret`, not `binding`. Secrets are locally-owned, so `controlPlane=false` — they appear in the default union view.

No migration shim (pre-release, per the plan). `ResolveVaultRef` is unchanged: its generic `Get` already resolves the full stored path, so `vault:secret/<name>` resolves with no resolver change. No OpenAPI change — `VaultEntry.scope` is a free-form string.

## Test plan

- `cmd/aileron`: `TestRunSecretSet_NewVault` extended to assert the value is stored at `secret/test_token` (Type `secret`), not the bare key, and that stdout contains `vault:secret/test_token`. New `TestRunSecretSet_RejectsSlashName` / `TestRunSecretSet_RejectsEmptyName` prove rejection happens before the vault file is created. Existing `TestRunSecretSet_HonorsEnvPassphrase` updated to the namespaced path.
- `internal/launch`: `TestValidateTokenRef_Plaintext` now asserts the error contains the namespaced hint `vault:secret/<name>`.
- `internal/app`: `TestClassifyVaultPath` adds `secret/foo` and a three-segment `secret/github/repo` case (pins the ordering guarantee that the prefix check wins over binding classification); the default-union test seeds a `secret/my_token` entry and asserts it surfaces with scope `secret` and is not excluded.
- `go test ./cmd/aileron/... ./internal/launch/... ./internal/app/... ./internal/comms/...` green; `go vet` clean.

Closes #1715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret names are now validated before saving, preventing empty names and names containing `/`.
  * Secret storage and references now use a namespaced format: `vault:secret/<name>`.

* **Bug Fixes**
  * Locally managed secrets now appear correctly in vault listings and are no longer confused with other path types.
  * Error messages and CLI output now consistently show the new secret path format.

* **Documentation**
  * Updated CLI examples to match the new secret reference format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->