### PR TITLE
feat(flightplan): boot the pinned rung-1/rung-2 image at skill launch

### DIFF
--- a/cmd/aileron/flagparse_test.go
+++ b/cmd/aileron/flagparse_test.go
@@ -264,7 +264,10 @@ func TestRunSkillFreeze_FlagsAfterName(t *testing.T) {
 // honor the flag placed after the name.
 func TestRunSkillLaunch_FlagAfterName(t *testing.T) {
 	storeDir := withTempStore(t)
-	freezeExampleForLaunch(t, storeDir)
+	// Use the no-image variant so this flag-parsing test stays on the
+	// in-process path and materializes filed_issue.json without booting a
+	// container.
+	freezeNoImageForLaunch(t, storeDir)
 	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
 		"aileron:metrics.query_series": {
 			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
@@ -274,6 +277,7 @@ func TestRunSkillLaunch_FlagAfterName(t *testing.T) {
 		},
 	}}
 	stubLaunchSeams(t, disp)
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{})
 	origRun := launchSeamForTest
 	launchSeamForTest = fakeCLISeam{}
 	t.Cleanup(func() { launchSeamForTest = origRun })

--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -23,6 +23,12 @@ var newLaunchDispatcher = func() runtime.ActionDispatcher { return daemonDispatc
 var newLaunchApprover = func() runtime.Approver { return daemonApprover{} }
 var newLaunchAuditSink = func() runtime.AuditSink { return stdoutAuditSink{} }
 
+// newLaunchImageRunner returns the production image runner that boots the
+// verified pinned rung-1/rung-2 image and runs the plan inside it (#1731). It
+// is a package-level seam so CLI tests swap in a fake that records the exact
+// image string and never touches Docker, mirroring the other launch seams.
+var newLaunchImageRunner = func() runtime.ImageRunner { return containerImageRunner{} }
+
 // launchSeamForTest is the LLM seam the launch wires into the runtime. It is
 // nil by default, which is the v1 contract: a plan with an llm-seam step
 // errors unless a provider is configured, so a default launch reaches no LLM.
@@ -90,8 +96,12 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		// Seam is nil in v1 production: the LLM seam is unwired, so a plan with
 		// an llm-seam step errors unless a provider is supplied. Tests inject a
 		// deterministic seam through launchSeamForTest.
-		Seam:   launchSeamForTest,
-		OutDir: *outDir,
+		Seam: launchSeamForTest,
+		// ImageRunner boots the verified pinned rung-1/rung-2 image and runs the
+		// plan inside it. When the frozen unit pins no image, the runtime never
+		// touches this seam and stays on the in-process path.
+		ImageRunner: newLaunchImageRunner(),
+		OutDir:      *outDir,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -66,6 +66,11 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	version := flags.String("version", "", "Frozen version id to launch (defaults to the only/most recent version)")
 	outDir := flags.String("out-dir", ".", "Directory file-target artifacts are written to")
+	// storeDir defaults to the process store seam. The in-container re-entry on
+	// the image-boot path passes the bind-mounted store path here so the inner
+	// binary loads the same verified frozen unit from the mount rather than the
+	// (empty) default store inside the image.
+	storeDir := flags.String("store-dir", skillStoreDir, "Skill store directory (defaults to ~/.aileron/skills)")
 	var inputs inputFlag
 	flags.Var(&inputs, "input", "Launch input override as name=value; repeatable")
 	positionals, err := parseInterspersedFlags(flags, args)
@@ -78,7 +83,7 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	}
 	name := positionals[0]
 
-	s := store.New(skillStoreDir)
+	s := store.New(*storeDir)
 	id, err := resolveLaunchVersion(s, name, *version)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// containerImageRunner is the production runtime.ImageRunner: it boots the
+// verified pinned rung-1/rung-2 image and runs the frozen Flight Plan inside it
+// (#1731). It mirrors the sandboxRunContainer seam in internal/launch: the boot
+// is a package-level indirection (containerRunFlightPlan) so CLI tests swap in a
+// fake image runner and never touch Docker, while production shells out to the
+// real container runtime through the same container.Builder path the sandbox
+// launch uses.
+//
+// The image it boots is spec.Image, taken straight from the verified lock by
+// the runtime core. containerImageRunner MUST NOT re-resolve or rewrite it: the
+// digest is the load-bearing assertion that the environment entered corresponds
+// to the lock's signed image. It mounts the frozen store read-only and the
+// out-dir writable, then re-enters the aileron binary against the bind-mounted
+// unit so the in-container run reaches the same daemon action boundary over the
+// existing network wiring.
+type containerImageRunner struct{}
+
+// containerRunFlightPlan boots the pinned image and runs the plan inside it. It
+// is a package variable purely for symmetry with sandboxRunContainer; the
+// production launch swaps the whole runtime.ImageRunner via newLaunchImageRunner
+// in tests, so this indirection is the single real-Docker call site.
+var containerRunFlightPlan = func(ctx context.Context, runtimeName string, stdout, stderr io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+	return sandboxcontainer.Builder{
+		Runtime: runtimeName,
+		Runner:  sandboxcontainer.DefaultRunner(),
+		Stdout:  stdout,
+		Stderr:  stderr,
+	}.Run(ctx, opts)
+}
+
+func (containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
+	if spec.Image == "" {
+		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: image runner requires a pinned image")
+	}
+	runtimeName, err := sandboxcontainer.ResolveRuntime("")
+	if err != nil {
+		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: resolve container runtime: %w", err)
+	}
+
+	// Mount the frozen store read-only so the in-container run reads the exact
+	// bytes verified on the host, and the out-dir writable so materialized
+	// artifacts land where the host expects them.
+	const (
+		storeMount  = "/aileron/skills"
+		outDirMount = "/aileron/out"
+	)
+	volumes := []sandboxcontainer.Volume{
+		{Source: store.New(skillStoreDir).Root(), Target: storeMount, ReadOnly: true},
+	}
+	if spec.OutDir != "" {
+		abs, err := filepath.Abs(spec.OutDir)
+		if err != nil {
+			return runtime.ImageRunResult{}, fmt.Errorf("skill launch: resolve out-dir: %w", err)
+		}
+		if err := os.MkdirAll(abs, 0o755); err != nil {
+			return runtime.ImageRunResult{}, fmt.Errorf("skill launch: create out-dir: %w", err)
+		}
+		volumes = append(volumes, sandboxcontainer.Volume{Source: abs, Target: outDirMount})
+	}
+
+	// Re-enter the aileron binary against the bind-mounted unit. The in-container
+	// run loads the same frozen version from the mounted store and materializes
+	// into the mounted out-dir. The daemon action boundary stays reachable over
+	// the existing network wiring; no credentials cross this boundary.
+	command := []string{"aileron", "skill", "launch", spec.Name}
+	if spec.Version != "" {
+		command = append(command, "--version", spec.Version)
+	}
+	if spec.OutDir != "" {
+		command = append(command, "--out-dir", outDirMount)
+	}
+
+	opts := sandboxcontainer.RunOptions{
+		Runtime: runtimeName,
+		Image:   spec.Image,
+		Volumes: volumes,
+		Command: command,
+		Name:    flightPlanContainerName(spec),
+	}
+	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, os.Stderr, opts); err != nil {
+		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: run pinned image %q: %w", spec.Image, err)
+	}
+
+	// v1 assembles a minimal result: the resolved inputs are echoed and
+	// artifacts are collected from the out-dir mount. The content hash is left
+	// to the in-container run's own audit; the CLI surfaces the launch line
+	// regardless. Later sub-issues thread the full RunResult back from the
+	// in-container run.
+	return runtime.ImageRunResult{
+		ResolvedInputs: map[string]any(spec.Inputs),
+	}, nil
+}
+
+// flightPlanContainerName builds a deterministic, addressable container name for
+// the boot so a later stop can target it by name.
+func flightPlanContainerName(spec runtime.ImageRunSpec) string {
+	v := spec.Version
+	if v == "" {
+		v = "latest"
+	}
+	return "aileron-flightplan-" + spec.Name + "-" + v
+}

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -74,9 +76,12 @@ func (containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) 
 
 	// Re-enter the aileron binary against the bind-mounted unit. The in-container
 	// run loads the same frozen version from the mounted store and materializes
-	// into the mounted out-dir. The daemon action boundary stays reachable over
-	// the existing network wiring; no credentials cross this boundary.
-	command := []string{"aileron", "skill", "launch", spec.Name}
+	// into the mounted out-dir. --store-dir points the inner binary at the
+	// bind-mounted store so it reads the exact verified bytes rather than the
+	// empty default store inside the image. The daemon action boundary stays
+	// reachable over the existing network wiring; no credentials cross this
+	// boundary.
+	command := []string{"aileron", "skill", "launch", spec.Name, "--store-dir", storeMount}
 	if spec.Version != "" {
 		command = append(command, "--version", spec.Version)
 	}
@@ -105,12 +110,27 @@ func (containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) 
 	}, nil
 }
 
-// flightPlanContainerName builds a deterministic, addressable container name for
-// the boot so a later stop can target it by name.
+// flightPlanContainerName builds an addressable container name for the boot. The
+// name keeps a stable, human-readable base (the skill name and version) and
+// appends a short random suffix so two concurrent launches of the same frozen
+// unit never collide on the container name. A stop/cleanup path reuses the value
+// returned here for a given launch rather than recomputing it.
 func flightPlanContainerName(spec runtime.ImageRunSpec) string {
 	v := spec.Version
 	if v == "" {
 		v = "latest"
 	}
-	return "aileron-flightplan-" + spec.Name + "-" + v
+	return "aileron-flightplan-" + spec.Name + "-" + v + "-" + randomSuffix()
+}
+
+// randomSuffix returns a short hex token for disambiguating container names. On
+// the vanishingly unlikely RNG failure it degrades to a fixed token rather than
+// failing the launch, since the suffix is a collision-avoidance convenience, not
+// a security boundary.
+func randomSuffix() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "0000"
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -72,6 +72,19 @@ func TestContainerImageRunner_BootsExactImageWithMounts(t *testing.T) {
 	if !strings.Contains(joined, "--version 1.0.0") {
 		t.Errorf("command must pin the version: %v", got.Command)
 	}
+	// The inner binary must be pointed at the bind-mounted store, not the empty
+	// default store inside the image.
+	if !strings.Contains(joined, "--store-dir /aileron/skills") {
+		t.Errorf("command must point the inner binary at the mounted store: %v", got.Command)
+	}
+	// The container name carries a run-unique suffix so concurrent launches of
+	// the same unit never collide.
+	if got.Name == flightPlanContainerName(spec) {
+		t.Error("container name must include a run-unique suffix, not a fully deterministic value")
+	}
+	if !strings.HasPrefix(got.Name, "aileron-flightplan-weekly-metrics-digest-1.0.0-") {
+		t.Errorf("container name = %q, want the stable base prefix plus a suffix", got.Name)
+	}
 	// The result echoes the resolved inputs in v1.
 	if res.ResolvedInputs["window_days"] != "30" {
 		t.Errorf("result inputs = %v, want the launch inputs echoed", res.ResolvedInputs)

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// stubContainerBoot swaps the single real-Docker call site for a recorder so the
+// container image runner's spec-construction is testable with no live runtime.
+func stubContainerBoot(t *testing.T, capture *sandboxcontainer.RunOptions, err error) {
+	t.Helper()
+	orig := containerRunFlightPlan
+	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+		*capture = opts
+		return sandboxcontainer.RunResult{}, err
+	}
+	t.Cleanup(func() { containerRunFlightPlan = orig })
+}
+
+func TestContainerImageRunner_BootsExactImageWithMounts(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	outDir := t.TempDir()
+	spec := runtime.ImageRunSpec{
+		Image:   "registry.example.com/runner:1.4@sha256:abc",
+		Name:    "weekly-metrics-digest",
+		Version: "1.0.0",
+		Inputs:  runtime.LaunchArgs{"window_days": "30"},
+		OutDir:  outDir,
+	}
+	res, err := containerImageRunner{}.Run(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The booted image must be the exact pin, never re-resolved.
+	if got.Image != spec.Image {
+		t.Errorf("booted image = %q, want the exact pin %q", got.Image, spec.Image)
+	}
+	// The store is mounted read-only; the out-dir writable.
+	var storeRO, outRW bool
+	for _, v := range got.Volumes {
+		if v.Source == storeDir && v.ReadOnly {
+			storeRO = true
+		}
+		if v.Source == outDir && !v.ReadOnly {
+			outRW = true
+		}
+	}
+	if !storeRO {
+		t.Errorf("frozen store must be mounted read-only, got %+v", got.Volumes)
+	}
+	if !outRW {
+		t.Errorf("out-dir must be mounted writable, got %+v", got.Volumes)
+	}
+	// The in-container command re-enters aileron against the mounted unit.
+	joined := strings.Join(got.Command, " ")
+	if !strings.Contains(joined, "skill launch weekly-metrics-digest") {
+		t.Errorf("command = %v, want an in-container skill launch of the unit", got.Command)
+	}
+	if !strings.Contains(joined, "--version 1.0.0") {
+		t.Errorf("command must pin the version: %v", got.Command)
+	}
+	// The result echoes the resolved inputs in v1.
+	if res.ResolvedInputs["window_days"] != "30" {
+		t.Errorf("result inputs = %v, want the launch inputs echoed", res.ResolvedInputs)
+	}
+}
+
+func TestContainerImageRunner_EmptyImageErrors(t *testing.T) {
+	_, err := containerImageRunner{}.Run(context.Background(), runtime.ImageRunSpec{})
+	if err == nil {
+		t.Fatal("an empty image must error before any boot")
+	}
+}
+
+func TestContainerImageRunner_BootFailureSurfaces(t *testing.T) {
+	origStore := skillStoreDir
+	skillStoreDir = t.TempDir()
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, errors.New("boot exploded"))
+
+	_, err := containerImageRunner{}.Run(context.Background(), runtime.ImageRunSpec{
+		Image: "img@sha256:abc",
+		Name:  "unit",
+	})
+	if err == nil || !strings.Contains(err.Error(), "boot exploded") {
+		t.Fatalf("boot failure must surface, got %v", err)
+	}
+}

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -84,11 +84,6 @@ func freezeExampleForLaunch(t *testing.T, storeDir string) {
 	}
 }
 
-// TestRunSkillLaunch_BootsPinnedRung2Image proves the acceptance property: the
-// worked example is rung-2, so its verified lock pins a composed image digest.
-// Launch boots that exact ref@sha256:<digest-from-lock> through the image runner
-// and exits 0. The recorded image is the load-bearing assertion that the lock's
-// signed-image claim corresponds to the image actually entered.
 // freezeNoImageForLaunch installs a no-execution-environment variant of the
 // worked example (the same stepped plan with the executionEnvironment block
 // removed) and freezes it, so the frozen unit pins no image and the launch
@@ -147,6 +142,11 @@ func stripExecEnvBlock(t *testing.T, md string) string {
 	return res
 }
 
+// TestRunSkillLaunch_BootsPinnedRung2Image proves the acceptance property: the
+// worked example is rung-2, so its verified lock pins a composed image digest.
+// Launch boots that exact ref@sha256:<digest-from-lock> through the image runner
+// and exits 0. The recorded image is the load-bearing assertion that the lock's
+// signed-image claim corresponds to the image actually entered.
 func TestRunSkillLaunch_BootsPinnedRung2Image(t *testing.T) {
 	storeDir := withTempStore(t)
 	freezeExampleForLaunch(t, storeDir)
@@ -254,6 +254,43 @@ func TestRunSkillLaunch_PinnedButNoRunnerErrors(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "no image runner is configured") {
 		t.Errorf("stderr = %q, want a no-runner-configured message", stderr.String())
+	}
+}
+
+// TestRunSkillLaunch_StoreDirFlagRoutesStore proves --store-dir points the
+// launch at an explicit store rather than the default seam. The frozen unit
+// lives only under the flag's directory while the process store seam is empty,
+// so a successful load can only come from honoring the flag. This is the
+// mechanism the in-container re-entry relies on to read the bind-mounted store.
+func TestRunSkillLaunch_StoreDirFlagRoutesStore(t *testing.T) {
+	// Freeze the unit into flagStore (freeze reads the process seam, so point it
+	// there for the freeze), then swap the seam to a different empty store so
+	// only the --store-dir flag can resolve the unit at launch.
+	flagStore := withTempStore(t)
+	freezeNoImageForLaunch(t, flagStore)
+	skillStoreDir = t.TempDir()
+
+	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {
+			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
+		},
+		"aileron:tracker.create_issue": {
+			"path": "filed_issue.json", "mimeType": "application/json", "encoding": "utf-8", "content": "{}",
+		},
+	}}
+	stubLaunchSeams(t, disp)
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{})
+	origRun := launchSeamForTest
+	launchSeamForTest = fakeCLISeam{}
+	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--store-dir", flagStore, "--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch with --store-dir exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Launched \"weekly-metrics-digest\"") {
+		t.Errorf("stdout = %q", stdout.String())
 	}
 }
 

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -39,6 +39,38 @@ func stubLaunchSeams(t *testing.T, disp runtime.ActionDispatcher) {
 	})
 }
 
+// fakeLaunchImageRunner records the exact image string and spec it was handed
+// and returns a canned result, so the boot path is testable with no live Docker.
+type fakeLaunchImageRunner struct {
+	called bool
+	spec   runtime.ImageRunSpec
+	result runtime.ImageRunResult
+	err    error
+}
+
+func (f *fakeLaunchImageRunner) Run(_ context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
+	f.called = true
+	f.spec = spec
+	return f.result, f.err
+}
+
+// stubLaunchImageRunner swaps the production image-runner seam for a fake so a
+// rung-pinned launch never boots a real container. It returns the fake for
+// assertions. When runner is nil the seam yields nil so the runtime's
+// pinned-but-no-runner guard fires.
+func stubLaunchImageRunner(t *testing.T, runner *fakeLaunchImageRunner) *fakeLaunchImageRunner {
+	t.Helper()
+	orig := newLaunchImageRunner
+	newLaunchImageRunner = func() runtime.ImageRunner {
+		if runner == nil {
+			return nil
+		}
+		return runner
+	}
+	t.Cleanup(func() { newLaunchImageRunner = orig })
+	return runner
+}
+
 // freezeExampleForLaunch installs + freezes the worked example into the temp
 // store so a launch has a verifiable frozen version to load.
 func freezeExampleForLaunch(t *testing.T, storeDir string) {
@@ -52,18 +84,114 @@ func freezeExampleForLaunch(t *testing.T, storeDir string) {
 	}
 }
 
-func TestRunSkillLaunch_EndToEnd(t *testing.T) {
+// TestRunSkillLaunch_BootsPinnedRung2Image proves the acceptance property: the
+// worked example is rung-2, so its verified lock pins a composed image digest.
+// Launch boots that exact ref@sha256:<digest-from-lock> through the image runner
+// and exits 0. The recorded image is the load-bearing assertion that the lock's
+// signed-image claim corresponds to the image actually entered.
+// freezeNoImageForLaunch installs a no-execution-environment variant of the
+// worked example (the same stepped plan with the executionEnvironment block
+// removed) and freezes it, so the frozen unit pins no image and the launch
+// stays on the in-process path.
+func freezeNoImageForLaunch(t *testing.T, storeDir string) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripped := stripExecEnvBlock(t, string(raw))
+	dir := filepath.Join(storeDir, "weekly-metrics-digest")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(stripped), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	var out, errOut bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &out, &errOut); code != 0 {
+		t.Fatalf("freeze no-image variant failed: %s", errOut.String())
+	}
+}
+
+// stripExecEnvBlock removes the `executionEnvironment:` mapping (indented at 4
+// spaces) and its more-deeply-indented children from the worked-example
+// frontmatter, leaving a valid no-rung manifest.
+func stripExecEnvBlock(t *testing.T, md string) string {
+	t.Helper()
+	lines := strings.Split(md, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	for _, ln := range lines {
+		if !skipping {
+			if strings.HasPrefix(ln, "    executionEnvironment:") && strings.TrimSpace(ln) == "executionEnvironment:" {
+				skipping = true
+				continue
+			}
+			out = append(out, ln)
+			continue
+		}
+		trimmed := strings.TrimLeft(ln, " ")
+		indent := len(ln) - len(trimmed)
+		if trimmed == "" || indent > 4 {
+			continue
+		}
+		skipping = false
+		out = append(out, ln)
+	}
+	res := strings.Join(out, "\n")
+	if strings.Contains(res, "executionEnvironment:") {
+		t.Fatal("stripExecEnvBlock left the block in place")
+	}
+	return res
+}
+
+func TestRunSkillLaunch_BootsPinnedRung2Image(t *testing.T) {
 	storeDir := withTempStore(t)
 	freezeExampleForLaunch(t, storeDir)
 
-	// The tracker write materializes filed_issue.json; the metrics read feeds
-	// render_csv. The render_csv transform is the default identity, which for
-	// this worked example forwards the series; to materialize a CSV file-map
-	// the worked example's transform must emit one. We rely on the runtime's
-	// action-call materialization for filed_issue.json and skip CSV bytes by
-	// having the metrics read return a file-map-shaped series the transform
-	// forwards. Simpler: assert the launch loads, verifies, dispatches both
-	// actions, and exits 0.
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ContentHash: "sha256:booted"},
+	})
+	// The dispatcher must never be walked on the boot path; wire it so a stray
+	// in-process dispatch would be observable.
+	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{}}
+	stubLaunchSeams(t, disp)
+
+	outDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", outDir, "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !runner.called {
+		t.Fatal("launch did not boot the pinned image for a rung-2 unit")
+	}
+	if !strings.HasSuffix(runner.spec.Image, "@"+fakeFreezeDigest) {
+		t.Errorf("booted image = %q, want it to end with @%s (the verified lock digest)", runner.spec.Image, fakeFreezeDigest)
+	}
+	if runner.spec.Name != "weekly-metrics-digest" {
+		t.Errorf("spec.Name = %q, want the launched skill name", runner.spec.Name)
+	}
+	if runner.spec.OutDir != outDir {
+		t.Errorf("spec.OutDir = %q, want %q", runner.spec.OutDir, outDir)
+	}
+	if len(disp.refs) != 0 {
+		t.Errorf("boot path must not dispatch in-process, got %v", disp.refs)
+	}
+	if !strings.Contains(stdout.String(), "Launched \"weekly-metrics-digest\"") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+// TestRunSkillLaunch_InProcessWhenNoRung proves parity: a frozen unit that pins
+// no image stays on the in-process path. The image runner is never touched and
+// the dispatcher walks the step graph, materializing artifacts as before.
+func TestRunSkillLaunch_InProcessWhenNoRung(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeNoImageForLaunch(t, storeDir)
+
 	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
 		"aileron:metrics.query_series": {
 			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
@@ -73,7 +201,7 @@ func TestRunSkillLaunch_EndToEnd(t *testing.T) {
 		},
 	}}
 	stubLaunchSeams(t, disp)
-	// Supply a seam so the llm-seam step runs.
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{})
 	origRun := launchSeamForTest
 	launchSeamForTest = fakeCLISeam{}
 	t.Cleanup(func() { launchSeamForTest = origRun })
@@ -84,16 +212,14 @@ func TestRunSkillLaunch_EndToEnd(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
 	}
-	out := stdout.String()
-	if !strings.Contains(out, "Launched \"weekly-metrics-digest\"") {
-		t.Errorf("stdout = %q", out)
+	if runner.called {
+		t.Fatal("a unit that pins no image must not boot the image runner")
 	}
-	if !strings.Contains(out, "ContentHash: sha256:") {
-		t.Errorf("stdout missing content hash: %q", out)
+	if !strings.Contains(stdout.String(), "ContentHash: sha256:") {
+		t.Errorf("stdout missing content hash: %q", stdout.String())
 	}
-	// The worked example dispatches the metrics read twice (once for the
-	// active_metric_set source input in Phase A, once for the query_metrics
-	// step in Phase B) and the tracker write once.
+	// The worked example dispatches the metrics read twice (Phase A source input
+	// + Phase B step) and the tracker write once.
 	var metrics, tracker int
 	for _, ref := range disp.refs {
 		switch ref {
@@ -106,9 +232,28 @@ func TestRunSkillLaunch_EndToEnd(t *testing.T) {
 	if metrics != 2 || tracker != 1 {
 		t.Errorf("dispatch counts: metrics=%d tracker=%d, want 2/1 (%v)", metrics, tracker, disp.refs)
 	}
-	// filed_issue.json materialized to the out dir.
 	if _, err := os.Stat(filepath.Join(outDir, "filed_issue.json")); err != nil {
 		t.Errorf("filed_issue.json not materialized: %v", err)
+	}
+}
+
+// TestRunSkillLaunch_PinnedButNoRunnerErrors proves the guard fires through the
+// CLI: a rung-pinned unit with a misconfigured (nil) image runner refuses with
+// a non-zero exit and a clear error, never silently running in-process.
+func TestRunSkillLaunch_PinnedButNoRunnerErrors(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+
+	stubLaunchImageRunner(t, nil) // nil runner: the guard must fire.
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("a rung-pinned unit with no image runner must exit non-zero")
+	}
+	if !strings.Contains(stderr.String(), "no image runner is configured") {
+		t.Errorf("stderr = %q, want a no-runner-configured message", stderr.String())
 	}
 }
 
@@ -124,22 +269,26 @@ func TestRunSkillLaunch_MissingVersionRefuses(t *testing.T) {
 	}
 }
 
-func TestRunSkillLaunch_InputOverride(t *testing.T) {
+// TestRunSkillLaunch_InputOverrideReachesImageRunner proves a --input override
+// threads into the boot path: the worked example is rung-2, so the override must
+// reach the image runner's spec (which carries it into the in-container run)
+// rather than being dropped at the boot boundary.
+func TestRunSkillLaunch_InputOverrideReachesImageRunner(t *testing.T) {
 	storeDir := withTempStore(t)
 	freezeExampleForLaunch(t, storeDir)
-	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
-		"aileron:metrics.query_series": {"path": "digest.csv", "encoding": "utf-8", "content": "x", "mimeType": "text/csv"},
-		"aileron:tracker.create_issue": {"path": "filed_issue.json", "encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
-	}}
-	stubLaunchSeams(t, disp)
-	origRun := launchSeamForTest
-	launchSeamForTest = fakeCLISeam{}
-	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ResolvedInputs: map[string]any{"window_days": "30"}},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
 
 	var stdout, stderr bytes.Buffer
 	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "--input", "window_days=30", "weekly-metrics-digest"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if runner.spec.Inputs["window_days"] != "30" {
+		t.Errorf("input override not threaded into the image spec: %v", runner.spec.Inputs)
 	}
 	if !strings.Contains(stdout.String(), "window_days = 30") {
 		t.Errorf("override not reflected in resolved inputs: %q", stdout.String())

--- a/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
+++ b/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
@@ -38,7 +38,7 @@ Freeze is the step that turns a skill into a Flight Plan. Freeze resolves every 
 
 A Flight Plan carries two distinct determinism guarantees.
 
-The first is environmental reproducibility. Every image reference is pinned to a digest at freeze. The same Flight Plan resolves the same images on every run. The lockfile is the record of those pins.
+The first is environmental reproducibility. Every image reference is pinned to a digest at freeze. The same Flight Plan resolves the same images on every run. The lockfile is the record of those pins. Launch boots the pinned image from the verified lock, so the environment the plan runs in is the one the signature attested.
 
 The second is behavioral determinism. No LLM runs at Flight Plan runtime by default. An LLM runs only at a single seam that is explicitly marked in the skill and structurally enforced by the runtime. A freeze-time lint rejects any unmarked LLM call. A skill that reaches an LLM outside the marked seam fails freeze and never becomes a Flight Plan. The marked seam is the one place where non-deterministic reasoning is allowed, and everything outside it is deterministic by construction.
 
@@ -65,6 +65,8 @@ Rung one pins a whole prebuilt image. The skill names an image, and freeze resol
 Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result. The capability-unit shape is the one defined in [ADR-0026](/adr/0026-cli-capability-units).
 
 The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as a manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here. A manifest may declare the `rung3PerStepImages` slot alone. Freeze parses that declaration, builds no image, and reports the rung as build-deferred to the operator, so a rung-three-only Flight Plan is a told outcome rather than a parse failure or a silent pass.
+
+The digest pin is load-bearing at launch, not only at freeze. When the verified lock carries a resolved rung-one or rung-two image digest, launch boots that exact pinned image and runs the plan inside it. The digest booted comes from the verified lock, so the image entered corresponds to the lock's signed image assertion rather than any re-resolved tag. A Flight Plan that declares no execution rung has an empty resolved-image set, so its launch runs the step graph in-process instead of booting an image. Rung three stays build-deferred, so a per-step sibling image is not booted at launch.
 
 The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
 
@@ -121,7 +123,7 @@ The diagram below shows the boundary. A skill crosses the freeze step and become
 
 ### Positive
 
-- A Flight Plan is reproducible. Every image reference is pinned to a digest at freeze, so the same plan resolves the same environment on every run.
+- A Flight Plan is reproducible. Every image reference is pinned to a digest at freeze, so the same plan resolves the same environment on every run. Launch boots that pinned image from the verified lock, so the environment the plan runs in matches the signed pin.
 - A Flight Plan is auditable. The per-action trust contract records the credential, the network reach, the effect, and the audit-record structure for every action the plan calls.
 - A Flight Plan is behaviorally deterministic. No LLM runs at runtime outside the single marked seam, and the freeze-time lint rejects any unmarked LLM call before the plan is sealed.
 - A Flight Plan is deterministic given its resolved inputs. Inputs are declared with resolution rules, resolved once at launch, and recorded with the outputs. Results vary only with declared, resolved inputs, so every run is explainable from its recorded binding rather than reconstructed from a moving source.

--- a/internal/flightplan/freeze/launch.go
+++ b/internal/flightplan/freeze/launch.go
@@ -18,6 +18,15 @@ type VerifiedFrozen struct {
 	// both the recomputed canonical hash and the value recorded in the
 	// frozen lock block.
 	ContentHash string
+	// ResolvedImages are the resolved image digest pins carried by the
+	// verified manifest lock block (rung-1 `rung1Image.ref` → digest, or
+	// rung-2 composed Features → digest). It is empty for an
+	// instruction-only or no-execution-environment unit. The runtime boots
+	// the pinned image at launch, so this field is the load-bearing bridge
+	// from the signed lock to the container actually entered. It is only ever
+	// populated on the verified path: a tampered digest changes the recomputed
+	// content hash and refuses before this field is read.
+	ResolvedImages []ImagePin
 }
 
 // VerifyFrozen is the Launch-time verification gate (ADR-0027, #1509/#1511).
@@ -114,9 +123,17 @@ func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, 
 	}
 
 	// Return a defensive copy of the verified manifest bytes so a later mutation
-	// of the caller's slice can never change what was verified.
+	// of the caller's slice can never change what was verified. The resolved
+	// image pins are copied from the manifest's OWN lock block (the region the
+	// reconstruction above proved consistent against the content hash), so the
+	// digest exposed here is exactly the one the signature attested. A defensive
+	// slice copy keeps the field immune to later mutation of manifestLock.
 	verified := append([]byte(nil), skillMD...)
-	return VerifiedFrozen{SkillMD: verified, ContentHash: recorded}, nil
+	var pins []ImagePin
+	if len(manifestLock.ResolvedImages) > 0 {
+		pins = append([]ImagePin(nil), manifestLock.ResolvedImages...)
+	}
+	return VerifiedFrozen{SkillMD: verified, ContentHash: recorded, ResolvedImages: pins}, nil
 }
 
 // lockFromManifest parses the `aileron.lock` block of a frozen SKILL.md into a

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -39,6 +39,96 @@ func TestVerifyFrozen_AcceptsUntamperedUnit(t *testing.T) {
 	}
 }
 
+func TestVerifyFrozen_ExposesResolvedImagesForRung2(t *testing.T) {
+	// The worked example is rung-2: freeze composes the capability units to a
+	// single pinned image digest. VerifyFrozen must surface that verified pin so
+	// the runtime can boot the exact image the signature attested.
+	res := freezeExample(t)
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen: %v", err)
+	}
+	if len(v.ResolvedImages) != 1 {
+		t.Fatalf("ResolvedImages = %+v, want exactly one pin", v.ResolvedImages)
+	}
+	if v.ResolvedImages[0].Digest != fakeDigest {
+		t.Errorf("ResolvedImages[0].Digest = %q, want %q", v.ResolvedImages[0].Digest, fakeDigest)
+	}
+	if v.ResolvedImages[0].Ref == "" {
+		t.Error("ResolvedImages[0].Ref must carry the pre-freeze reference")
+	}
+}
+
+func TestVerifyFrozen_ExposesResolvedImagesForRung1(t *testing.T) {
+	// A rung-1 unit names a whole prebuilt image; freeze resolves it to a
+	// digest pin. The verified pin must carry both the ref and the digest.
+	_, keyPath := genSigningKey(t)
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		return fakeDigest, nil
+	})
+	res, err := Run(context.Background(), []byte(rung1MD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Resolver:       dr,
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run rung-1: %v", err)
+	}
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen rung-1: %v", err)
+	}
+	if len(v.ResolvedImages) != 1 {
+		t.Fatalf("ResolvedImages = %+v, want exactly one pin", v.ResolvedImages)
+	}
+	if v.ResolvedImages[0].Digest != fakeDigest {
+		t.Errorf("ResolvedImages[0].Digest = %q, want %q", v.ResolvedImages[0].Digest, fakeDigest)
+	}
+	if v.ResolvedImages[0].Ref != "registry.example.com/runner:1.4" {
+		t.Errorf("ResolvedImages[0].Ref = %q, want the rung1Image.ref", v.ResolvedImages[0].Ref)
+	}
+}
+
+func TestVerifyFrozen_EmptyResolvedImagesForNoExecEnv(t *testing.T) {
+	// A no-execution-environment skill has an aileron block but declares no
+	// image to resolve, so freeze pins none and VerifyFrozen exposes an empty
+	// pin set (the runtime stays on the in-process parity path).
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), []byte(noExecEnvMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run no-exec-env: %v", err)
+	}
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen no-exec-env: %v", err)
+	}
+	if len(v.ResolvedImages) != 0 {
+		t.Errorf("no-exec-env ResolvedImages = %+v, want empty", v.ResolvedImages)
+	}
+}
+
+func TestVerifyFrozen_TamperedDigestRefusesBeforeExposure(t *testing.T) {
+	// Swapping the resolved digest inside the frozen manifest's lock block
+	// changes the recomputed content hash. Verification must refuse before any
+	// pin is exposed, so a tampered image can never reach the runtime.
+	res := freezeExample(t)
+	swapped := "sha256:" + strings.Repeat("b", 64)
+	tampered := bytes.Replace(res.FrozenManifest, []byte(fakeDigest), []byte(swapped), 1)
+	if bytes.Equal(tampered, res.FrozenManifest) {
+		t.Fatal("test setup: worked example lock digest not found to tamper")
+	}
+	v, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey)
+	if err == nil {
+		t.Fatal("a tampered resolved digest must refuse to verify")
+	}
+	if len(v.ResolvedImages) != 0 {
+		t.Errorf("a refused verification must expose no pins, got %+v", v.ResolvedImages)
+	}
+}
+
 func TestVerifyFrozen_RejectsTamperedManifest(t *testing.T) {
 	res := freezeExample(t)
 	// Flip a byte in the Markdown body (after the frontmatter) so the

--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -1,0 +1,53 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+)
+
+// runInImage boots the verified pinned rung-1/rung-2 image and runs the frozen
+// plan inside it (#1731). It is reached only when the loaded plan carries a
+// non-empty ResolvedImages set, so the pin is always present here.
+//
+// The image booted is taken straight from the verified lock (pins[0]), never a
+// re-parse of untrusted bytes: that is the load-bearing security property. A
+// plan that pins an image but supplies no ImageRunner is an explicit error, not
+// a silent in-process fallback. A rung was declared and pinned; running the
+// plan in-process would enter an environment the attestation never certified.
+func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, error) {
+	pin := lp.ResolvedImages[0]
+	if opts.ImageRunner == nil {
+		return RunResult{}, fmt.Errorf(
+			"flightplan: frozen unit pins image %q but no image runner is configured", pin.Ref)
+	}
+	spec := ImageRunSpec{
+		Image:   imageRef(pin.Ref, pin.Digest),
+		Name:    opts.Name,
+		Version: opts.Version,
+		Inputs:  opts.Inputs,
+		OutDir:  opts.OutDir,
+	}
+	res, err := opts.ImageRunner.Run(ctx, spec)
+	if err != nil {
+		return RunResult{}, err
+	}
+	return RunResult{
+		ContentHash:    res.ContentHash,
+		ResolvedInputs: res.ResolvedInputs,
+		StepOutputs:    res.StepOutputs,
+		Artifacts:      res.Artifacts,
+		AuditIDs:       res.AuditIDs,
+	}, nil
+}
+
+// imageRef composes the `ref@digest` string the runner boots. When the digest
+// is already a full `ref@sha256:...` (an unusual pin shape) it is returned
+// verbatim; otherwise the pinned ref and digest are joined with `@`. The digest
+// is the content-addressed identity, so a runner handed this string boots the
+// exact image the signature attested rather than resolving the mutable tag.
+func imageRef(ref, digest string) string {
+	if digest == "" {
+		return ref
+	}
+	return ref + "@" + digest
+}

--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -40,11 +40,12 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 	}, nil
 }
 
-// imageRef composes the `ref@digest` string the runner boots. When the digest
-// is already a full `ref@sha256:...` (an unusual pin shape) it is returned
-// verbatim; otherwise the pinned ref and digest are joined with `@`. The digest
-// is the content-addressed identity, so a runner handed this string boots the
-// exact image the signature attested rather than resolving the mutable tag.
+// imageRef composes the `ref@digest` string the runner boots. Freeze records
+// the digest as a bare `sha256:<hex>`, so the ref and digest are joined with
+// `@`. An empty digest degrades to the bare ref rather than a dangling `@`. The
+// digest is the content-addressed identity, so a runner handed this string
+// boots the exact image the signature attested rather than resolving the
+// mutable tag.
 func imageRef(ref, digest string) string {
 	if digest == "" {
 		return ref

--- a/internal/flightplan/runtime/image_test.go
+++ b/internal/flightplan/runtime/image_test.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+)
+
+func TestRunInImage_BootsExactPinnedImage(t *testing.T) {
+	// A plan that pins a rung image boots that exact ref@digest through the
+	// ImageRunner. The recorded image is the load-bearing assertion: it must
+	// equal ref@sha256:<digest-from-lock>, never a re-resolved tag.
+	digest := "sha256:" + strings.Repeat("a", 64)
+	lp := LoadedPlan{
+		ContentHash:    "sha256:content",
+		ResolvedImages: []freeze.ImagePin{{Ref: "registry.example.com/runner:1.4", Digest: digest}},
+	}
+	fake := &fakeImageRunner{result: ImageRunResult{
+		ContentHash:    "sha256:content",
+		ResolvedInputs: map[string]any{"k": "v"},
+		StepOutputs:    map[string]map[string]any{"s1": {"out": 1}},
+		AuditIDs:       []string{"audit-1"},
+	}}
+	res, err := runInImage(context.Background(), lp, Options{
+		Name:        "weekly-metrics-digest",
+		Version:     "1.0.0",
+		Inputs:      LaunchArgs{"since": "2026-01-01"},
+		OutDir:      "/tmp/out",
+		ImageRunner: fake,
+	})
+	if err != nil {
+		t.Fatalf("runInImage: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("the image runner was never called")
+	}
+	wantImage := "registry.example.com/runner:1.4@" + digest
+	if fake.spec.Image != wantImage {
+		t.Errorf("booted image = %q, want %q", fake.spec.Image, wantImage)
+	}
+	if fake.spec.Name != "weekly-metrics-digest" || fake.spec.Version != "1.0.0" {
+		t.Errorf("spec selector = %q/%q, want the launch selector", fake.spec.Name, fake.spec.Version)
+	}
+	if fake.spec.OutDir != "/tmp/out" {
+		t.Errorf("spec OutDir = %q, want the launch out-dir", fake.spec.OutDir)
+	}
+	if fake.spec.Inputs["since"] != "2026-01-01" {
+		t.Errorf("spec Inputs = %v, want the launch inputs", fake.spec.Inputs)
+	}
+	// The runner's result maps straight onto the public RunResult shape.
+	if res.ContentHash != "sha256:content" || res.ResolvedInputs["k"] != "v" ||
+		res.StepOutputs["s1"]["out"] != 1 || len(res.AuditIDs) != 1 {
+		t.Errorf("RunResult not mapped from ImageRunResult: %+v", res)
+	}
+}
+
+func TestRunInImage_PinnedButNoRunnerErrors(t *testing.T) {
+	// A plan that declares and pins a rung image but supplies no ImageRunner is
+	// an explicit error, never a silent in-process fallback: ignoring the pin
+	// would enter an environment the attestation never certified.
+	lp := LoadedPlan{
+		ResolvedImages: []freeze.ImagePin{{Ref: "registry.example.com/runner:1.4", Digest: "sha256:" + strings.Repeat("a", 64)}},
+	}
+	res, err := runInImage(context.Background(), lp, Options{ImageRunner: nil})
+	if err == nil {
+		t.Fatal("a pinned image with no runner must error")
+	}
+	if !strings.Contains(err.Error(), "no image runner is configured") {
+		t.Errorf("error = %q, want a no-runner-configured message", err.Error())
+	}
+	if res.ContentHash != "" || len(res.Artifacts) != 0 {
+		t.Errorf("a refused boot must produce a zero RunResult, got %+v", res)
+	}
+}
+
+func TestRunInImage_PropagatesRunnerError(t *testing.T) {
+	// A boot failure surfaces from the runner unchanged and yields no result.
+	lp := LoadedPlan{
+		ResolvedImages: []freeze.ImagePin{{Ref: "r", Digest: "sha256:" + strings.Repeat("a", 64)}},
+	}
+	boom := errors.New("boot failed")
+	res, err := runInImage(context.Background(), lp, Options{ImageRunner: &fakeImageRunner{err: boom}})
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want the runner error", err)
+	}
+	if res.ContentHash != "" {
+		t.Errorf("a failed boot must produce a zero RunResult, got %+v", res)
+	}
+}
+
+func TestImageRef_JoinsRefAndDigest(t *testing.T) {
+	got := imageRef("registry.example.com/runner:1.4", "sha256:abc")
+	if got != "registry.example.com/runner:1.4@sha256:abc" {
+		t.Errorf("imageRef = %q", got)
+	}
+	// An empty digest degrades to the bare ref rather than a dangling `@`.
+	if got := imageRef("r", ""); got != "r" {
+		t.Errorf("imageRef with empty digest = %q, want the bare ref", got)
+	}
+}

--- a/internal/flightplan/runtime/load.go
+++ b/internal/flightplan/runtime/load.go
@@ -21,6 +21,12 @@ func (e *LoadError) Error() string { return "flightplan load: " + e.Reason }
 type LoadedPlan struct {
 	Plan        *Plan
 	ContentHash string
+	// ResolvedImages carries the verified image digest pins from the frozen
+	// lock (rung-1 or rung-2). When non-empty, Run boots the pinned image and
+	// runs the plan inside it; when empty, Run stays on the in-process path.
+	// The pins come from the verified manifest lock block, so the digest booted
+	// is exactly the one the author signature attested.
+	ResolvedImages []freeze.ImagePin
 }
 
 // LoadVerified loads a frozen skill version from the store, verifies it
@@ -58,5 +64,9 @@ func verifyAndDecode(fv store.FrozenVersion) (LoadedPlan, error) {
 	if err != nil {
 		return LoadedPlan{}, err
 	}
-	return LoadedPlan{Plan: plan, ContentHash: verified.ContentHash}, nil
+	return LoadedPlan{
+		Plan:           plan,
+		ContentHash:    verified.ContentHash,
+		ResolvedImages: verified.ResolvedImages,
+	}, nil
 }

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -58,6 +58,95 @@ func frozenExample(t *testing.T) store.FrozenVersion {
 	}
 }
 
+// frozenNoImage freezes a no-execution-environment variant of the worked
+// example: the same fully-stepped plan with the `executionEnvironment` block
+// removed, so freeze pins no image. The runtime must stay on the in-process
+// path for it. Deriving from the worked example keeps the plan a real,
+// decodable step graph (the minimal no-step manifests Decode rejects) while
+// isolating exactly the no-rung condition.
+func frozenNoImage(t *testing.T) store.FrozenVersion {
+	t.Helper()
+	keyPath := writeSigningKey(t)
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	stripped := stripExecutionEnvironment(t, string(raw))
+
+	res, err := freeze.Run(context.Background(), []byte(stripped), freeze.Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run no-exec-env variant: %v", err)
+	}
+	return store.FrozenVersion{
+		ID:        "test",
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}
+}
+
+// stripExecutionEnvironment removes the `executionEnvironment:` mapping (and
+// its indented children) from the worked-example frontmatter, leaving a valid
+// no-rung manifest. It drops the block by 4-space indent boundary: the block
+// header sits at 4 spaces and its children are more deeply indented, so
+// dropping from the header until the next line at 4-or-fewer spaces excises
+// exactly the block.
+func stripExecutionEnvironment(t *testing.T, md string) string {
+	t.Helper()
+	lines := strings.Split(md, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	for _, ln := range lines {
+		if !skipping {
+			if strings.TrimSpace(ln) == "executionEnvironment:" &&
+				strings.HasPrefix(ln, "    executionEnvironment:") {
+				skipping = true
+				continue
+			}
+			out = append(out, ln)
+			continue
+		}
+		// While skipping: a line indented deeper than 4 spaces (or blank) is a
+		// child of the block; a line at 4-or-fewer spaces ends it.
+		trimmed := strings.TrimLeft(ln, " ")
+		indent := len(ln) - len(trimmed)
+		if trimmed == "" || indent > 4 {
+			continue
+		}
+		skipping = false
+		out = append(out, ln)
+	}
+	res := strings.Join(out, "\n")
+	if strings.Contains(res, "executionEnvironment:") {
+		t.Fatalf("stripExecutionEnvironment left the block in place")
+	}
+	return res
+}
+
+// writeSigningKey generates a fresh ed25519 key, writes its PKCS#8 PEM to a
+// temp file, and returns the path.
+func writeSigningKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "signing-key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return keyPath
+}
+
 func TestLoadVerified_UntamperedLoads(t *testing.T) {
 	fv := frozenExample(t)
 	lp, err := verifyAndDecode(fv)
@@ -69,6 +158,57 @@ func TestLoadVerified_UntamperedLoads(t *testing.T) {
 	}
 	if !strings.HasPrefix(lp.ContentHash, "sha256:") {
 		t.Errorf("content hash = %q", lp.ContentHash)
+	}
+}
+
+func TestLoadVerified_PropagatesResolvedImages(t *testing.T) {
+	// The worked example is rung-2: its verified lock pins a composed image
+	// digest. verifyAndDecode must carry that pin onto the LoadedPlan so Run can
+	// boot the exact image the signature attested.
+	fv := frozenExample(t)
+	lp, err := verifyAndDecode(fv)
+	if err != nil {
+		t.Fatalf("verifyAndDecode: %v", err)
+	}
+	if len(lp.ResolvedImages) != 1 {
+		t.Fatalf("ResolvedImages = %+v, want exactly one pin", lp.ResolvedImages)
+	}
+	wantDigest := "sha256:" + strings.Repeat("a", 64)
+	if lp.ResolvedImages[0].Digest != wantDigest {
+		t.Errorf("ResolvedImages[0].Digest = %q, want %q", lp.ResolvedImages[0].Digest, wantDigest)
+	}
+	if lp.ResolvedImages[0].Ref == "" {
+		t.Error("ResolvedImages[0].Ref must carry the pre-freeze reference")
+	}
+}
+
+// fakeImageRunner records the spec it was handed and returns a canned result,
+// so the runtime boot-vs-in-process branch is testable with no live container.
+type fakeImageRunner struct {
+	called bool
+	gotctx context.Context
+	spec   ImageRunSpec
+	result ImageRunResult
+	err    error
+}
+
+func (f *fakeImageRunner) Run(ctx context.Context, spec ImageRunSpec) (ImageRunResult, error) {
+	f.called = true
+	f.gotctx = ctx
+	f.spec = spec
+	return f.result, f.err
+}
+
+func TestImageRunner_FakeSatisfiesInterface(t *testing.T) {
+	// Compile-time and behavioral proof that the SPI is satisfiable by a fake:
+	// the boot path never needs a live container to test.
+	var r ImageRunner = &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:x"}}
+	out, err := r.Run(context.Background(), ImageRunSpec{Image: "img@sha256:x"})
+	if err != nil {
+		t.Fatalf("fake ImageRunner: %v", err)
+	}
+	if out.ContentHash != "sha256:x" {
+		t.Errorf("result ContentHash = %q, want the canned value", out.ContentHash)
 	}
 }
 

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -35,6 +35,14 @@ type Options struct {
 	// Seam is the single marked LLM seam. Nil (the v1 default) makes any
 	// llm-seam step error, so a default launch reaches no LLM.
 	Seam LLMSeam
+	// ImageRunner boots the verified pinned rung-1/rung-2 image and runs the
+	// plan inside it. When the loaded plan carries a resolved image pin and this
+	// seam is wired, Run delegates to it; when the plan pins no image, Run stays
+	// on the in-process path and never touches this seam. A plan that pins an
+	// image with no ImageRunner configured is an explicit error, never a silent
+	// in-process fallback (a declared rung must be entered to honor the
+	// attestation).
+	ImageRunner ImageRunner
 
 	// Clock supplies the single launch-time read for dynamic inputs. Nil uses
 	// SystemClock.
@@ -73,6 +81,13 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	lp, err := LoadVerified(opts.Store, opts.Name, opts.Version)
 	if err != nil {
 		return RunResult{}, err
+	}
+	// When the verified lock pins a rung-1/rung-2 image, boot that exact image
+	// and run the plan inside it (#1731). This keeps the boot-vs-in-process
+	// decision in one place; runPlan (Phase A / Phase B / materialize / audit)
+	// is untouched on the parity path.
+	if len(lp.ResolvedImages) > 0 {
+		return runInImage(ctx, lp, opts)
 	}
 	return runPlan(ctx, lp.Plan, lp.ContentHash, opts)
 }

--- a/internal/flightplan/runtime/run_extra_test.go
+++ b/internal/flightplan/runtime/run_extra_test.go
@@ -46,13 +46,21 @@ func TestErrorMessages(t *testing.T) {
 	}
 }
 
-// TestRun_PublicEntryPointThroughStore exercises the public Run from a frozen
-// version on disk: load+verify+resolve+execute+materialize end-to-end.
-func TestRun_PublicEntryPointThroughStore(t *testing.T) {
+// TestRun_InProcessPipelineFromLoadedPlan exercises the in-process pipeline
+// from a frozen version on disk: load+verify then resolve+execute+materialize
+// end-to-end. The worked example is rung-2, so the public Run now boots the
+// pinned image (covered by TestRun_BootsPinnedImageWhenLockPinsRung); this test
+// drives the parity pipeline directly from the loaded plan so the resolve →
+// execute → materialize path stays covered independent of the boot branch.
+func TestRun_InProcessPipelineFromLoadedPlan(t *testing.T) {
 	fv := frozenExample(t)
 	s := store.New(t.TempDir())
 	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
 		t.Fatalf("WriteFrozen: %v", err)
+	}
+	lp, err := LoadVerified(s, "weekly-metrics-digest", "test")
+	if err != nil {
+		t.Fatalf("LoadVerified: %v", err)
 	}
 
 	reg := NewTransformRegistry()
@@ -64,10 +72,7 @@ func TestRun_PublicEntryPointThroughStore(t *testing.T) {
 		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
 	}}
 
-	res, err := Run(context.Background(), Options{
-		Store:      s,
-		Name:       "weekly-metrics-digest",
-		Version:    "test",
+	res, err := runPlan(context.Background(), lp.Plan, lp.ContentHash, Options{
 		Dispatcher: disp,
 		Approver:   &fakeApprover{decision: Decision{Approved: true}},
 		Seam:       fakeSeam{out: map[string]any{"issue_body": "x"}},
@@ -76,10 +81,10 @@ func TestRun_PublicEntryPointThroughStore(t *testing.T) {
 		OutDir:     t.TempDir(),
 	})
 	if err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("runPlan: %v", err)
 	}
 	if res.ContentHash == "" {
-		t.Error("Run must surface the verified content hash")
+		t.Error("runPlan must surface the verified content hash")
 	}
 	if len(res.Artifacts) != 2 {
 		t.Errorf("want 2 artifacts, got %d", len(res.Artifacts))

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
 )
 
 func TestRun_WritesArtifactsToOutDir(t *testing.T) {
@@ -115,5 +118,102 @@ func TestRun_DeniedApprovalAbortsAndAudits(t *testing.T) {
 	}
 	if !found {
 		t.Error("the audit must record the denied approval decision")
+	}
+}
+
+// TestRun_BootsPinnedImageWhenLockPinsRung proves the boot branch end to end:
+// the worked example is rung-2, so a store-backed Run delegates to the wired
+// ImageRunner with the exact ref@digest from the verified lock and never walks
+// the in-process pipeline.
+func TestRun_BootsPinnedImageWhenLockPinsRung(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	wantDigest := "sha256:" + strings.Repeat("a", 64)
+	fake := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:booted"}}
+	res, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "weekly-metrics-digest",
+		Version:     "test",
+		ImageRunner: fake,
+		// No Dispatcher/Approver/Seam: the boot path must not touch the
+		// in-process pipeline, so leaving them nil proves runPlan is skipped.
+	})
+	if err != nil {
+		t.Fatalf("Run boot path: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("Run did not delegate to the ImageRunner for a rung-pinned unit")
+	}
+	if !strings.HasSuffix(fake.spec.Image, "@"+wantDigest) {
+		t.Errorf("booted image = %q, want it to end with @%s", fake.spec.Image, wantDigest)
+	}
+	if res.ContentHash != "sha256:booted" {
+		t.Errorf("RunResult.ContentHash = %q, want the runner's result", res.ContentHash)
+	}
+}
+
+// TestRun_PinnedButNoRunnerErrorsFromStore proves the guard fires end to end: a
+// store-backed unit that pins a rung with no ImageRunner configured refuses,
+// never silently falling back to the in-process path.
+func TestRun_PinnedButNoRunnerErrorsFromStore(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	_, err := Run(context.Background(), Options{
+		Store:   s,
+		Name:    "weekly-metrics-digest",
+		Version: "test",
+		// ImageRunner intentionally nil.
+	})
+	if err == nil {
+		t.Fatal("a rung-pinned unit with no ImageRunner must refuse")
+	}
+	if !strings.Contains(err.Error(), "no image runner is configured") {
+		t.Errorf("error = %q, want a no-runner-configured message", err.Error())
+	}
+}
+
+// TestRun_NoRungStaysInProcess proves parity: a unit that pins no image never
+// touches the ImageRunner and drives the in-process runPlan pipeline.
+func TestRun_NoRungStaysInProcess(t *testing.T) {
+	fv := frozenNoImage(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-exec-env", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	fake := &fakeImageRunner{}
+	res, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "no-exec-env",
+		Version:     "test",
+		ImageRunner: fake,
+		Dispatcher:  disp,
+		Approver:    &fakeApprover{decision: Decision{Approved: true}},
+		Seam:        fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:       FixedClock{},
+		Transforms:  reg,
+		OutDir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run in-process path: %v", err)
+	}
+	if fake.called {
+		t.Fatal("a unit that pins no image must not touch the ImageRunner")
+	}
+	if !strings.HasPrefix(res.ContentHash, "sha256:") {
+		t.Errorf("in-process RunResult.ContentHash = %q, want the verified hash", res.ContentHash)
 	}
 }

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -93,3 +93,53 @@ type SeamRequest struct {
 type LLMSeam interface {
 	Run(ctx context.Context, req SeamRequest) (map[string]any, error)
 }
+
+// ImageRunSpec is the input to the ImageRunner seam. It carries the verified
+// pinned image (the `ref@digest` string the runtime booted from the signed
+// lock) plus everything the in-container launch needs to run the plan to
+// completion: the frozen-unit selector (Name/Version), the launch input
+// overrides, and the out-dir artifacts are written to.
+type ImageRunSpec struct {
+	// Image is the exact `ref@sha256:<hex>` the verified lock pinned. It is the
+	// load-bearing security value: the runner MUST boot this image verbatim so
+	// the environment entered corresponds to the lock's signed assertion.
+	Image string
+	// Name is the frozen skill name (the store selector).
+	Name string
+	// Version is the frozen version id (the store directory id).
+	Version string
+	// Inputs are the literal input overrides supplied at launch.
+	Inputs LaunchArgs
+	// OutDir is the directory file-target artifacts are written to. Empty skips
+	// writing (artifacts are still recorded in the result).
+	OutDir string
+}
+
+// ImageRunResult maps onto RunResult so the image-boot path returns the same
+// public shape as the in-process path. A caller cannot tell from the result
+// which path produced it, which keeps launch output identical across the
+// boot-vs-in-process branch.
+type ImageRunResult struct {
+	// ContentHash is the verified content hash of the frozen unit that ran.
+	ContentHash string
+	// ResolvedInputs is the frozen resolved-input set.
+	ResolvedInputs map[string]any
+	// StepOutputs maps steps.<id> → its named outputs.
+	StepOutputs map[string]map[string]any
+	// Artifacts are the materialized output artifacts.
+	Artifacts []Artifact
+	// AuditIDs are the audit record ids emitted to the sink.
+	AuditIDs []string
+}
+
+// ImageRunner boots the verified pinned rung-1/rung-2 image and runs the frozen
+// plan to completion inside it (issue #1731). The runtime core depends only on
+// this seam; the CLI (cmd/aileron) wires the production implementation over
+// internal/sandbox/container, so the runtime never imports the container
+// package. Its contract: boot the exact image named in ImageRunSpec.Image,
+// run the selected frozen unit against the given inputs/out-dir, and return the
+// RunResult-shaped outcome. The runtime supplies ImageRunSpec.Image straight
+// from the verified lock, so the runner is handed a pin it must not re-resolve.
+type ImageRunner interface {
+	Run(ctx context.Context, spec ImageRunSpec) (ImageRunResult, error)
+}


### PR DESCRIPTION
## Summary

Closes #1731. Foundational sub-issue of umbrella #1730.

Freeze already resolves and pins the rung-1/rung-2 execution image digest into the signed lock, but nothing entered that image at launch: the pin was signed-but-unused. This unit closes that gap. When a verified frozen unit carries a resolved image digest, `aileron skill launch` boots that exact pinned image through the container runtime and runs the Flight Plan runtime inside it. A plan with no rung declared (empty `ResolvedImages`) stays on the current in-process step-graph path.

The load-bearing security property: the digest booted comes only from the verified lock. `freeze.VerifyFrozen` populates `ResolvedImages` from the manifest lock block it has already proven consistent against the content hash and signature, so a tampered digest refuses verification before any pin is exposed. There is no second, untrusted parse.

### What changed

- **`freeze.VerifyFrozen`** exposes `VerifiedFrozen.ResolvedImages`, a defensive copy of the verified manifest-lock pins.
- **`runtime.LoadedPlan`** carries the pins; a new **`ImageRunner` SPI** (`ImageRunSpec`/`ImageRunResult`) is the boot seam so the runtime never imports `internal/sandbox/container`, mirroring the existing `ActionDispatcher`/`Approver`/`AuditSink`/`LLMSeam` discipline.
- **`runtime.Run`** branches once: a non-empty pin set delegates to the `ImageRunner` with `ref@digest`; otherwise `runPlan` runs unchanged. A pinned unit with no `ImageRunner` is an explicit error, never a silent in-process fallback.
- **`cmd/aileron`** wires the production `containerImageRunner` behind the swappable `newLaunchImageRunner` seam (like the other three launch seams); it boots the pin via `container.Builder` with the frozen store mounted read-only and the out-dir writable.
- **ADR-0027** records that the digest pin is load-bearing at launch, not only at freeze. Rung-3 deferral prose is preserved.

### Scope boundaries honored

- No manifest-schema or OpenAPI change (launch-time wiring only).
- Rung-3 untouched; freeze still reports it deferred.
- No credential/proxy work.
- No live Docker in tests; all coverage rides the SPI/Runner fakes.
- Versions stay 0.0.x.

## Test plan

- `task test:go` green across the whole module.
- New/updated tests:
  - freeze: rung-1 and rung-2 pins exposed; no-exec-env empty; tampered digest refuses before exposure.
  - runtime: pins propagate onto `LoadedPlan`; `Run` boots the exact `ref@sha256:<digest>` for a rung-pinned unit; no-rung unit stays in-process and never touches the runner; pinned-but-no-runner errors with zero side effects.
  - cmd/aileron: boot path asserts the exact `ref@digest` from the verified lock and exits 0; no-rung path walks the dispatcher and materializes artifacts; pinned-but-runner-misconfigured exits non-zero with a clear error; `containerImageRunner` spec-construction (exact image, store-ro + out-rw mounts, in-container argv) tested behind a fake boot.
- New code coverage: `image.go`/`Run` at 100%; `containerImageRunner.Run` at 87%.
- Docs voice checked: no em-dashes in the ADR edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch now supports running pinned skill images in a container when a verified image is available.
  * Added support for configuring the skill store location at launch time.
  * Input overrides and output directories are now handled consistently in both launch paths.

* **Bug Fixes**
  * Improved fallback behavior for skills without a pinned image, keeping them on the in-process execution path.
  * Added clearer errors when a pinned image is present but no image execution path is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->