### PR TITLE
fix(cli): let vault delete remove secret/ entries via the local vault

### DIFF
--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -16,6 +17,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/vaultscope"
 )
 
 // Environment variable that supplies the vault passphrase non-
@@ -35,11 +37,13 @@ with its scope. --scope narrows to a single typed namespace.
 
 vault delete accepts any path vault list prints: an agent entry
 (agents/<name>/<purpose>, e.g. agents/claude/oauth), a user entry
-(user/<service>, e.g. user/github), or a binding
+(user/<service>, e.g. user/github), a locally-stored secret
+(secret/<name>, e.g. secret/linear_token), or a binding
 (<kind>/<service>/<identity>, e.g. aws_sigv4/athena/default). It
-dispatches to the matching namespace's delete endpoint. Control-plane
-entries (connected-accounts/, llm-config/) are managed by the control
-plane, not this CLI.
+dispatches to the matching namespace's delete endpoint; secret/ entries
+are removed from the local vault (where secret set writes them).
+Control-plane entries (connected-accounts/, llm-config/) are managed by
+the control plane, not this CLI.
 
 vault put remains agents-only: you create a binding with ` + "`binding setup`" + `,
 not ` + "`vault put`" + `.`
@@ -344,11 +348,19 @@ func runVaultDelete(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		return 1
 	}
 
+	// secret/<name> entries (written by `aileron secret set`) live in the
+	// local file vault, not behind a daemon namespace endpoint. Delete them
+	// through the same local-vault access `secret set` uses so
+	// `vault list` and `vault delete` stay symmetric (#1704, #1716).
+	if scope, _ := vaultscope.Classify(positionals[0]); scope == vaultscope.ScopeSecret {
+		return runVaultDeleteSecret(positionals[0], *yes, stdin, stdout, stderr)
+	}
+
 	target, ok := vaultDeleteTargetFor(positionals[0])
 	if !ok {
 		fmt.Fprintf(stderr, "error: %q is not a CLI-deletable vault path\n", positionals[0])
-		fmt.Fprintln(stderr, "vault delete accepts agents/<name>/<purpose>, user/<service>, or a binding")
-		fmt.Fprintln(stderr, "(<kind>/<service>/<identity>) — exactly what vault list prints. Control-plane")
+		fmt.Fprintln(stderr, "vault delete accepts agents/<name>/<purpose>, user/<service>, secret/<name>, or a")
+		fmt.Fprintln(stderr, "binding (<kind>/<service>/<identity>) — exactly what vault list prints. Control-plane")
 		fmt.Fprintln(stderr, "entries (connected-accounts/, llm-config/) are managed by the control plane.")
 		return 1
 	}
@@ -383,6 +395,79 @@ func runVaultDelete(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(respBody))
 		return 1
 	}
+}
+
+// runVaultDeleteSecret deletes a secret/<name> entry directly from the
+// local file vault, mirroring how `aileron secret set` writes it
+// (launch.DefaultVaultPath + readVaultPassphrase + launch.OpenLocalVault).
+// `vault list` surfaces secret/ entries but the daemon exposes no
+// namespace-scoped delete endpoint for them, so routing this branch to
+// the local vault restores the list/delete symmetry #1704 established
+// (the asymmetry called out in #1716). It is a `vault delete` branch, not
+// a separate `secret rm` command, so operators paste back exactly what
+// `vault list` prints.
+func runVaultDeleteSecret(arg string, yes bool, stdin io.Reader, stdout, stderr io.Writer) int {
+	// secret/<name> is a single-segment namespace, exactly like
+	// `secret set` writes: reject a name that itself contains a '/'.
+	name := strings.TrimPrefix(arg, vaultscope.SecretVaultPrefix)
+	if name == "" || strings.Contains(name, "/") {
+		fmt.Fprintf(stderr, "error: secret name must be a single segment (no '/'): %q\n", arg)
+		return 1
+	}
+	storedPath := vaultscope.SecretVaultPrefix + name
+
+	if !yes {
+		answer := promptLine(stdin, stdout, fmt.Sprintf("Delete %s? [y/N]: ", storedPath))
+		if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
+			fmt.Fprintln(stdout, "cancelled")
+			return 0
+		}
+	}
+
+	vaultPath := launch.DefaultVaultPath()
+	passphrase, _, err := readVaultPassphrase("", "Vault passphrase: ", stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if passphrase == "" {
+		fmt.Fprintln(stderr, "error: passphrase cannot be empty")
+		return 1
+	}
+
+	v, err := launch.OpenLocalVault(vaultPath, passphrase)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	// The local file vault's Delete is idempotent (no error when the path
+	// is absent), but the daemon-backed branch reports a not-found miss.
+	// Check existence first so `vault delete secret/<name>` gives the same
+	// "no credential entry" signal for a name that was never stored.
+	entries, err := v.List(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	found := false
+	for _, e := range entries {
+		if e.Path == storedPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		fmt.Fprintf(stderr, "error: no credential entry for %s\n", storedPath)
+		return 1
+	}
+
+	if err := v.Delete(context.Background(), storedPath); err != nil {
+		fmt.Fprintf(stderr, "error deleting secret: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Deleted %s\n", storedPath)
+	return 0
 }
 
 // runVaultList prints the credential entries the daemon holds. Output

--- a/cmd/aileron/vault_test.go
+++ b/cmd/aileron/vault_test.go
@@ -328,3 +328,134 @@ func TestRunSecretSet_HonorsEnvPassphrase(t *testing.T) {
 		t.Errorf("stored value = %q, want %q", string(got.Value), "the-secret-value")
 	}
 }
+
+// setSecretForTest stores secret/<name> in the temp-home vault via the
+// same `aileron secret set` path production uses, so the delete tests
+// exercise a genuinely-written entry. The vault passphrase is supplied
+// through AILERON_VAULT_PASSPHRASE (already set by the caller) and the
+// secret value comes from the scripted prompt.
+func setSecretForTest(t *testing.T, name, value string) {
+	t.Helper()
+	restore := scriptPrompt(value)
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"secret", "set", name}, newTestRegistry(), &stdout, &stderr); code != 0 {
+		t.Fatalf("secret set %s: exit = %d; stderr=%s", name, code, stderr.String())
+	}
+}
+
+// TestRunVaultDelete_SecretRoundTrip is the #1716 regression guard: a
+// secret written with `aileron secret set` (stored at secret/<name> in
+// the local vault and surfaced by `vault list`) must be deletable with
+// `aileron vault delete secret/<name>`. Before the fix vaultDeleteTargetFor
+// had no secret/ case, so the command returned the not-CLI-deletable
+// rejection — asymmetric with list. This asserts the local-vault delete
+// path removes the entry.
+func TestRunVaultDelete_SecretRoundTrip(t *testing.T) {
+	vaultPath := vaultInitTempHome(t)
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envVaultPassphrase, "from-env-pass")
+
+	setSecretForTest(t, "linear_token", "the-secret-value")
+
+	// Confirm it is present before delete.
+	v, err := vault.Unlock(vaultPath, "from-env-pass")
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if _, err := v.Get(t.Context(), "secret/linear_token"); err != nil {
+		t.Fatalf("precondition Get: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"delete", "secret/linear_token", "--yes"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("vault delete: exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Deleted secret/linear_token") {
+		t.Errorf("stdout = %q; want 'Deleted secret/linear_token'", stdout.String())
+	}
+
+	// The entry must be gone.
+	v2, err := vault.Unlock(vaultPath, "from-env-pass")
+	if err != nil {
+		t.Fatalf("Unlock after delete: %v", err)
+	}
+	if _, err := v2.Get(t.Context(), "secret/linear_token"); err == nil {
+		t.Errorf("secret/linear_token still present after delete")
+	}
+}
+
+// TestRunVaultDelete_SecretNotFound: deleting a secret/ path that was
+// never stored reports the not-found error (exit 1), symmetric with the
+// daemon-backed namespaces' 404 handling rather than silently succeeding
+// on the idempotent local Delete.
+func TestRunVaultDelete_SecretNotFound(t *testing.T) {
+	vaultPath := vaultInitTempHome(t)
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envVaultPassphrase, "from-env-pass")
+
+	// Create the vault with a real entry so OpenLocalVault validates the
+	// passphrase, then target a different, absent name.
+	setSecretForTest(t, "present", "v")
+
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"delete", "secret/absent", "--yes"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("vault delete absent: exit = %d, want 1; stdout=%s stderr=%s",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no credential entry for secret/absent") {
+		t.Errorf("stderr = %q; want 'no credential entry for secret/absent'", stderr.String())
+	}
+}
+
+// TestRunVaultDelete_SecretRejectsMultiSegment: secret/ is a single-
+// segment namespace (matching `secret set`), so a name containing a '/'
+// is rejected before the vault is touched.
+func TestRunVaultDelete_SecretRejectsMultiSegment(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"delete", "secret/foo/bar", "--yes"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "single segment") {
+		t.Errorf("stderr = %q; want 'single segment' rejection", stderr.String())
+	}
+}
+
+// TestRunVaultDelete_SecretInteractiveCancel: without --yes the secret
+// branch honors the confirmation prompt; a non-y answer cancels and the
+// entry survives.
+func TestRunVaultDelete_SecretInteractiveCancel(t *testing.T) {
+	vaultPath := vaultInitTempHome(t)
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envVaultPassphrase, "from-env-pass")
+	setSecretForTest(t, "keep", "v")
+
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"delete", "secret/keep"},
+		strings.NewReader("n\n"), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cancelled") {
+		t.Errorf("stdout = %q; want 'cancelled'", stdout.String())
+	}
+	v, err := vault.Unlock(vaultPath, "from-env-pass")
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if _, err := v.Get(t.Context(), "secret/keep"); err != nil {
+		t.Errorf("secret/keep should survive a cancelled delete: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Resolves the remaining actionable findings from cw-review-residual #1721 (plan findings for #1716).

`aileron vault list` surfaces `secret/<name>` entries (written by `aileron secret set`, stored in the local vault at `secret/<name>`), but `aileron vault delete secret/<name>` had no `secret/` case — it fell through `vaultDeleteTargetFor` and returned the "not a CLI-deletable vault path" rejection. That broke the list/delete symmetry #1704 established.

This adds a `secret/` branch to `vault delete`:

- `runVaultDelete` classifies the path with `vaultscope.Classify`; when the scope is `secret`, it routes to a new local-vault delete path (`runVaultDeleteSecret`) instead of the HTTP daemon dispatch.
- `runVaultDeleteSecret` mirrors how `secret set` writes: `launch.DefaultVaultPath()` + passphrase via `readVaultPassphrase` + `launch.OpenLocalVault(...).Delete(ctx, "secret/"+name)`.
- The name is validated as a single segment (no `/`), matching `secret set`.
- The local `FileVault.Delete` is idempotent (no error on a missing key), so the branch existence-checks via `List` first and reports `no credential entry for secret/<name>` for an absent name — symmetric with the daemon-backed namespaces' 404 handling.
- Confirmation prompt (`--yes` to skip) is preserved, consistent with the other delete branches.
- Usage text and the rejection help now list `secret/<name>` alongside the other deletable namespaces.

Kept as a `vault delete` branch, not a new `secret rm` command, so operators paste back exactly what `vault list` prints.

The second triaged finding (CLI delete predicates re-enumerate vault namespaces instead of importing `internal/vaultscope`) was operator-answered as "file a small follow-up sub-issue under umbrella #1713, tracked as its own unit, not folded here." Filed as #1724 and linked as a sub-issue of #1713.

## Test plan

- `go test github.com/ALRubinger/aileron/cmd/aileron` — green.
- New regression tests in `cmd/aileron/vault_test.go`:
  - `TestRunVaultDelete_SecretRoundTrip` — the #1716 guard: `secret set` then `vault delete secret/<name>` succeeds and the entry is gone. Fails before the fix (old code returns the not-CLI-deletable rejection).
  - `TestRunVaultDelete_SecretNotFound` — deleting an absent `secret/` path returns exit 1 with the not-found message.
  - `TestRunVaultDelete_SecretRejectsMultiSegment` — `secret/foo/bar` is rejected as multi-segment before touching the vault.
  - `TestRunVaultDelete_SecretInteractiveCancel` — without `--yes`, a non-`y` answer cancels and the entry survives.
- `go vet` clean on the changed package.

Closes #1721

🤖 Generated with [Claude Code](https://claude.com/claude-code)
