### PR TITLE
fix(flightplan): guard single-pin invariant in runInImage

### DIFF
--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -15,6 +15,13 @@ import (
 // a silent in-process fallback. A rung was declared and pinned; running the
 // plan in-process would enter an environment the attestation never certified.
 func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, error) {
+	// Rung-1/rung-2 resolve exactly one image pin, and the attestation certifies
+	// that single environment. Guard the invariant so a future multi-pin rung
+	// can never silently boot only pins[0] while ignoring the rest.
+	if len(lp.ResolvedImages) != 1 {
+		return RunResult{}, fmt.Errorf(
+			"flightplan: expected exactly one resolved image pin, got %d", len(lp.ResolvedImages))
+	}
 	pin := lp.ResolvedImages[0]
 	if opts.ImageRunner == nil {
 		return RunResult{}, fmt.Errorf(

--- a/internal/flightplan/runtime/image_test.go
+++ b/internal/flightplan/runtime/image_test.go
@@ -91,6 +91,32 @@ func TestRunInImage_PropagatesRunnerError(t *testing.T) {
 	}
 }
 
+func TestRunInImage_RejectsMultiplePins(t *testing.T) {
+	// The attestation certifies exactly one image environment, so a plan that
+	// somehow carries more than one resolved pin must error rather than silently
+	// boot pins[0] and ignore the rest. Guards the single-pin invariant against a
+	// future multi-pin rung.
+	lp := LoadedPlan{
+		ResolvedImages: []freeze.ImagePin{
+			{Ref: "registry.example.com/runner:1.4", Digest: "sha256:" + strings.Repeat("a", 64)},
+			{Ref: "registry.example.com/runner:2.0", Digest: "sha256:" + strings.Repeat("b", 64)},
+		},
+	}
+	res, err := runInImage(context.Background(), lp, Options{ImageRunner: &fakeImageRunner{}})
+	if err == nil {
+		t.Fatal("a plan with two resolved pins must error")
+	}
+	if !strings.Contains(err.Error(), "expected exactly one resolved image pin") {
+		t.Errorf("error = %q, want a single-pin invariant message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "got 2") {
+		t.Errorf("error = %q, want the observed pin count", err.Error())
+	}
+	if res.ContentHash != "" || len(res.Artifacts) != 0 {
+		t.Errorf("a rejected boot must produce a zero RunResult, got %+v", res)
+	}
+}
+
 func TestImageRef_JoinsRefAndDigest(t *testing.T) {
 	got := imageRef("registry.example.com/runner:1.4", "sha256:abc")
 	if got != "registry.example.com/runner:1.4@sha256:abc" {


### PR DESCRIPTION
## Summary

`runInImage` in `internal/flightplan/runtime/image.go` selected `lp.ResolvedImages[0]` guarded only by the caller's `len > 0` check, with no assertion that exactly one pin exists. Rung-1/rung-2 always resolve exactly one pin today, so this guard changes no current behavior. It hardens the attestation claim: a future multi-pin rung can no longer silently boot only the first image while ignoring the rest. The boot now fails fast with a clear error when the resolved-pin count is not exactly one.

## Test plan

- Added `TestRunInImage_RejectsMultiplePins` asserting the guard fires for a two-pin `LoadedPlan` (errors with the single-pin invariant message, reports the observed count, and returns a zero `RunResult`). Fails before the guard, passes after.
- Existing single-pin happy-path / no-runner / runner-error tests still pass.
- `go test ./internal/flightplan/runtime/...` green; `go build ./internal/...` and `go vet ./internal/flightplan/runtime/...` clean.

Relates to #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)