### PR TITLE
fix(cli): count only secret/ entries in status vault view

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1548,7 +1549,23 @@ func showStatusVault(dir string, w io.Writer) {
 		return
 	}
 
-	names := fv.Names()
+	entries, err := fv.List(context.Background())
+	if err != nil {
+		fmt.Fprintf(w, "  Vault file: %s (error: %v)\n", vaultPath, err)
+		return
+	}
+	// Count and list only `secret/`-scoped entries, using the same
+	// vault-scope classifier that `secret list` (runSecretList) treats as
+	// the single source of truth for "a secret". Without this filter, agent
+	// credentials (agents/<name>/...) and control-plane bindings
+	// (oauth2/<...>) leak into the "Secrets:" count and bullet list.
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if scope, _ := vaultscope.Classify(e.Path); scope == vaultscope.ScopeSecret {
+			names = append(names, e.Path)
+		}
+	}
+	sort.Strings(names)
 	fmt.Fprintf(w, "  Vault file: %s\n", vaultPath)
 	fmt.Fprintf(w, "  Secrets:    %d stored\n", len(names))
 	for _, name := range names {

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -961,9 +961,12 @@ func TestRunStatus_Vault(t *testing.T) {
 func TestRunStatus_VaultWithSecrets(t *testing.T) {
 	dir := setTestHome(t)
 
+	// `secret set` stores secrets under the `secret/<name>` path, which is
+	// what the vault-scope classifier recognizes as a secret. The status
+	// view counts and lists only those `secret/`-scoped entries.
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
 	os.MkdirAll(filepath.Dir(vaultPath), 0o700)
-	os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"slack_bot":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600)
+	os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"secret/slack_bot":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"status", "vault"}, newTestRegistry(), &stdout, &stderr)
@@ -974,7 +977,7 @@ func TestRunStatus_VaultWithSecrets(t *testing.T) {
 	if !strings.Contains(out, "1 stored") {
 		t.Error("expected '1 stored'")
 	}
-	if !strings.Contains(out, "slack_bot") {
+	if !strings.Contains(out, "secret/slack_bot") {
 		t.Error("expected secret name")
 	}
 }

--- a/cmd/aileron/status_vault_test.go
+++ b/cmd/aileron/status_vault_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// showStatusVault renders the "Vault" section of `aileron status`. Its
+// contract (mirroring `secret list` / runSecretList) is that the
+// "Secrets:" count and bullet list reflect ONLY `secret/`-scoped entries,
+// classified by the shared vault-scope classifier. Agent credentials
+// (agents/<name>/...) and control-plane / capability bindings
+// (oauth2/<...>) are stored in the same vault file but are not secrets,
+// so they must not leak into the count or the list.
+//
+// Regression for cw-review-residual #1717: showStatusVault previously
+// called the unfiltered fv.Names(), miscounting and listing every stored
+// path as a "Secret".
+func TestShowStatusVault_CountsAndListsSecretsOnly(t *testing.T) {
+	home := setTestHome(t)
+	vaultPath := filepath.Join(home, ".aileron", "secrets.json")
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate a mixed vault: one real secret, one agent credential, one
+	// capability binding. Only the secret should surface in the status view.
+	fv, err := vault.NewFileVault(vaultPath)
+	if err != nil {
+		t.Fatalf("NewFileVault: %v", err)
+	}
+	ctx := context.Background()
+	for _, path := range []string{
+		"secret/linear_token",
+		"agents/claude/oauth",
+		"oauth2/google/default",
+	} {
+		if err := fv.Put(ctx, path, []byte("v"), vault.Metadata{}); err != nil {
+			t.Fatalf("Put(%q): %v", path, err)
+		}
+	}
+
+	// Sanity: DefaultVaultPath resolves under the temp HOME so the real
+	// ~/.aileron is never touched.
+	if got := launch.DefaultVaultPath(); got != vaultPath {
+		t.Fatalf("DefaultVaultPath() = %q, want %q", got, vaultPath)
+	}
+
+	var out bytes.Buffer
+	showStatusVault(home, &out)
+	got := out.String()
+
+	if !strings.Contains(got, "Secrets:    1 stored") {
+		t.Errorf("status view = %q; want 'Secrets:    1 stored' (only the secret/ entry)", got)
+	}
+	if !strings.Contains(got, "- secret/linear_token") {
+		t.Errorf("status view = %q; want the secret listed", got)
+	}
+	if strings.Contains(got, "agents/claude/oauth") {
+		t.Errorf("status view = %q; agent credential leaked into Secrets list", got)
+	}
+	if strings.Contains(got, "oauth2/google/default") {
+		t.Errorf("status view = %q; capability binding leaked into Secrets list", got)
+	}
+}


### PR DESCRIPTION
## Summary

`aileron status vault` (`showStatusVault`) rendered its `Secrets:` count and bullet list from the unfiltered `fv.Names()`, so every stored vault path was counted and displayed as a "Secret". Agent credentials (`agents/<name>/...`) and capability/OAuth bindings (`oauth2/<...>`) live in the same vault file, so they leaked into the count and list and misrepresented what the operator has stored.

This mirrors the shipped `secret list` (`runSecretList`, refactored in #1722): list entries via `fv.List(context.Background())` and keep only those whose path classifies as `vaultscope.ScopeSecret` — the single source of truth for "a secret". Output is sorted for deterministic rendering (the vault `List` iterates a map).

This resolves the last remaining actionable finding from the plan-review residual.

Closes #1717

## Test plan

- New regression test `TestShowStatusVault_CountsAndListsSecretsOnly`: a mixed vault (`secret/linear_token` + `agents/claude/oauth` + `oauth2/google/default`) asserts the status view reports `Secrets: 1 stored`, lists only `secret/linear_token`, and does not leak the agent credential or the binding. Verified it fails before the fix (`3 stored`, all three leaked) and passes after.
- Updated existing `TestRunStatus_VaultWithSecrets` fixture to the real `secret/<name>` path that `secret set` writes (the old bare `slack_bot` key predated the `secret/` convention and now correctly classifies as non-secret).
- `go test ./cmd/aileron/` green; `go vet` clean; module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `status vault` now lists only `secret/`-scoped entries in the Secrets section.
  * Secret entries are shown in a consistent sorted order.
  * Mixed vault contents no longer inflate the Secrets count with other entry types.

* **Tests**
  * Added coverage for vault status output with mixed entry types.
  * Updated existing expectations to match the `secret/` path convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->