### PR TITLE
refactor(cli): make secret list a projection over the shared vault-scope classifier

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/sandbox/spawnhelper"
 	"github.com/ALRubinger/aileron/internal/suite"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 	"github.com/ALRubinger/aileron/internal/version"
 	"golang.org/x/term"
 )
@@ -397,7 +398,12 @@ func runSecretList(args []string, stdout, stderr io.Writer) int {
 	}
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if e.Metadata.Type == "secret" {
+		// Filter by the shared vault-scope classifier so `secret list` and
+		// the daemon vault union agree on exactly one definition of what a
+		// `secret/`-scoped entry is. The full path (`secret/<name>`) is
+		// printed, matching what `secret set` reports and the
+		// `vault:secret/<name>` reference it hands back.
+		if scope, _ := vaultscope.Classify(e.Path); scope == vaultscope.ScopeSecret {
 			names = append(names, e.Path)
 		}
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -1161,7 +1161,7 @@ func TestRunSecret_ListWithSecrets(t *testing.T) {
 	// Pre-populate the vault file directly (skip encryption for test).
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
 	os.MkdirAll(filepath.Dir(vaultPath), 0o700)
-	os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"slack_bot_token":{"value":"ZW5j","metadata":{"type":"secret"}},"discord_token":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600)
+	os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"secret/slack_bot_token":{"value":"ZW5j","metadata":{"type":"secret"}},"secret/discord_token":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"secret", "list"}, newTestRegistry(), &stdout, &stderr)
@@ -1169,11 +1169,11 @@ func TestRunSecret_ListWithSecrets(t *testing.T) {
 		t.Errorf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "slack_bot_token") {
-		t.Errorf("expected 'slack_bot_token' in output, got: %s", out)
+	if !strings.Contains(out, "secret/slack_bot_token") {
+		t.Errorf("expected 'secret/slack_bot_token' in output, got: %s", out)
 	}
-	if !strings.Contains(out, "discord_token") {
-		t.Errorf("expected 'discord_token' in output, got: %s", out)
+	if !strings.Contains(out, "secret/discord_token") {
+		t.Errorf("expected 'secret/discord_token' in output, got: %s", out)
 	}
 }
 
@@ -1202,7 +1202,7 @@ func TestRunSecret_ListJSON_NDJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"a":{"value":"ZW5j","metadata":{"type":"secret"}},"b":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600); err != nil {
+	if err := os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"secret/a":{"value":"ZW5j","metadata":{"type":"secret"}},"secret/b":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1223,29 +1223,32 @@ func TestRunSecret_ListJSON_NDJSON(t *testing.T) {
 		}
 		got[name] = true
 	}
-	for _, want := range []string{"a", "b"} {
+	for _, want := range []string{"secret/a", "secret/b"} {
 		if !got[want] {
 			t.Errorf("missing name %q in: %v", want, got)
 		}
 	}
 }
 
-// TestRunSecret_ListOnlyReturnsSecretTypedEntries proves `secret list`
-// shows only entries a user stored via `aileron secret set` (tagged
-// Type=="secret") and hides the rest of the vault keyspace (agent
-// creds, OAuth bindings). Regression for the leak where the list path
-// dumped every key via Names().
-func TestRunSecret_ListOnlyReturnsSecretTypedEntries(t *testing.T) {
+// TestRunSecret_ListOnlyReturnsSecretScopedEntries proves `secret list`
+// shows only entries a user stored via `aileron secret set` (which live
+// under the `secret/` namespace) and hides the rest of the vault keyspace
+// (agent creds, OAuth bindings). The filter is now the shared vaultscope
+// classifier (path-based `secret/` scope), not the ad-hoc `Type` tag, so
+// this test seeds a canonical `secret/<name>` entry alongside non-secret
+// decoys. Regression for the leak where the list path dumped every key.
+func TestRunSecret_ListOnlyReturnsSecretScopedEntries(t *testing.T) {
 	dir := setTestHome(t)
 
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
 	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	// Mixed keyspace: one user secret, one agent cred (empty Type),
-	// one OAuth binding (non-secret Type).
+	// Mixed keyspace: one user secret under the `secret/` namespace, one
+	// agent cred, one OAuth binding. Only the `secret/`-scoped entry must
+	// surface, regardless of the metadata Type tag.
 	seed := `{"salt":"AAAA","secrets":{` +
-		`"api_token":{"value":"ZW5j","metadata":{"type":"secret"}},` +
+		`"secret/api_token":{"value":"ZW5j","metadata":{"type":"secret"}},` +
 		`"agents/claude/oauth":{"value":"ZW5j","metadata":{}},` +
 		`"oauth2/github/work":{"value":"ZW5j","metadata":{"type":"oauth_refresh_token"}}` +
 		`}}`
@@ -1260,8 +1263,8 @@ func TestRunSecret_ListOnlyReturnsSecretTypedEntries(t *testing.T) {
 			t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 		}
 		out := stdout.String()
-		if !strings.Contains(out, "api_token") {
-			t.Errorf("expected 'api_token' in output, got: %s", out)
+		if !strings.Contains(out, "secret/api_token") {
+			t.Errorf("expected 'secret/api_token' in output, got: %s", out)
 		}
 		if strings.Contains(out, "agents/claude/oauth") {
 			t.Errorf("non-secret agent cred leaked into output: %s", out)
@@ -1287,8 +1290,8 @@ func TestRunSecret_ListOnlyReturnsSecretTypedEntries(t *testing.T) {
 			}
 			got[name] = true
 		}
-		want := map[string]bool{"api_token": true}
-		if len(got) != len(want) || !got["api_token"] {
+		want := map[string]bool{"secret/api_token": true}
+		if len(got) != len(want) || !got["secret/api_token"] {
 			t.Errorf("decoded set = %v, want %v", got, want)
 		}
 	})

--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -258,7 +258,7 @@ type vaultDeleteTarget struct {
 }
 
 // vaultDeleteTargetFor classifies arg into the matching deletable
-// namespace, mirroring the daemon's classifyVaultPath order so the CLI
+// namespace, mirroring the shared vaultscope.Classify order so the CLI
 // recognizes exactly what `vault list` surfaces. The order is
 // load-bearing: agents/<name>/<purpose> also matches the binding name
 // grammar, so it must be checked first.
@@ -310,8 +310,8 @@ func vaultDeleteTargetFor(arg string) (vaultDeleteTarget, bool) {
 
 // userServiceFromArg extracts the service from a `user/<service>` path,
 // returning false for any path that does not match the scheme. Mirrors the
-// daemon's userServiceFromVaultPath so the CLI accepts exactly what the
-// daemon stores.
+// shared vaultscope.UserServiceFromVaultPath so the CLI accepts exactly what
+// the daemon stores.
 func userServiceFromArg(arg string) (service string, ok bool) {
 	const prefix = "user/"
 	if !strings.HasPrefix(arg, prefix) {

--- a/internal/app/handlers_local_vault_secrets.go
+++ b/internal/app/handlers_local_vault_secrets.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 )
 
 // vaultCredentialSessionHeader is the optional request header the
@@ -175,39 +176,6 @@ func resolveAgentCredentialPurpose(p *string) string {
 // (or supplied the validated default) before reaching here.
 func agentCredentialVaultPath(name, purpose string) string {
 	return "agents/" + name + "/" + purpose
-}
-
-// agentNameAndPurposeFromVaultPath is the inverse of
-// agentCredentialVaultPath: it splits an `agents/<name>/<purpose>` vault
-// path into its name and purpose segments. It accepts any conforming
-// path (any purpose, not just `oauth`) so the list surfaces apikey-only
-// agents that the old `/oauth`-suffix match made invisible. It returns
-// false for any path that does not match the scheme so the list filter
-// ignores non-agent entries (user credentials, bindings, etc.).
-//
-// The purpose segment is re-validated through the same allow-list the
-// write path uses (validateAgentCredentialPurpose) so a malformed stored
-// path can never surface a junk purpose in the list response.
-func agentNameAndPurposeFromVaultPath(path string) (name, purpose string, ok bool) {
-	const prefix = "agents/"
-	if !strings.HasPrefix(path, prefix) {
-		return "", "", false
-	}
-	rest := path[len(prefix):]
-	// Exactly two remaining segments: <name>/<purpose>. A name or purpose
-	// containing a slash (extra segments) is rejected.
-	parts := strings.Split(rest, "/")
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	name, purpose = parts[0], parts[1]
-	if name == "" || purpose == "" {
-		return "", "", false
-	}
-	if !validateAgentCredentialPurpose(purpose) {
-		return "", "", false
-	}
-	return name, purpose, true
 }
 
 // GetAgentCredentials returns the per-agent credential envelope for
@@ -415,7 +383,7 @@ func (s *apiServer) ListAgentCredentials(w http.ResponseWriter, r *http.Request)
 
 	list := api.AgentCredentialsList{Agents: []api.AgentCredentialSummary{}}
 	for _, e := range entries {
-		name, purpose, ok := agentNameAndPurposeFromVaultPath(e.Path)
+		name, purpose, ok := vaultscope.AgentNameAndPurposeFromVaultPath(e.Path)
 		if !ok {
 			continue
 		}

--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -574,33 +574,8 @@ func TestListAgentCredentials_ListErrorReturns500(t *testing.T) {
 	assertErrorCode(t, rec, "vault_list_failed")
 }
 
-func TestAgentNameAndPurposeFromVaultPath(t *testing.T) {
-	cases := []struct {
-		path        string
-		wantName    string
-		wantPurpose string
-		wantOK      bool
-	}{
-		{"agents/claude/oauth", "claude", "oauth", true},
-		{"agents/codex/oauth", "codex", "oauth", true},
-		{"agents/claude/apikey", "claude", "apikey", true}, // apikey now conforms
-		{"agents//apikey", "", "", false},                  // empty name
-		{"agents/claude", "", "", false},                   // missing purpose segment
-		{"agents/oauth", "", "", false},                    // only two segments
-		{"agents/a/b/oauth", "", "", false},                // nested name / extra segment
-		{"some/other/path", "", "", false},                 // wrong prefix
-		{"user/github", "", "", false},                     // user namespace, not agent
-		{"agents/claude/oauth/extra", "", "", false},       // extra segment
-		{"agents/claude/OAUTH", "", "", false},             // purpose fails the allow-list
-	}
-	for _, c := range cases {
-		gotName, gotPurpose, gotOK := agentNameAndPurposeFromVaultPath(c.path)
-		if gotOK != c.wantOK || gotName != c.wantName || gotPurpose != c.wantPurpose {
-			t.Errorf("agentNameAndPurposeFromVaultPath(%q) = (%q,%q,%v), want (%q,%q,%v)",
-				c.path, gotName, gotPurpose, gotOK, c.wantName, c.wantPurpose, c.wantOK)
-		}
-	}
-}
+// agentNameAndPurposeFromVaultPath moved to internal/vaultscope (as
+// AgentNameAndPurposeFromVaultPath) and is tested there.
 
 func strPtr(s string) *string { return &s }
 

--- a/internal/app/handlers_local_vault_union.go
+++ b/internal/app/handlers_local_vault_union.go
@@ -2,84 +2,10 @@ package app
 
 import (
 	"net/http"
-	"strings"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
-	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 )
-
-// Control-plane namespace prefixes. These two namespaces are tenant-keyed
-// records the cloud-shaped control plane owns (a per-user connected OAuth
-// account and a per-owner LLM config), not local single-user `aileron
-// launch` credentials. They are excluded from the default union view so
-// `aileron vault list` surfaces only the locally-owned namespaces; an
-// explicit opt-in (`include_control_plane=true`) includes them.
-const (
-	connectedAccountsVaultPrefix = "connected-accounts/"
-	llmConfigVaultPrefix         = "llm-config/"
-	secretVaultPrefix            = "secret/"
-)
-
-// Vault entry scope labels surfaced in the union view's `scope` field.
-// These mirror the documented values in the OpenAPI `VaultEntry.scope`
-// description; the spec models the field as a free-form string (not an
-// enum) so these literals do not collide with the same words in other
-// enums and force a global enum-constant rename in the generated code.
-const (
-	vaultScopeAgent            = "agent"
-	vaultScopeUser             = "user"
-	vaultScopeBinding          = "binding"
-	vaultScopeConnectedAccount = "connected-account"
-	vaultScopeLlmConfig        = "llm-config"
-	vaultScopeSecret           = "secret"
-	vaultScopeOther            = "other"
-)
-
-// classifyVaultPath maps a raw vault path to its VaultEntry scope label and
-// reports whether it belongs to a control-plane namespace.
-//
-// The locally-owned namespaces (`agents/`, `user/`, `secret/`, and
-// capability bindings — which include connector credentials like
-// `connectors/<provider>/default` and OAuth bindings like
-// `oauth2/google/...`) are always part of the union. The two tenant-keyed
-// control-plane namespaces (`connected-accounts/`, `llm-config/`) are
-// classified too but flagged so the caller can exclude them by default.
-//
-// Classification order is load-bearing: the prefixed namespaces are
-// checked before the generic three-segment binding shape, because an
-// `agents/<name>/<purpose>` path also matches the binding name grammar
-// (`<kind>/<service>/<identity>`) and must classify as `agent`, not
-// `binding`.
-//
-// Every path receives a scope. A path matching none of the known
-// namespaces classifies as `other` so the union never silently hides an
-// entry — surfacing unknown entries is the whole point of the union view
-// (#1402).
-func classifyVaultPath(path string) (scope string, controlPlane bool) {
-	switch {
-	case strings.HasPrefix(path, connectedAccountsVaultPrefix):
-		return vaultScopeConnectedAccount, true
-	case strings.HasPrefix(path, llmConfigVaultPrefix):
-		return vaultScopeLlmConfig, true
-	case strings.HasPrefix(path, secretVaultPrefix):
-		// Secrets set via `aileron secret set` are locally-owned, so they
-		// are part of the default union (controlPlane=false). This is
-		// checked before the binding grammar below because a slash-bearing
-		// secret path could otherwise match the three-segment binding
-		// shape.
-		return vaultScopeSecret, false
-	}
-	if _, _, ok := agentNameAndPurposeFromVaultPath(path); ok {
-		return vaultScopeAgent, false
-	}
-	if _, ok := userServiceFromVaultPath(path); ok {
-		return vaultScopeUser, false
-	}
-	if binding.IsBindingPath(path) {
-		return vaultScopeBinding, false
-	}
-	return vaultScopeOther, false
-}
 
 // ListVaultEntries returns the union of every entry in the local vault,
 // each classified by namespace scope, with plaintext metadata only — never
@@ -106,7 +32,7 @@ func (s *apiServer) ListVaultEntries(w http.ResponseWriter, r *http.Request, par
 
 	list := api.VaultEntriesList{Entries: []api.VaultEntry{}}
 	for _, e := range entries {
-		scope, controlPlane := classifyVaultPath(e.Path)
+		scope, controlPlane := vaultscope.Classify(e.Path)
 		if controlPlane && !includeControlPlane {
 			continue
 		}

--- a/internal/app/handlers_local_vault_union_test.go
+++ b/internal/app/handlers_local_vault_union_test.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 )
 
 // GET /v1/vault (union view) contract (#1402):
@@ -17,54 +18,16 @@ import (
 //   - Walks vault.List() once and surfaces EVERY locally-owned namespace
 //     (agent, user, connector/capability-binding), not just the two typed
 //     scopes — connector credentials must no longer be silently hidden.
-//   - Classifies each entry by namespace via classifyVaultPath.
+//   - Classifies each entry by namespace via vaultscope.Classify.
 //   - Excludes the two control-plane namespaces (connected-accounts/,
 //     llm-config/) by default; includes them only with
 //     include_control_plane=true.
 //   - Never returns credential bytes (ADR-0011).
 //   - 503 when the daemon has no vault wired.
 
-// classifyVaultPath is the load-bearing classifier; pin each namespace and
-// the ordering edge case where an agent path also matches the binding
-// grammar.
-func TestClassifyVaultPath(t *testing.T) {
-	cases := []struct {
-		path        string
-		wantScope   string
-		wantControl bool
-	}{
-		{"agents/claude/oauth", vaultScopeAgent, false},
-		{"agents/codex/apikey", vaultScopeAgent, false},
-		{"user/github", vaultScopeUser, false},
-		// Connector + OAuth capability bindings are three-segment binding
-		// names. They are exactly the entries the old typed-endpoint list
-		// silently hid (#1402); the union must classify them as bindings.
-		{"connectors/github/default", vaultScopeBinding, false},
-		{"oauth2/google/default", vaultScopeBinding, false},
-		{"github/repo/me", vaultScopeBinding, false},
-		// Control-plane namespaces: classified but flagged for exclusion.
-		{"connected-accounts/usr_123/slack", vaultScopeConnectedAccount, true},
-		{"llm-config/user/usr_123", vaultScopeLlmConfig, true},
-		// Secrets set via `aileron secret set` live under `secret/` and are
-		// locally-owned (not control-plane).
-		{"secret/foo", vaultScopeSecret, false},
-		// A `secret/`-prefixed path that also looks three-segment must still
-		// classify as `secret`, proving the prefix check wins over the
-		// binding grammar.
-		{"secret/github/repo", vaultScopeSecret, false},
-		// Anything matching no known namespace must still surface as `other`
-		// rather than vanish.
-		{"weird-single-segment", vaultScopeOther, false},
-		{"_internal/reserved", vaultScopeOther, false},
-	}
-	for _, c := range cases {
-		scope, control := classifyVaultPath(c.path)
-		if scope != c.wantScope || control != c.wantControl {
-			t.Errorf("classifyVaultPath(%q) = (%q, %v), want (%q, %v)",
-				c.path, scope, control, c.wantScope, c.wantControl)
-		}
-	}
-}
+// The classifier itself (Classify, and its two predicate helpers) is tested
+// in internal/vaultscope. These daemon-level tests exercise the union
+// endpoint's projection over it.
 
 // The default union view must surface agent, user, AND connector/binding
 // entries together, and must omit the control-plane namespaces.
@@ -109,12 +72,12 @@ func TestListVaultEntries_UnionDefaultExcludesControlPlane(t *testing.T) {
 	}
 	// The locally-owned namespaces must all be present and correctly scoped.
 	want := map[string]string{
-		"agents/claude/oauth":       vaultScopeAgent,
-		"user/github":               vaultScopeUser,
-		"connectors/github/default": vaultScopeBinding,
-		"oauth2/google/default":     vaultScopeBinding,
+		"agents/claude/oauth":       vaultscope.ScopeAgent,
+		"user/github":               vaultscope.ScopeUser,
+		"connectors/github/default": vaultscope.ScopeBinding,
+		"oauth2/google/default":     vaultscope.ScopeBinding,
 		// Locally-owned secrets must appear in the default union view.
-		"secret/my_token": vaultScopeSecret,
+		"secret/my_token": vaultscope.ScopeSecret,
 	}
 	for p, scope := range want {
 		if byPath[p] != scope {
@@ -152,7 +115,7 @@ func TestListVaultEntries_IncludeControlPlane(t *testing.T) {
 	for _, e := range got.Entries {
 		scopes[string(e.Scope)] = true
 	}
-	for _, want := range []string{vaultScopeAgent, vaultScopeConnectedAccount, vaultScopeLlmConfig} {
+	for _, want := range []string{vaultscope.ScopeAgent, vaultscope.ScopeConnectedAccount, vaultscope.ScopeLlmConfig} {
 		if !scopes[want] {
 			t.Errorf("include-control-plane view missing scope %q (got %v)", want, scopes)
 		}

--- a/internal/app/handlers_local_vault_user.go
+++ b/internal/app/handlers_local_vault_user.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
-	"strings"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 )
 
 // userServiceRe is the allow-list for the `{service}` path parameter of
@@ -263,25 +263,6 @@ func (s *apiServer) DeleteUserCredentials(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// userServiceFromVaultPath is the inverse of userCredentialVaultPath: it
-// extracts the service name from a `user/<service>` vault path. It returns
-// false for any path that does not match the scheme so the list filter
-// ignores non-user entries (agent OAuth envelopes, bindings, etc.). The
-// returned service must still pass validateUserService — a stored path that
-// somehow contains a `/` or other metacharacter in the service segment is
-// rejected rather than surfaced.
-func userServiceFromVaultPath(path string) (string, bool) {
-	const prefix = "user/"
-	if !strings.HasPrefix(path, prefix) {
-		return "", false
-	}
-	service := path[len(prefix):]
-	if !validateUserService(service) {
-		return "", false
-	}
-	return service, true
-}
-
 // ListUserCredentials returns the service names that have a user-level
 // credential envelope stored at `user/<service>`, with plaintext metadata
 // only — never the credential value (ADR-0011). It works on a locked vault
@@ -301,7 +282,7 @@ func (s *apiServer) ListUserCredentials(w http.ResponseWriter, r *http.Request) 
 
 	list := api.UserCredentialsList{Services: []api.UserCredentialSummary{}}
 	for _, e := range entries {
-		service, ok := userServiceFromVaultPath(e.Path)
+		service, ok := vaultscope.UserServiceFromVaultPath(e.Path)
 		if !ok {
 			continue
 		}

--- a/internal/app/handlers_local_vault_user_test.go
+++ b/internal/app/handlers_local_vault_user_test.go
@@ -744,25 +744,5 @@ func TestListUserCredentials_ListErrorReturns500(t *testing.T) {
 	assertErrorCode(t, rec, "vault_list_failed")
 }
 
-func TestUserServiceFromVaultPath(t *testing.T) {
-	cases := []struct {
-		path   string
-		want   string
-		wantOK bool
-	}{
-		{"user/github", "github", true},
-		{"user/git-hub_1", "git-hub_1", true},
-		{"agents/claude/oauth", "", false},
-		{"user/", "", false},
-		{"user/has/slash", "", false},
-		{"user/Bad", "", false},
-		{"other/github", "", false},
-	}
-	for _, c := range cases {
-		got, ok := userServiceFromVaultPath(c.path)
-		if ok != c.wantOK || got != c.want {
-			t.Errorf("userServiceFromVaultPath(%q) = (%q, %v), want (%q, %v)",
-				c.path, got, ok, c.want, c.wantOK)
-		}
-	}
-}
+// userServiceFromVaultPath moved to internal/vaultscope (as
+// UserServiceFromVaultPath) and is tested there.

--- a/internal/vaultscope/vaultscope.go
+++ b/internal/vaultscope/vaultscope.go
@@ -1,0 +1,159 @@
+// Package vaultscope is the single source of truth for classifying a raw
+// vault path into its namespace scope. It is shared by the daemon's vault
+// union endpoint (which projects it into the `VaultEntry.scope` wire field)
+// and the `aileron secret list` CLI (which filters offline by the same
+// classification), so both surfaces agree on exactly one code path for what
+// a path means.
+//
+// The classification here is intentionally self-contained: it depends only
+// on internal/binding for the binding-path grammar. It does NOT depend on
+// internal/app, so the CLI can classify a path without spawning or reaching
+// the daemon. The write-path validators and path builders (which construct
+// `agents/<name>/<purpose>` and `user/<service>` keys) stay in internal/app
+// where the credential handlers live; vaultscope only ever parses and
+// classifies already-stored paths, never constructs them.
+package vaultscope
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// Namespace prefixes. The two control-plane namespaces
+// (ConnectedAccountsVaultPrefix, LlmConfigVaultPrefix) are tenant-keyed
+// records the cloud-shaped control plane owns (a per-user connected OAuth
+// account and a per-owner LLM config), not local single-user `aileron
+// launch` credentials. Classify flags them so a caller can exclude them
+// from the default union view; an explicit opt-in includes them. The other
+// prefixes name locally-owned namespaces that are always part of the union.
+const (
+	AgentVaultPrefix             = "agents/"
+	UserVaultPrefix              = "user/"
+	SecretVaultPrefix            = "secret/"
+	ConnectedAccountsVaultPrefix = "connected-accounts/"
+	LlmConfigVaultPrefix         = "llm-config/"
+)
+
+// Scope labels surfaced in the union view's `scope` field. These mirror the
+// documented values in the OpenAPI `VaultEntry.scope` description; the spec
+// models the field as a free-form string (not an enum) so these literals do
+// not collide with the same words in other enums and force a global
+// enum-constant rename in the generated code.
+const (
+	ScopeAgent            = "agent"
+	ScopeUser             = "user"
+	ScopeBinding          = "binding"
+	ScopeConnectedAccount = "connected-account"
+	ScopeLlmConfig        = "llm-config"
+	ScopeSecret           = "secret"
+	ScopeOther            = "other"
+)
+
+// agentPurposeSegmentRe and userServiceSegmentRe are private, defensive
+// allow-lists for the trailing segment of a stored path. They mirror the
+// write-path validators in internal/app (`^[a-z0-9][a-z0-9_-]*$`) so a
+// malformed stored path can never surface a junk purpose or service in a
+// classification. They are deliberately duplicated here rather than shared
+// with the app write path: moving the app validators into this package
+// would force a circular import (app -> vaultscope -> app) or a wide,
+// security-sensitive rewrite of the write handlers for zero functional
+// benefit. Keeping a small private copy for parse-time defense keeps the
+// write-path behavior byte-identical and this package self-contained.
+var (
+	agentPurposeSegmentRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+	userServiceSegmentRe  = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+)
+
+// AgentNameAndPurposeFromVaultPath splits an `agents/<name>/<purpose>` vault
+// path into its name and purpose segments. It accepts any conforming path
+// (any purpose, not just `oauth`) so a list surfaces apikey-only agents that
+// an `/oauth`-suffix match would make invisible. It returns false for any
+// path that does not match the scheme so a list filter ignores non-agent
+// entries (user credentials, bindings, etc.).
+//
+// The purpose segment is re-validated through the same allow-list the write
+// path uses so a malformed stored path can never surface a junk purpose.
+func AgentNameAndPurposeFromVaultPath(path string) (name, purpose string, ok bool) {
+	if !strings.HasPrefix(path, AgentVaultPrefix) {
+		return "", "", false
+	}
+	rest := path[len(AgentVaultPrefix):]
+	// Exactly two remaining segments: <name>/<purpose>. A name or purpose
+	// containing a slash (extra segments) is rejected.
+	parts := strings.Split(rest, "/")
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	name, purpose = parts[0], parts[1]
+	if name == "" || purpose == "" {
+		return "", "", false
+	}
+	if !agentPurposeSegmentRe.MatchString(purpose) {
+		return "", "", false
+	}
+	return name, purpose, true
+}
+
+// UserServiceFromVaultPath extracts the service name from a `user/<service>`
+// vault path. It returns false for any path that does not match the scheme
+// so a list filter ignores non-user entries (agent OAuth envelopes,
+// bindings, etc.). The returned service must still pass the defensive
+// allow-list: a stored path that somehow contains a `/` or other
+// metacharacter in the service segment is rejected rather than surfaced.
+func UserServiceFromVaultPath(path string) (string, bool) {
+	if !strings.HasPrefix(path, UserVaultPrefix) {
+		return "", false
+	}
+	service := path[len(UserVaultPrefix):]
+	if !userServiceSegmentRe.MatchString(service) {
+		return "", false
+	}
+	return service, true
+}
+
+// Classify maps a raw vault path to its scope label and reports whether it
+// belongs to a control-plane namespace.
+//
+// The locally-owned namespaces (`agents/`, `user/`, `secret/`, and
+// capability bindings — which include connector credentials like
+// `connectors/<provider>/default` and OAuth bindings like
+// `oauth2/google/...`) are always part of the union. The two tenant-keyed
+// control-plane namespaces (`connected-accounts/`, `llm-config/`) are
+// classified too but flagged so the caller can exclude them by default.
+//
+// Classification order is load-bearing: the prefixed namespaces are checked
+// before the generic three-segment binding shape, because an
+// `agents/<name>/<purpose>` path also matches the binding name grammar
+// (`<kind>/<service>/<identity>`) and must classify as `agent`, not
+// `binding`.
+//
+// Every path receives a scope. A path matching none of the known namespaces
+// classifies as `other` so the union never silently hides an entry —
+// surfacing unknown entries is the whole point of the union view (#1402).
+func Classify(path string) (scope string, controlPlane bool) {
+	switch {
+	case strings.HasPrefix(path, ConnectedAccountsVaultPrefix):
+		return ScopeConnectedAccount, true
+	case strings.HasPrefix(path, LlmConfigVaultPrefix):
+		return ScopeLlmConfig, true
+	case strings.HasPrefix(path, SecretVaultPrefix):
+		// Secrets set via `aileron secret set` are locally-owned, so they
+		// are part of the default union (controlPlane=false). This is
+		// checked before the binding grammar below because a slash-bearing
+		// secret path could otherwise match the three-segment binding
+		// shape.
+		return ScopeSecret, false
+	}
+	if _, _, ok := AgentNameAndPurposeFromVaultPath(path); ok {
+		return ScopeAgent, false
+	}
+	if _, ok := UserServiceFromVaultPath(path); ok {
+		return ScopeUser, false
+	}
+	if binding.IsBindingPath(path) {
+		return ScopeBinding, false
+	}
+	return ScopeOther, false
+}

--- a/internal/vaultscope/vaultscope_test.go
+++ b/internal/vaultscope/vaultscope_test.go
@@ -1,0 +1,96 @@
+package vaultscope
+
+import "testing"
+
+// Classify is the load-bearing classifier shared by the daemon vault union
+// and the `aileron secret list` CLI; pin each namespace and the ordering
+// edge case where an agent path also matches the binding grammar.
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		path        string
+		wantScope   string
+		wantControl bool
+	}{
+		{"agents/claude/oauth", ScopeAgent, false},
+		{"agents/codex/apikey", ScopeAgent, false},
+		{"user/github", ScopeUser, false},
+		// Connector + OAuth capability bindings are three-segment binding
+		// names. They are exactly the entries the old typed-endpoint list
+		// silently hid (#1402); the union must classify them as bindings.
+		{"connectors/github/default", ScopeBinding, false},
+		{"oauth2/google/default", ScopeBinding, false},
+		{"github/repo/me", ScopeBinding, false},
+		// Control-plane namespaces: classified but flagged for exclusion.
+		{"connected-accounts/usr_123/slack", ScopeConnectedAccount, true},
+		{"llm-config/user/usr_123", ScopeLlmConfig, true},
+		// Secrets set via `aileron secret set` live under `secret/` and are
+		// locally-owned (not control-plane).
+		{"secret/foo", ScopeSecret, false},
+		// A `secret/`-prefixed path that also looks three-segment must still
+		// classify as `secret`, proving the prefix check wins over the
+		// binding grammar.
+		{"secret/github/repo", ScopeSecret, false},
+		// Anything matching no known namespace must still surface as `other`
+		// rather than vanish.
+		{"weird-single-segment", ScopeOther, false},
+		{"_internal/reserved", ScopeOther, false},
+	}
+	for _, c := range cases {
+		scope, control := Classify(c.path)
+		if scope != c.wantScope || control != c.wantControl {
+			t.Errorf("Classify(%q) = (%q, %v), want (%q, %v)",
+				c.path, scope, control, c.wantScope, c.wantControl)
+		}
+	}
+}
+
+func TestAgentNameAndPurposeFromVaultPath(t *testing.T) {
+	cases := []struct {
+		path        string
+		wantName    string
+		wantPurpose string
+		wantOK      bool
+	}{
+		{"agents/claude/oauth", "claude", "oauth", true},
+		{"agents/codex/oauth", "codex", "oauth", true},
+		{"agents/claude/apikey", "claude", "apikey", true}, // apikey now conforms
+		{"agents//apikey", "", "", false},                  // empty name
+		{"agents/claude", "", "", false},                   // missing purpose segment
+		{"agents/oauth", "", "", false},                    // only two segments
+		{"agents/a/b/oauth", "", "", false},                // nested name / extra segment
+		{"some/other/path", "", "", false},                 // wrong prefix
+		{"user/github", "", "", false},                     // user namespace, not agent
+		{"agents/claude/oauth/extra", "", "", false},       // extra segment
+		{"agents/claude/OAUTH", "", "", false},             // purpose fails the allow-list
+	}
+	for _, c := range cases {
+		gotName, gotPurpose, gotOK := AgentNameAndPurposeFromVaultPath(c.path)
+		if gotOK != c.wantOK || gotName != c.wantName || gotPurpose != c.wantPurpose {
+			t.Errorf("AgentNameAndPurposeFromVaultPath(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.path, gotName, gotPurpose, gotOK, c.wantName, c.wantPurpose, c.wantOK)
+		}
+	}
+}
+
+func TestUserServiceFromVaultPath(t *testing.T) {
+	cases := []struct {
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{"user/github", "github", true},
+		{"user/git-hub_1", "git-hub_1", true},
+		{"agents/claude/oauth", "", false},
+		{"user/", "", false},
+		{"user/has/slash", "", false},
+		{"user/Bad", "", false},
+		{"other/github", "", false},
+	}
+	for _, c := range cases {
+		got, ok := UserServiceFromVaultPath(c.path)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("UserServiceFromVaultPath(%q) = (%q, %v), want (%q, %v)",
+				c.path, got, ok, c.want, c.wantOK)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Sub-issue 3 of the vault-scope-classifier umbrella. Extracts the vault-path classification logic into a new self-contained `internal/vaultscope` package, so the daemon vault union endpoint and the `aileron secret list` CLI share exactly one definition of a path's scope.

- **New `internal/vaultscope`** holds the exported prefix consts, exported scope-label consts (`ScopeAgent … ScopeOther`), the two parse predicates (`AgentNameAndPurposeFromVaultPath`, `UserServiceFromVaultPath`), and `Classify(path) (scope, controlPlane)` — moved verbatim from `internal/app` with the load-bearing ordering (prefixes → agent → user → binding → other) and doc comments preserved. It imports only `internal/binding`, so the CLI can classify a path offline with no daemon spawn and no import cycle.
- **Daemon repointed:** `ListVaultEntries`, `ListAgentCredentials`, and `ListUserCredentials` now call `vaultscope.*`. The prefix/scope consts, `classifyVaultPath`, `agentNameAndPurposeFromVaultPath`, and `userServiceFromVaultPath` are deleted from the app handlers. The union wire shape and scope strings are byte-identical.
- **`secret list` reprojected:** `runSecretList` swaps the ad-hoc `Metadata.Type == "secret"` filter for `vaultscope.Classify(e.Path) == vaultscope.ScopeSecret`, still reading the local `FileVault` directly (offline). It continues to print the full `secret/<name>` path, matching `secret set`'s output and the `vault:secret/<name>` reference.

### Deliberate scope boundary
The write-path validators, path builders, and `resolveAgentCredentialPurpose` stay in `internal/app`. Moving them would force an `app → vaultscope → app` cycle or a wide, security-sensitive rewrite of the GET/PUT/DELETE handlers for zero functional benefit. `vaultscope` instead carries small **private** copies of the two defensive segment regexes (`^[a-z0-9][a-z0-9_-]*$`) used purely for parse-time classification, keeping write-path behavior byte-identical. No OpenAPI or generated-code changes.

## Test plan

- New `internal/vaultscope/vaultscope_test.go` (100% statement coverage): `TestClassify` (agent-vs-binding ordering, `secret` scope, control-plane flags, `other` fallback) plus the two predicate tests, moved from the app suite and repointed to the exported names.
- `internal/app` union tests (`TestListVaultEntries_*`) are the unchanged guard that the daemon union endpoint's observable behavior is preserved; repointed from `vaultScope*` to `vaultscope.Scope*`. The moved predicate/classifier tests are removed from the app suite.
- `cmd/aileron` secret-list tests reseeded to the canonical `secret/<name>` form so the path-based classifier surfaces them; `TestRunSecret_ListOnlyReturnsSecretScopedEntries` is the preserved regression that `secret list` returns only `secret/`-scoped entries (renamed to reflect the classifier-based filter). `TestRunSecret_ListEmptyAfterFilter` survives unchanged.
- `go build`, `go vet`, and targeted `go test` pass green for all three modules.

Closes #1716
