### PR TITLE
fix(cli): make LookupAnyVersion deterministic and advise on hash-pinning

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -2225,7 +2225,24 @@ func runConnectorInstall(args []string, stdin io.Reader, stdout, stderr io.Write
 	}
 	fmt.Fprintf(stdout, "%s: %s@%s\n  hash: %s\n  path: %s\n",
 		verb, resp.Fqn, resp.Version, resp.Hash, resp.EntryDir)
+	if !resp.AlreadyInstalled {
+		printPinAdvisory(stdout)
+	}
 	return 0
+}
+
+// printPinAdvisory reminds the operator, after a fresh connector install,
+// that Aileron pins connectors by content hash (ADR-0004). Existing
+// actions and flight plans keep running whatever (version, hash) they
+// were published against until they are reinstalled or re-published; a
+// new connector install does not retroactively re-resolve them. This is
+// a static advisory only — nothing re-resolves at execution time.
+func printPinAdvisory(w io.Writer) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Note: connectors are pinned by content hash (ADR-0004).")
+	fmt.Fprintln(w, "  Existing actions and flight plans keep their pinned version until")
+	fmt.Fprintln(w, "  reinstalled or re-published. Run `aileron connector check` to see")
+	fmt.Fprintln(w, "  what is installed and whether newer versions are available.")
 }
 
 // tryHubInstallDecisionFlow asks the daemon for the Hub install-decision
@@ -2728,6 +2745,9 @@ func doConfirmedInstall(fqn, version, expectedHash, fingerprint string, stdout, 
 	}
 	fmt.Fprintf(stdout, "%s: %s@%s\n  hash: %s\n  path: %s\n",
 		verb, installed.Fqn, installed.Version, installed.Hash, installed.EntryDir)
+	if !installed.AlreadyInstalled {
+		printPinAdvisory(stdout)
+	}
 	return 0
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -2487,10 +2487,88 @@ func TestRunConnector_InstallHappyPath(t *testing.T) {
 		!strings.Contains(string(seenInstallBody), `"version":"1.0.0"`) {
 		t.Errorf("body = %s", seenInstallBody)
 	}
-	for _, want := range []string{"Connector install preview", "Installed:", "github://acme/x@1.0.0", "sha256:abc", "/path/to/entry"} {
+	for _, want := range []string{
+		"Connector install preview", "Installed:", "github://acme/x@1.0.0",
+		"sha256:abc", "/path/to/entry",
+		// Fresh installs advise that connectors are content-hash-pinned
+		// (ADR-0004) and existing actions/flight plans keep their pinned
+		// version until reinstalled/re-published, pointing at the check cmd.
+		"pinned by content hash", "aileron connector check",
+	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Errorf("stdout missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+// TestRunConnector_InstallFreshEmitsPinAdvisory asserts the direct
+// (preview) path emits the content-hash-pin advisory only after a fresh
+// install, so operators learn that already-published actions/flight
+// plans keep their pinned (version, hash) until reinstalled per ADR-0004.
+func TestRunConnector_InstallFreshEmitsPinAdvisory(t *testing.T) {
+	connectorInstallServer(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"fqn":"github://acme/x","version":"1.0.0","hash":"sha256:abc","entry_dir":"/path","already_installed":false}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector", "install", "github://acme/x@1.0.0", "--yes"},
+		newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pinned by content hash") {
+		t.Errorf("fresh install missing pin advisory:\n%s", stdout.String())
+	}
+}
+
+// TestRunConnector_InstallAlreadyInstalledResponseSkipsPinAdvisory asserts
+// the advisory is suppressed when the install endpoint reports the
+// connector was already present. A no-op install must not nag; the
+// advisory is about the effect of adding *new* content.
+func TestRunConnector_InstallAlreadyInstalledResponseSkipsPinAdvisory(t *testing.T) {
+	connectorInstallServer(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"fqn":"github://acme/x","version":"1.0.0","hash":"sha256:abc","entry_dir":"/path","already_installed":true}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector", "install", "github://acme/x@1.0.0", "--yes"},
+		newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Already installed") {
+		t.Errorf("expected 'Already installed' in output: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "pinned by content hash") {
+		t.Errorf("advisory should be suppressed on already-installed:\n%s", stdout.String())
+	}
+}
+
+// TestRunConnector_InstallHubPathEmitsPinAdvisory asserts the Hub
+// install-decision path (doConfirmedInstall) also emits the pin advisory
+// after a fresh install, so both install code paths share the same
+// ADR-0004 messaging.
+func TestRunConnector_InstallHubPathEmitsPinAdvisory(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/x","publisher_github":"acme","fingerprint":"AB:CD","trust_state":"trusted"}`)
+		case "/connectors/install":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/x","version":"1.0.0","hash":"sha256:abc","entry_dir":"/path","already_installed":false}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector", "install", "github://acme/x@1.0.0", "--yes"},
+		newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pinned by content hash") {
+		t.Errorf("hub-path fresh install missing pin advisory:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cstore/store.go
+++ b/internal/cstore/store.go
@@ -169,10 +169,18 @@ func (s *Store) LookupAnyVersion(fqn FQN) (Ref, string, bool) {
 			continue
 		}
 		version := strings.TrimPrefix(k, prefix)
-		if !found || semver.Compare("v"+version, "v"+bestVersion) > 0 {
+		if !found {
+			bestVersion, bestHash, found = version, h, true
+			continue
+		}
+		// SemVer precedence first; on an exact precedence tie (e.g. two
+		// versions differing only in build metadata, which semver.Compare
+		// treats as equal) fall back to lexical version order so the
+		// winner never depends on map iteration order.
+		cmp := semver.Compare("v"+version, "v"+bestVersion)
+		if cmp > 0 || (cmp == 0 && version > bestVersion) {
 			bestVersion = version
 			bestHash = h
-			found = true
 		}
 	}
 	if !found {

--- a/internal/cstore/store.go
+++ b/internal/cstore/store.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"golang.org/x/mod/semver"
 )
 
 // Store is the on-disk content-addressed connector store rooted at a
@@ -143,20 +145,40 @@ func (s *Store) ListInstalled() []Ref {
 
 // LookupAnyVersion returns one installed (Ref, hash) pair for the
 // given FQN, or `false` when no version of the connector is installed.
-// Multiple installed versions return an unspecified one — callers that
-// need a specific version should use Lookup. Used by the binding setup
-// flow which is FQN-scoped, not version-scoped.
+// When multiple versions of the FQN are installed it deterministically
+// returns the SemVer-highest one — Go randomizes map iteration, so
+// picking the highest version keeps the result stable across runs
+// rather than depending on iteration order. Callers that need a
+// specific version should use Lookup. Used by the binding setup and
+// preview flows which are FQN-scoped, not version-scoped.
+//
+// Index versions are strict SemVer with no leading "v" (see ADR-0004);
+// golang.org/x/mod/semver requires the "v" prefix, so it is prepended
+// only for comparison.
 func (s *Store) LookupAnyVersion(fqn FQN) (Ref, string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	prefix := fqn.String() + "@"
+	var (
+		bestVersion string
+		bestHash    string
+		found       bool
+	)
 	for k, h := range s.index {
-		if strings.HasPrefix(k, prefix) {
-			version := strings.TrimPrefix(k, prefix)
-			return Ref{FQN: fqn, Version: version}, h, true
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		version := strings.TrimPrefix(k, prefix)
+		if !found || semver.Compare("v"+version, "v"+bestVersion) > 0 {
+			bestVersion = version
+			bestHash = h
+			found = true
 		}
 	}
-	return Ref{}, "", false
+	if !found {
+		return Ref{}, "", false
+	}
+	return Ref{FQN: fqn, Version: bestVersion}, bestHash, true
 }
 
 // LoadIndex reads the index file from disk into memory. A missing index

--- a/internal/cstore/store_test.go
+++ b/internal/cstore/store_test.go
@@ -249,3 +249,39 @@ func TestStore_LookupAnyVersion_ReturnsAnyInstalledVersion(t *testing.T) {
 		t.Errorf("hash = %q", gotHash)
 	}
 }
+
+func TestStore_LookupAnyVersion_ReturnsHighestSemVerDeterministically(t *testing.T) {
+	// Contract: when multiple versions of an FQN are installed,
+	// LookupAnyVersion returns the SemVer-highest one, and does so
+	// deterministically. Go randomizes map iteration, so the previous
+	// "return the first prefix match" behavior could return any installed
+	// version depending on the run. This regression test installs several
+	// versions and asserts the highest is returned on every iteration.
+	dir := t.TempDir()
+	store := NewStore(dir)
+	fqn, _ := ParseFQN("github://acme/x")
+
+	// Populate out of SemVer order to prove the selection is by version,
+	// not insertion or iteration order. 2.0.0 is the highest.
+	store.index["github://acme/x@1.0.0"] = "sha256:aaaa"
+	store.index["github://acme/x@2.0.0"] = "sha256:bbbb"
+	store.index["github://acme/x@1.10.0"] = "sha256:cccc"
+	store.index["github://acme/x@1.2.0"] = "sha256:dddd"
+	// A different FQN sharing the store must never leak into the result.
+	store.index["github://acme/y@9.9.9"] = "sha256:eeee"
+
+	// Repeat so map-iteration randomization would surface any
+	// nondeterminism as a flake rather than a silent pass.
+	for i := 0; i < 100; i++ {
+		gotRef, gotHash, ok := store.LookupAnyVersion(fqn)
+		if !ok {
+			t.Fatal("LookupAnyVersion = ok=false with versions installed")
+		}
+		if gotRef.Version != "2.0.0" {
+			t.Fatalf("iteration %d: Version = %q, want highest 2.0.0", i, gotRef.Version)
+		}
+		if gotHash != "sha256:bbbb" {
+			t.Fatalf("iteration %d: hash = %q, want sha256:bbbb", i, gotHash)
+		}
+	}
+}

--- a/internal/cstore/store_test.go
+++ b/internal/cstore/store_test.go
@@ -285,3 +285,31 @@ func TestStore_LookupAnyVersion_ReturnsHighestSemVerDeterministically(t *testing
 		}
 	}
 }
+
+func TestStore_LookupAnyVersion_TieBreakIsStable(t *testing.T) {
+	// Two versions that differ only in SemVer build metadata compare
+	// equal under semver precedence rules. The result must still be
+	// stable across runs rather than depending on map iteration order.
+	dir := t.TempDir()
+	store := NewStore(dir)
+	fqn, _ := ParseFQN("github://acme/x")
+	store.index["github://acme/x@1.0.0+a"] = "sha256:1111"
+	store.index["github://acme/x@1.0.0+b"] = "sha256:2222"
+
+	var firstRef Ref
+	var firstHash string
+	for i := 0; i < 100; i++ {
+		gotRef, gotHash, ok := store.LookupAnyVersion(fqn)
+		if !ok {
+			t.Fatal("LookupAnyVersion = ok=false with versions installed")
+		}
+		if i == 0 {
+			firstRef, firstHash = gotRef, gotHash
+			continue
+		}
+		if gotRef != firstRef || gotHash != firstHash {
+			t.Fatalf("iteration %d: got (%v, %q), want stable (%v, %q)",
+				i, gotRef, gotHash, firstRef, firstHash)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two bounded, independent fixes from feedback triage (#1727). Both keep ADR-0004's frozen-by-hash contract intact: no floating/"latest" resolution, no execution-path re-resolution, no relaxing of validate.go's hash-required rule.

1. **`LookupAnyVersion` determinism (correctness fix).** `internal/cstore/store.go` ranged the in-memory index map and returned the *first* prefix match. Go randomizes map iteration, so the returned version was non-deterministic (the doc comment admitted it returned an "unspecified" version). It now collects every `"<FQN>@"` index key and returns the SemVer-highest version deterministically, reusing `golang.org/x/mod/semver` (already a dependency, used in `list_versions.go`). Index versions are strict SemVer with no "v" prefix, so "v" is prepended only for comparison. Unpinned callers that benefit: `internal/app` binding-setup (`handlers_bindings.go`), action-install (`handlers_install_actions.go`), and action-preview (`handlers_action_preview.go`).

2. **Hash-pinning advisory (UX/observability).** `aileron connector install` printed its success line at two spots (direct/preview path and the Hub `doConfirmedInstall` path) with nothing signalling that already-published actions/flight plans keep running their previously pinned `(version, hash)` until reinstalled/re-published per ADR-0004. Both fresh-install paths now emit a short advisory: connectors are pinned by content hash (ADR-0004), existing actions/flight plans keep their pinned version until reinstalled or re-published, and to run `aileron connector check`. Suppressed on already-installed (no-op) installs. Static advisory only.

## Test plan

- `internal/cstore`: new `TestStore_LookupAnyVersion_ReturnsHighestSemVerDeterministically` installs several out-of-order versions and asserts the SemVer-highest is returned on every iteration (100x to surface map-iteration nondeterminism). Verified it **fails** against the old first-match body and **passes** after the fix.
- `cmd/aileron`: extended the happy-path install test to assert the advisory text; added `TestRunConnector_InstallFreshEmitsPinAdvisory`, `TestRunConnector_InstallAlreadyInstalledResponseSkipsPinAdvisory` (advisory suppressed on no-op), and `TestRunConnector_InstallHubPathEmitsPinAdvisory` (Hub confirmed-install path shares the messaging).
- Full `internal/cstore`, `internal/app`, and `cmd/aileron` suites pass. Coverage: cstore 89.1%, cmd/aileron 86.1%. `gofmt`/`go vet` clean.

Out of scope per contract-A: floating/"latest" resolution, relaxing the hash-required rule, any execution-path re-resolution. This does not by itself fix the reported execution symptom (accepted).

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connector installs now show a clearer post-install advisory for fresh installs, including the content-hash pinning note and a follow-up check hint.

- **Bug Fixes**
  - Suppressed the pinning advisory when a connector is already installed, avoiding redundant output.
  - Improved connector version lookup to consistently use the highest available version when multiple versions are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->