### PR TITLE
feat(flightplan): build and pin rung-3 per-step tool images at freeze

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -78,12 +78,6 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
 	fmt.Fprintf(stdout, "  Stored at:   %s\n", s.FrozenDir(res.Name, id))
-	// Surface any execution-environment rung that was declared but
-	// intentionally not built (today: the reserved rung-3 slot). The operator
-	// is told explicitly rather than left to assume the image set is complete.
-	for _, rung := range res.DeferredRungs {
-		fmt.Fprintf(stdout, "  Rung 3 declared: build-deferred (reserved manifest slot %q, ADR-0027); no image built\n", rung)
-	}
 	return 0
 }
 

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -270,16 +270,17 @@ aileron:
 	}
 }
 
-func TestRunSkillFreeze_Rung3ReportedDeferred(t *testing.T) {
+func TestRunSkillFreeze_Rung3PinsPerStepDigest(t *testing.T) {
 	storeDir := withTempStore(t)
 	stubFreezeResolvers(t, fakeFreezeDigest)
 	key := writeSigningKey(t)
 
-	// A skill declaring only the reserved rung-3 slot. Freeze must succeed,
-	// pin no image, and tell the operator the rung is build-deferred.
+	// A skill declaring a rung-3 per-step image. Freeze must succeed, resolve
+	// the per-step sibling image to a digest pin recorded in the lockfile, and
+	// no longer print a build-deferred line.
 	const rung3MD = `---
 name: rung3-skill
-description: Reserved rung-3 declaration.
+description: Rung-3 per-step image declaration.
 aileron:
   schemaVersion: aileron.flightplan.v1
   requires:
@@ -317,17 +318,14 @@ aileron:
 	var stdout, stderr bytes.Buffer
 	code := runSkillFreeze([]string{"--signing-key", key, "rung3-skill"}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("a rung-3 freeze must succeed (build-deferred, not an error), exit=%d stderr=%s", code, stderr.String())
+		t.Fatalf("a rung-3 freeze must succeed, exit=%d stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "Rung 3 declared: build-deferred") {
-		t.Errorf("operator must be told rung-3 is build-deferred, stdout=%q", out)
-	}
-	if !strings.Contains(out, "ADR-0027") {
-		t.Errorf("the deferred line should cite ADR-0027, stdout=%q", out)
+	if strings.Contains(out, "build-deferred") {
+		t.Errorf("rung-3 is now built; no build-deferred line must be printed, stdout=%q", out)
 	}
 
-	// The frozen lockfile pins no image (nothing was built).
+	// The frozen lockfile pins the per-step digest (rung-3 builds).
 	s := store.New(storeDir)
 	ids, err := s.FrozenVersions("rung3-skill")
 	if err != nil || len(ids) != 1 {
@@ -337,8 +335,11 @@ aileron:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(v.Lockfile), "resolvedImages:") {
-		t.Errorf("a rung-3 freeze must pin no image, lockfile:\n%s", v.Lockfile)
+	if !strings.Contains(string(v.Lockfile), "resolvedImages:") {
+		t.Errorf("a rung-3 freeze must pin the per-step image, lockfile:\n%s", v.Lockfile)
+	}
+	if !strings.Contains(string(v.Lockfile), fakeFreezeDigest) {
+		t.Errorf("a rung-3 freeze must pin the resolved digest, lockfile:\n%s", v.Lockfile)
 	}
 	if len(v.Signature) == 0 {
 		t.Error("a rung-3 freeze must still be signed")

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -83,11 +83,27 @@
     },
     "executionEnvironment": {
       "type": "object",
-      "description": "The execution-environment dependency. At most one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs; rung-1 and rung-2 are mutually exclusive. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot: a manifest may declare rung3PerStepImages alone, in which case freeze parses it and reports it as build-deferred rather than building anything.",
+      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image), rung-2 (composed capability units on the Aileron base), or rung-3 (per-step sealed sibling-image dispatch) is declared per ADR-0027 execution rungs; the three rungs are mutually exclusive. Freeze resolves the declared rung to content-addressed digest pins recorded in the lock section.",
       "additionalProperties": false,
       "oneOf": [
-        { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
-        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
+        {
+          "required": ["rung1Image"],
+          "not": {
+            "anyOf": [
+              { "required": ["rung2CapabilityUnits"] },
+              { "required": ["rung3PerStepImages"] }
+            ]
+          }
+        },
+        {
+          "required": ["rung2CapabilityUnits"],
+          "not": {
+            "anyOf": [
+              { "required": ["rung1Image"] },
+              { "required": ["rung3PerStepImages"] }
+            ]
+          }
+        },
         {
           "required": ["rung3PerStepImages"],
           "not": {
@@ -131,9 +147,58 @@
           }
         },
         "rung3PerStepImages": {
-          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling. Freeze parses a rung-3 declaration and reports it as build-deferred (empty image set); it never builds a rung-3 image in v1.",
           "type": "object",
-          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. A manifest may declare this slot alone: freeze parses it and reports it as build-deferred rather than building anything. Do not author this field expecting runtime support."
+          "description": "Rung three. Per-step sealed sibling-image dispatch with mount and run-and-collect I/O (ADR-0027 rung three). Each step names a sibling image freeze resolves to a content-addressed digest, pinned in the lock section alongside the rung-1 and rung-2 pins. The per-step image is the operator-owned tool the step dispatches to.",
+          "additionalProperties": false,
+          "required": ["steps"],
+          "properties": {
+            "steps": {
+              "type": "array",
+              "description": "The per-step sibling images. Each entry names an image freeze resolves to a digest pin, with an optional identifier and an optional mount and run-and-collect I/O declaration.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An optional step identifier, unique within the rung-3 step set.",
+                    "minLength": 1
+                  },
+                  "image": {
+                    "type": "string",
+                    "description": "An OCI image reference for the per-step sibling tool. Pre-freeze this may be a fixed-version tag (for example registry.example.com/aws-cli:2). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+                    "minLength": 1
+                  },
+                  "mount": {
+                    "type": "object",
+                    "description": "An optional mount declaration for the step's input I/O (ADR-0027 mount boundary).",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "description": "The mount path inside the per-step image.",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "collect": {
+                    "type": "object",
+                    "description": "An optional run-and-collect declaration for the step's output I/O (ADR-0027 run-and-collect boundary).",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "description": "The path inside the per-step image whose contents are collected as the step output.",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
+++ b/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
@@ -64,9 +64,9 @@ Rung one pins a whole prebuilt image. The skill names an image, and freeze resol
 
 Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result. The capability-unit shape is the one defined in [ADR-0026](/adr/0026-cli-capability-units).
 
-The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as a manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here. A manifest may declare the `rung3PerStepImages` slot alone. Freeze parses that declaration, builds no image, and reports the rung as build-deferred to the operator, so a rung-three-only Flight Plan is a told outcome rather than a parse failure or a silent pass.
+Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Each step names a sibling image, and freeze resolves each named image to a content-addressed digest. Freeze records one digest pin per step in the lock alongside the rung-one and rung-two pins. The per-step image is the operator-owned tool the step dispatches to. A manifest may declare the `rung3PerStepImages` rung alone, and freeze pins one digest per step so a rung-three Flight Plan seals to a signed image assertion like every other rung.
 
-The digest pin is load-bearing at launch, not only at freeze. When the verified lock carries a resolved rung-one or rung-two image digest, launch boots that exact pinned image and runs the plan inside it. The digest booted comes from the verified lock, so the image entered corresponds to the lock's signed image assertion rather than any re-resolved tag. A Flight Plan that declares no execution rung has an empty resolved-image set, so its launch runs the step graph in-process instead of booting an image. Rung three stays build-deferred, so a per-step sibling image is not booted at launch.
+The digest pin is load-bearing at launch, not only at freeze. When the verified lock carries a resolved rung-one or rung-two image digest, launch boots that exact pinned image and runs the plan inside it. The digest booted comes from the verified lock, so the image entered corresponds to the lock's signed image assertion rather than any re-resolved tag. A Flight Plan that declares no execution rung has an empty resolved-image set, so its launch runs the step graph in-process instead of booting an image. Rung three records each per-step sibling image as a verified digest pin, so a step that dispatches a sibling image enters it by its signed digest rather than a re-resolved tag.
 
 The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
 
@@ -134,7 +134,6 @@ The diagram below shows the boundary. A skill crosses the freeze step and become
 ### Negative
 
 - Freeze is rigid. A frozen Flight Plan pins one resolved environment, and changing the environment requires a new freeze and a new version.
-- Rung three is deferred. Per-step sealed sibling-image dispatch with mount and run-and-collect I/O is a manifest slot only, so a Flight Plan cannot yet dispatch per-step sibling images.
 - The single-seam constraint is strict. A Flight Plan that needs LLM reasoning in more than one place must route all of it through the one marked seam or restructure to fit.
 - The trust contract is verbose. Every action carries a full contract block, and authoring a Flight Plan with many actions records many such blocks.
 
@@ -142,7 +141,7 @@ The diagram below shows the boundary. A skill crosses the freeze step and become
 
 The following are out of scope for this ADR and this layer's MVP.
 
-- Rung three build. The per-step sealed sibling-image dispatch with mount and run-and-collect I/O is a forward-declared manifest slot only.
+- Per-step launch dispatch. Freeze pins the rung-three per-step sibling images by digest, but the launch-time runtime that mounts each image, runs it, and collects its output is a follow-up.
 - Binary outputs. The `outputs:` contract reserves the `base64` encoding, but the v1 runtime materializes `utf-8` artifacts only. Binary output is blocked on a host-ABI binary-body field, because the current JSON-string result body coerces arbitrary bytes to valid UTF-8 and corrupts them. The mount and run-and-collect boundary of rung three (#1510) is the escape hatch for large or binary artifacts when a consumer arrives.
 - STS and SSO. Short-lived token services and single sign-on integration are not specified here.
 - Specific connectors. No named connector is specified by this ADR. The trust-contract format applies to any action, and individual connector contracts are authored against this format elsewhere.

--- a/docs/src/content/docs/concepts/flight-plans.md
+++ b/docs/src/content/docs/concepts/flight-plans.md
@@ -64,7 +64,7 @@ Rung one pins a whole prebuilt image. The skill names an image, and freeze resol
 
 Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result.
 
-The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch, and it is a forward-declared manifest slot only. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
+Rung three is a per-step sealed sibling-image dispatch. Freeze resolves each step's sibling image to a content-addressed digest pinned in the lock. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
 
 ## The lifecycle
 

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -77,7 +77,7 @@ An unsatisfied `requires:` entry is a missing-requirement signal the runtime sur
 
 ### `requires.executionEnvironment`
 
-The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two. When `executionEnvironment` declares an image rung it carries at most one of `rung1Image` or `rung2CapabilityUnits`; the two are mutually exclusive. The reserved `rung3PerStepImages` slot may be declared alone. Freeze parses a rung-three declaration and reports it as build-deferred (it pins no image), so a rung-three-only manifest is valid and is told to the operator rather than failing.
+The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). Exactly one of `rung1Image`, `rung2CapabilityUnits`, or `rung3PerStepImages` is declared when `executionEnvironment` is present. The three rungs are mutually exclusive. Freeze resolves the declared rung to content-addressed digest pins recorded in the lock section.
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|
@@ -85,7 +85,12 @@ The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-se
 | `rung1Image.ref` | string | Yes within `rung1Image` | An OCI image reference. Freeze resolves a tag to an `image@sha256:` digest pin. |
 | `rung2CapabilityUnits` | object | No | Rung two. Declares capability units composed onto the Aileron agent-free base image. |
 | `rung2CapabilityUnits.features` | array | Yes within `rung2CapabilityUnits` | The capability-unit devcontainer Feature references ([ADR-0026](/adr/0026-cli-capability-units)). |
-| `rung3PerStepImages` | object | No | RESERVED and build-deferred. The rung-three per-step sibling-image dispatch slot. Designed as a manifest slot only. Not implemented in v1. May be declared alone: freeze parses it and reports it as build-deferred rather than building anything. |
+| `rung3PerStepImages` | object | No | Rung three. Per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Freeze resolves each step's sibling image to a digest pin recorded in the lock. |
+| `rung3PerStepImages.steps` | array | Yes within `rung3PerStepImages` | The per-step sibling images. Non-empty; freeze pins one digest per step. |
+| `rung3PerStepImages.steps[].image` | string | Yes within a step | An OCI image reference for the per-step sibling tool. Freeze resolves a tag to an `image@sha256:` digest pin. |
+| `rung3PerStepImages.steps[].id` | string | No | An optional step identifier, unique within the rung-three step set. |
+| `rung3PerStepImages.steps[].mount` | object | No | An optional mount declaration for the step's input I/O. `mount.path` is the mount path inside the image. |
+| `rung3PerStepImages.steps[].collect` | object | No | An optional run-and-collect declaration for the step's output I/O. `collect.path` is the path whose contents are collected as the step output. |
 
 ### `requires.actions[].trustContract`
 
@@ -263,4 +268,4 @@ The version is the content hash plus a semver label. The content hash identifies
 
 A Flight Plan runs on a composed execution image assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). Rung one pins a whole prebuilt operator-owned image, declared as `rung1Image`. Rung two declares capability units that Aileron composes onto a generic agent-free minimal base image, declared as `rung2CapabilityUnits` whose Features follow [ADR-0026](/adr/0026-cli-capability-units).
 
-The MVP ships rung one and rung two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as the `rung3PerStepImages` manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
+Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O carried in the `rung3PerStepImages` rung. Freeze resolves each step's sibling image to a content-addressed digest pinned in the lock. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.

--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -105,12 +105,11 @@ Declare the minimum each action needs. The contract is verbose by design. A plan
 
 ### The execution environment
 
-`requires.executionEnvironment` declares the image the Flight Plan runs in, as one rung. The MVP ships two rungs, and they are mutually exclusive.
+`requires.executionEnvironment` declares the image the Flight Plan runs in, as one rung. The three rungs are mutually exclusive, so exactly one is declared.
 
 - `rung1Image.ref` names a whole prebuilt operator-owned image. Freeze resolves a tag to an `image@sha256:` digest pin.
 - `rung2CapabilityUnits.features` declares the capability-unit devcontainer Features composed onto the Aileron agent-free base image. Freeze composes them and pins the built image by digest.
-
-The reserved `rung3PerStepImages` slot may be declared alone. Freeze parses it, builds nothing, and reports it as build-deferred, so a rung-three-only manifest is a told outcome rather than a parse failure.
+- `rung3PerStepImages.steps` declares one sibling image per step, each with an optional `id`, `mount`, and `collect`. Freeze resolves each step's image to an `image@sha256:` digest pin recorded in the lock.
 
 The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
 
@@ -202,7 +201,7 @@ After freeze, [launch](/guides/launching-a-flight-plan/) runs the frozen Flight 
 - **More than one seam.** v1 allows exactly one marked seam. Route all reasoning through it.
 - **An `actionRef` with no matching `requires.actions[].ref`.** A step can only call an action the `requires:` block declares. The freeze lint catches the mismatch.
 - **Hand-writing the lock.** The `lock` section is produced by freeze. It is absent before freeze, and you never author it.
-- **A `base64` output in v1.** The `encoding` field reserves `base64`, but the v1 runtime materializes `utf-8` text only. A binary artifact waits on the deferred rung-three boundary.
+- **A `base64` output in v1.** The `encoding` field reserves `base64`, but the v1 runtime materializes `utf-8` text only. A binary artifact waits on the deferred rung-three run-and-collect launch boundary.
 
 ## Where to go next
 

--- a/internal/flightplan/freeze/freeze.go
+++ b/internal/flightplan/freeze/freeze.go
@@ -48,14 +48,6 @@ type Result struct {
 	PublicKey []byte
 	// Lock is the structured lockfile record (contentHash included).
 	Lock Lockfile
-	// DeferredRungs records execution-environment rungs that were declared in
-	// the manifest but intentionally not built by freeze. Today this is the
-	// reserved, build-deferred rung-3 slot (rung3PerStepImages, ADR-0027):
-	// when present it is parsed and reported as deferred rather than failing
-	// or silently passing. Empty for a fully-resolved or instruction-only
-	// skill. This lives in the Result and CLI output only; it is not persisted
-	// to the lockfile (no lockfile schema change).
-	DeferredRungs []string
 }
 
 // Options configures a Run.
@@ -101,7 +93,7 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	pins, capSet, deferred, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
+	pins, capSet, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
 	if err != nil {
 		return Result{}, err
 	}
@@ -153,6 +145,5 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		Signature:      sig,
 		PublicKey:      pubPEM,
 		Lock:           lock,
-		DeferredRungs:  deferred,
 	}, nil
 }

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -66,6 +66,62 @@ func TestRun_Rung2HappyPath(t *testing.T) {
 	}
 }
 
+func TestRun_Rung3PinsAndSigns(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	digestFor := map[string]string{
+		"registry.example.com/tool-a:1": fakeDigest,
+		"registry.example.com/tool-b:2": fakeDigest2,
+	}
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		return digestFor[ref], nil
+	})
+	res, err := Run(context.Background(), []byte(rung3MultiStepMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Resolver:       dr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The lockfile records one digest pin per rung-3 step, in declared order.
+	if len(res.Lock.ResolvedImages) != 2 {
+		t.Fatalf("rung-3 must pin one image per step, got %+v", res.Lock.ResolvedImages)
+	}
+	if res.Lock.ResolvedImages[0].Ref != "registry.example.com/tool-a:1" || res.Lock.ResolvedImages[0].Digest != fakeDigest {
+		t.Errorf("first pin = %+v", res.Lock.ResolvedImages[0])
+	}
+	if res.Lock.ResolvedImages[1].Ref != "registry.example.com/tool-b:2" || res.Lock.ResolvedImages[1].Digest != fakeDigest2 {
+		t.Errorf("second pin = %+v", res.Lock.ResolvedImages[1])
+	}
+	if len(res.Lock.ResolvedCapabilitySet) != 0 {
+		t.Errorf("rung-3 pins no capability set, got %v", res.Lock.ResolvedCapabilitySet)
+	}
+
+	// The signature verifies over the canonical content bytes, so the rung-3
+	// pins are covered by the plan content hash and signature.
+	lockNoHash := res.Lock.withoutContentHash()
+	mNoHash, err := injectLock([]byte(rung3MultiStepMD), lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lfNoHash, err := MarshalLockfile(lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(canonicalContent(mNoHash, lfNoHash), res.Signature, res.PublicKey); err != nil {
+		t.Errorf("signature must verify over the rung-3 pins: %v", err)
+	}
+
+	// The frozen manifest re-parses with the lock present, carrying the pins.
+	fm, err := manifest.Parse(res.FrozenManifest)
+	if err != nil {
+		t.Fatalf("frozen rung-3 manifest must re-parse: %v", err)
+	}
+	if fm.Aileron.Lock["contentHash"] != res.ContentHash {
+		t.Errorf("frozen manifest lock.contentHash = %v, want %v", fm.Aileron.Lock["contentHash"], res.ContentHash)
+	}
+}
+
 func TestRun_Reproducible(t *testing.T) {
 	_, keyPath := genSigningKey(t)
 	opts := Options{Version: "1.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)}

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -56,91 +56,118 @@ func (f FeatureComposerFunc) ComposeDigest(ctx context.Context, features []strin
 	return f(ctx, features)
 }
 
-// rung3Name is the rung label recorded in Result.DeferredRungs when a
-// manifest declares the reserved, build-deferred rung-3 slot.
+// rung3Name is the execution-environment key for rung-3 (per-step
+// sibling-image dispatch).
 const rung3Name = "rung3PerStepImages"
 
 // resolveImages resolves a manifest's execution environment to the pinned
-// image set and resolved capability set, returning the data the lockfile
-// records plus the rungs that were declared but intentionally not built. The
-// cases:
+// image set and resolved capability set the lockfile records. The cases:
 //
 //   - instruction-only / no executionEnvironment: empty pins, no error
 //     (the skill still gets a contentHash and signature);
 //   - rung-1 (rung1Image.ref): resolve the named image to a digest pin;
 //   - rung-2 (rung2CapabilityUnits.features): compose the Features and pin
 //     the built image's digest plus the resolved capability set;
-//   - rung-3 (rung3PerStepImages, no rung-1/rung-2): a reserved,
-//     build-deferred slot (ADR-0027). It parses to an empty image set and is
-//     reported as deferred, never built. This is a first-class outcome, not
-//     an error;
-//   - both rung-1 and rung-2 present, or an executionEnvironment naming
-//     neither an image rung nor rung-3: a malformed manifest the schema
-//     already rejects; guarded here defensively.
+//   - rung-3 (rung3PerStepImages.steps[].image): resolve each per-step
+//     sibling image to a digest pin, one ImagePin per step (ADR-0027);
+//   - more than one image rung present, or an executionEnvironment naming
+//     no rung: a malformed manifest the schema already rejects; guarded here
+//     defensively.
 //
 // Every resolved digest is checked against digestPattern: a resolver that
 // yields a tag rather than a digest is rejected (pin by digest, never tag).
-func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, deferred []string, err error) {
+func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, err error) {
 	if m == nil || m.InstructionOnly {
-		return nil, nil, nil, nil
+		return nil, nil, nil
 	}
 	env := m.Aileron.Requires.ExecutionEnvironment
 	if len(env) == 0 {
 		// No execution environment declared: an instruction/composition-only
 		// skill freezes with an empty resolvedImages set.
-		return nil, nil, nil, nil
+		return nil, nil, nil
 	}
 
 	rung1, hasRung1 := env["rung1Image"]
 	rung2, hasRung2 := env["rung2CapabilityUnits"]
-	_, hasRung3 := env[rung3Name]
+	rung3, hasRung3 := env[rung3Name]
 	switch {
-	case hasRung1 && hasRung2:
-		return nil, nil, nil, fmt.Errorf("freeze: executionEnvironment declares both rung1Image and rung2CapabilityUnits; exactly one is permitted")
+	case moreThanOne(hasRung1, hasRung2, hasRung3):
+		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares more than one of rung1Image, rung2CapabilityUnits, rung3PerStepImages; exactly one is permitted")
 	case hasRung1:
 		ref, err := rung1ImageRef(rung1)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		if dr == nil {
-			return nil, nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
+			return nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
 		}
 		digest, err := dr.ResolveDigest(ctx, ref)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
+			return nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
 		}
 		if err := requireDigest(ref, digest); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
-		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil, nil
+		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil
 	case hasRung2:
 		features, err := rung2Features(rung2)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		if fc == nil {
-			return nil, nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
+			return nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
 		}
 		digest, err := fc.ComposeDigest(ctx, features)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
+			return nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
 		}
 		if err := requireDigest("rung2:"+joinFeatures(features), digest); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		// The pre-freeze "ref" for a composed image is the feature set; the
 		// resolved capability set is the same features, pinned.
-		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil, nil
+		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil
 	case hasRung3:
-		// Rung-3 (per-step sibling-image dispatch) is a reserved,
-		// build-deferred slot (ADR-0027). Freeze parses it and reports it as
-		// deferred: no image is built, the resolved image set is empty, and
-		// the rung is recorded as intentionally not built. This is a normal
-		// freeze outcome, not an error.
-		return nil, nil, []string{rung3Name}, nil
+		// Rung-3 (per-step sibling-image dispatch) is a built image rung
+		// (ADR-0027): freeze resolves each step's sibling image to a digest
+		// and pins one ImagePin per step. The pins flow into resolvedImages
+		// alongside the rung-1/rung-2 pins, so the plan content hash and
+		// signature cover them.
+		refs, err := rung3StepImages(rung3)
+		if err != nil {
+			return nil, nil, err
+		}
+		if dr == nil {
+			return nil, nil, fmt.Errorf("freeze: rung-3 per-step images require a digest resolver")
+		}
+		out := make([]ImagePin, 0, len(refs))
+		for _, ref := range refs {
+			digest, err := dr.ResolveDigest(ctx, ref)
+			if err != nil {
+				return nil, nil, fmt.Errorf("freeze: resolve rung-3 image %q: %w", ref, err)
+			}
+			if err := requireDigest(ref, digest); err != nil {
+				return nil, nil, err
+			}
+			out = append(out, ImagePin{Ref: ref, Digest: digest})
+		}
+		return out, nil, nil
 	default:
-		return nil, nil, nil, fmt.Errorf("freeze: executionEnvironment declares neither rung1Image nor rung2CapabilityUnits")
+		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares no image rung (rung1Image, rung2CapabilityUnits, or rung3PerStepImages)")
 	}
+}
+
+// moreThanOne reports whether more than one of the given booleans is true. It
+// is the exactly-one-rung guard: the schema already forbids two image rungs,
+// so this is the freeze-time defensive backstop.
+func moreThanOne(bs ...bool) bool {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n > 1
 }
 
 // requireDigest enforces the pin-by-digest invariant: a resolved value that
@@ -189,6 +216,36 @@ func rung2Features(v any) ([]string, error) {
 		features = append(features, strings.TrimSpace(s))
 	}
 	return features, nil
+}
+
+// rung3StepImages extracts each rung3PerStepImages.steps[].image from the
+// untyped execution environment block, returning the per-step image
+// references in declared order. Each step MUST be a mapping carrying a
+// non-empty string image; a non-mapping step, a missing/empty steps list, or
+// a non-string/empty image is rejected rather than stringified so a bad step
+// never silently produces a wrong pin. It mirrors rung2Features.
+func rung3StepImages(v any) ([]string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("freeze: rung3PerStepImages is not a mapping")
+	}
+	rawList, ok := m["steps"].([]any)
+	if !ok || len(rawList) == 0 {
+		return nil, fmt.Errorf("freeze: rung3PerStepImages.steps is missing or empty")
+	}
+	refs := make([]string, 0, len(rawList))
+	for _, s := range rawList {
+		step, ok := s.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("freeze: rung3PerStepImages.steps contains a non-mapping entry")
+		}
+		img, ok := step["image"].(string)
+		if !ok || strings.TrimSpace(img) == "" {
+			return nil, fmt.Errorf("freeze: rung3PerStepImages.steps contains a step with an empty or non-string image")
+		}
+		refs = append(refs, strings.TrimSpace(img))
+	}
+	return refs, nil
 }
 
 // composedRef renders a stable pre-freeze reference for a composed rung-2

--- a/internal/flightplan/freeze/images_malformed_test.go
+++ b/internal/flightplan/freeze/images_malformed_test.go
@@ -20,54 +20,114 @@ func mWithExecEnv(env map[string]any) *manifest.Manifest {
 	}
 }
 
+// dummyResolver returns a resolver that yields a valid digest, so a malformed
+// executionEnvironment shape surfaces its parse error rather than a
+// nil-resolver error. The shape checks run before resolution, so the resolver
+// is never actually called on these malformed cases.
+func dummyResolver() DigestResolver {
+	return DigestResolverFunc(func(context.Context, string) (string, error) { return fakeDigest, nil })
+}
+
 func TestResolveImages_BothRungsRejected(t *testing.T) {
 	m := mWithExecEnv(map[string]any{
 		"rung1Image":           map[string]any{"ref": "a:1"},
 		"rung2CapabilityUnits": map[string]any{"features": []any{"f"}},
 	})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("declaring both rungs must error")
+	}
+}
+
+func TestResolveImages_Rung3AlongsideRung1Rejected(t *testing.T) {
+	m := mWithExecEnv(map[string]any{
+		"rung1Image":         map[string]any{"ref": "a:1"},
+		"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": "b:1"}}},
+	})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("declaring rung-3 alongside rung-1 must error (exactly one image rung)")
 	}
 }
 
 func TestResolveImages_Rung1MissingRef(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{}})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("rung1Image with no ref must error")
 	}
 }
 
 func TestResolveImages_Rung1NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung1Image": "scalar"})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("rung1Image that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatures(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{}}})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2 with empty features must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatureEntry(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{""}}})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2 with an empty feature entry must error")
 	}
 }
 
 func TestResolveImages_Rung2NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": "scalar"})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2CapabilityUnits that is not a mapping must error")
+	}
+}
+
+func TestResolveImages_Rung3NotMapping(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": "scalar"})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("rung3PerStepImages that is not a mapping must error")
+	}
+}
+
+func TestResolveImages_Rung3MissingSteps(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{}})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("rung3PerStepImages with no steps must error")
+	}
+}
+
+func TestResolveImages_Rung3EmptySteps(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{}}})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("rung3PerStepImages with an empty steps list must error")
+	}
+}
+
+func TestResolveImages_Rung3StepNotMapping(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{"scalar"}}})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("a rung-3 step that is not a mapping must error")
+	}
+}
+
+func TestResolveImages_Rung3StepEmptyImage(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": ""}}}})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("a rung-3 step with an empty image must error")
+	}
+}
+
+func TestResolveImages_Rung3StepNonStringImage(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": 42}}}})
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+		t.Error("a rung-3 step with a non-string image must error")
 	}
 }
 
 func TestResolveImages_NeitherRung(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"somethingElse": map[string]any{}})
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("an executionEnvironment with neither rung must error")
 	}
 }

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -25,12 +25,9 @@ func TestResolveImages_Rung1ResolvesToDigest(t *testing.T) {
 		gotRef = ref
 		return fakeDigest, nil
 	})
-	pins, capSet, deferred, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
-	}
-	if len(deferred) != 0 {
-		t.Errorf("rung-1 must defer nothing, got %v", deferred)
 	}
 	if gotRef != "registry.example.com/runner:1.4" {
 		t.Errorf("resolver got ref %q", gotRef)
@@ -50,12 +47,9 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 		gotFeatures = features
 		return fakeDigest, nil
 	})
-	pins, capSet, deferred, err := resolveImages(context.Background(), m, nil, fc)
+	pins, capSet, err := resolveImages(context.Background(), m, nil, fc)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
-	}
-	if len(deferred) != 0 {
-		t.Errorf("rung-2 must defer nothing, got %v", deferred)
 	}
 	wantFeatures := []string{
 		"ghcr.io/example/aileron-feature-metrics-cli:1",
@@ -74,7 +68,7 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 
 func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 	m := parseM(t, []byte(instructionOnlyMD))
-	pins, capSet, _, err := resolveImages(context.Background(), m, nil, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -85,7 +79,7 @@ func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 
 func TestResolveImages_NoExecEnvEmpty(t *testing.T) {
 	m := parseM(t, []byte(noExecEnvMD))
-	pins, _, _, err := resolveImages(context.Background(), m, nil, nil)
+	pins, _, err := resolveImages(context.Background(), m, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -99,7 +93,7 @@ func TestResolveImages_RejectsTagNotDigest(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "registry.example.com/runner:1.4", nil // a tag, not a digest
 	})
-	_, _, _, err := resolveImages(context.Background(), m, dr, nil)
+	_, _, err := resolveImages(context.Background(), m, dr, nil)
 	if err == nil {
 		t.Fatal("a resolver returning a tag must be rejected")
 	}
@@ -113,21 +107,21 @@ func TestResolveImages_ResolverError(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "", errors.New("image not found")
 	})
-	if _, _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
 		t.Error("an unresolvable image must error")
 	}
 }
 
 func TestResolveImages_Rung1NeedsResolver(t *testing.T) {
 	m := parseM(t, []byte(rung1MD))
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("a rung-1 manifest with no resolver must error")
 	}
 }
 
 func TestResolveImages_Rung2NeedsComposer(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("a rung-2 manifest with no composer must error")
 	}
 }
@@ -143,25 +137,79 @@ func TestRequireDigest(t *testing.T) {
 	}
 }
 
-// TestResolveImages_Rung3DeclaredReportedDeferred is the #1510 acceptance
-// proof for rung-3: a manifest declaring only the reserved rung-3 slot is
-// parsed, builds no image (empty pins, empty capability set), and is reported
-// as deferred rather than erroring. A nil resolver and composer are passed to
-// prove rung-3 never touches the build seams.
-func TestResolveImages_Rung3DeclaredReportedDeferred(t *testing.T) {
-	m := parseM(t, []byte(rung3MD))
-	pins, capSet, deferred, err := resolveImages(context.Background(), m, nil, nil)
-	if err != nil {
-		t.Fatalf("a rung-3 declaration must parse and defer, not error: %v", err)
+// TestResolveImages_Rung3ResolvesPerStepDigests is the #1732 acceptance proof
+// for rung-3: a manifest declaring rung-3 per-step images resolves each step's
+// sibling image to a digest pin (one ImagePin per step), pins no capability
+// set, and does not error. A fake resolver maps each step image to a distinct
+// digest so the per-step pinning is observable.
+func TestResolveImages_Rung3ResolvesPerStepDigests(t *testing.T) {
+	m := parseM(t, []byte(rung3MultiStepMD))
+	digestFor := map[string]string{
+		"registry.example.com/tool-a:1": fakeDigest,
+		"registry.example.com/tool-b:2": fakeDigest2,
 	}
-	if len(pins) != 0 {
-		t.Errorf("rung-3 must build no image, got pins %+v", pins)
+	var gotRefs []string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRefs = append(gotRefs, ref)
+		return digestFor[ref], nil
+	})
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	if err != nil {
+		t.Fatalf("rung-3 resolution must succeed: %v", err)
+	}
+	if len(pins) != 2 {
+		t.Fatalf("rung-3 must pin one image per step, got %+v", pins)
+	}
+	if pins[0].Ref != "registry.example.com/tool-a:1" || pins[0].Digest != fakeDigest {
+		t.Errorf("first step pin = %+v", pins[0])
+	}
+	if pins[1].Ref != "registry.example.com/tool-b:2" || pins[1].Digest != fakeDigest2 {
+		t.Errorf("second step pin = %+v", pins[1])
 	}
 	if len(capSet) != 0 {
 		t.Errorf("rung-3 must pin no capability set, got %v", capSet)
 	}
-	if len(deferred) != 1 || deferred[0] != rung3Name {
-		t.Errorf("rung-3 must be reported deferred as %q, got %v", rung3Name, deferred)
+	if strings.Join(gotRefs, ",") != "registry.example.com/tool-a:1,registry.example.com/tool-b:2" {
+		t.Errorf("resolver saw refs %v in the wrong order or set", gotRefs)
+	}
+}
+
+// TestResolveImages_Rung3RejectsTagNotDigest proves the pin-by-digest guard
+// covers rung-3: a resolver that yields a tag rather than a digest is a hard
+// error, so no tag-shaped ref ever survives into a rung-3 pin.
+func TestResolveImages_Rung3RejectsTagNotDigest(t *testing.T) {
+	m := parseM(t, []byte(rung3MD))
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		return "registry.example.com/per-step-tool:1", nil // a tag, not a digest
+	})
+	_, _, err := resolveImages(context.Background(), m, dr, nil)
+	if err == nil {
+		t.Fatal("a rung-3 resolver returning a tag must be rejected")
+	}
+	if !strings.Contains(err.Error(), "digest") {
+		t.Errorf("error should explain the pin-by-digest rule, got: %v", err)
+	}
+}
+
+// TestResolveImages_Rung3ResolverError proves a per-step resolver failure
+// surfaces as a Run-level error rather than a silent skip.
+func TestResolveImages_Rung3ResolverError(t *testing.T) {
+	m := parseM(t, []byte(rung3MD))
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		return "", errors.New("image not found")
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+		t.Error("an unresolvable rung-3 image must error")
+	}
+}
+
+// TestResolveImages_Rung3NeedsResolver proves rung-3 requires a digest
+// resolver: a rung-3 manifest with no resolver errors rather than silently
+// pinning nothing (mirrors the rung-1 nil-resolver contract).
+func TestResolveImages_Rung3NeedsResolver(t *testing.T) {
+	m := parseM(t, []byte(rung3MD))
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("a rung-3 manifest with no resolver must error")
 	}
 }
 
@@ -198,11 +246,11 @@ func TestResolveImages_DistinctFeatureSetsDistinctPins(t *testing.T) {
 		}
 	}
 
-	pinsA, _, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	pinsA, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
 	if err != nil {
 		t.Fatalf("compose feature set A: %v", err)
 	}
-	pinsB, _, _, err := resolveImages(context.Background(), mWithFeatures("b"), nil, fc)
+	pinsB, _, err := resolveImages(context.Background(), mWithFeatures("b"), nil, fc)
 	if err != nil {
 		t.Fatalf("compose feature set B: %v", err)
 	}
@@ -213,7 +261,7 @@ func TestResolveImages_DistinctFeatureSetsDistinctPins(t *testing.T) {
 		t.Errorf("distinct Feature sets must produce distinct pinned digests, both pinned %q", pinsA[0].Digest)
 	}
 	// Same feature set must reproduce the same pin (determinism).
-	pinsA2, _, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	pinsA2, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
 	if err != nil {
 		t.Fatalf("recompose feature set A: %v", err)
 	}
@@ -234,7 +282,7 @@ func TestFreeze_Rung1WorkedExample(t *testing.T) {
 		gotRef = ref
 		return fakeDigest, nil
 	})
-	pins, capSet, deferred, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
 	if err != nil {
 		t.Fatalf("freeze rung-1 worked example: %v", err)
 	}
@@ -246,8 +294,5 @@ func TestFreeze_Rung1WorkedExample(t *testing.T) {
 	}
 	if len(capSet) != 0 {
 		t.Errorf("rung-1 has no capability set, got %v", capSet)
-	}
-	if len(deferred) != 0 {
-		t.Errorf("rung-1 example must defer nothing, got %v", deferred)
 	}
 }

--- a/internal/flightplan/freeze/testdata_test.go
+++ b/internal/flightplan/freeze/testdata_test.go
@@ -123,13 +123,13 @@ aileron:
 # No Exec Env
 `
 
-// rung3MD declares only the reserved, build-deferred rung-3 slot
-// (rung3PerStepImages) with neither rung-1 nor rung-2. The schema permits a
-// rung-3-only declaration and freeze parses it, builds no image, and reports
-// it as deferred (ADR-0027).
+// rung3MD declares a single-step rung-3 execution environment
+// (rung3PerStepImages) with neither rung-1 nor rung-2. Rung three is a built
+// image rung: freeze resolves each per-step sibling image to a digest pin
+// (ADR-0027, #1732).
 const rung3MD = `---
 name: rung3-skill
-description: A skill declaring only the reserved rung-3 slot.
+description: A skill declaring a rung-3 per-step image.
 aileron:
   schemaVersion: aileron.flightplan.v1
   requires:
@@ -155,6 +155,46 @@ aileron:
 ---
 
 # Rung 3 Skill
+`
+
+// rung3MultiStepMD declares a rung-3 execution environment with two steps
+// (each naming a distinct sibling image) plus optional id/mount/collect I/O.
+// It proves freeze pins one digest per step and preserves declared order.
+const rung3MultiStepMD = `---
+name: rung3-multistep-skill
+description: A skill declaring multiple rung-3 per-step images.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung3PerStepImages:
+        steps:
+          - id: extract
+            image: registry.example.com/tool-a:1
+            mount:
+              path: /work
+            collect:
+              path: /work/out
+          - id: convert
+            image: registry.example.com/tool-b:2
+  inputs: []
+  outputs: []
+---
+
+# Rung 3 Multi-Step Skill
 `
 
 // genSigningKey returns a fresh ed25519 private key and writes its PKCS#8

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -83,11 +83,27 @@
     },
     "executionEnvironment": {
       "type": "object",
-      "description": "The execution-environment dependency. At most one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs; rung-1 and rung-2 are mutually exclusive. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot: a manifest may declare rung3PerStepImages alone, in which case freeze parses it and reports it as build-deferred rather than building anything.",
+      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image), rung-2 (composed capability units on the Aileron base), or rung-3 (per-step sealed sibling-image dispatch) is declared per ADR-0027 execution rungs; the three rungs are mutually exclusive. Freeze resolves the declared rung to content-addressed digest pins recorded in the lock section.",
       "additionalProperties": false,
       "oneOf": [
-        { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
-        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
+        {
+          "required": ["rung1Image"],
+          "not": {
+            "anyOf": [
+              { "required": ["rung2CapabilityUnits"] },
+              { "required": ["rung3PerStepImages"] }
+            ]
+          }
+        },
+        {
+          "required": ["rung2CapabilityUnits"],
+          "not": {
+            "anyOf": [
+              { "required": ["rung1Image"] },
+              { "required": ["rung3PerStepImages"] }
+            ]
+          }
+        },
         {
           "required": ["rung3PerStepImages"],
           "not": {
@@ -131,9 +147,58 @@
           }
         },
         "rung3PerStepImages": {
-          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling. Freeze parses a rung-3 declaration and reports it as build-deferred (empty image set); it never builds a rung-3 image in v1.",
           "type": "object",
-          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. A manifest may declare this slot alone: freeze parses it and reports it as build-deferred rather than building anything. Do not author this field expecting runtime support."
+          "description": "Rung three. Per-step sealed sibling-image dispatch with mount and run-and-collect I/O (ADR-0027 rung three). Each step names a sibling image freeze resolves to a content-addressed digest, pinned in the lock section alongside the rung-1 and rung-2 pins. The per-step image is the operator-owned tool the step dispatches to.",
+          "additionalProperties": false,
+          "required": ["steps"],
+          "properties": {
+            "steps": {
+              "type": "array",
+              "description": "The per-step sibling images. Each entry names an image freeze resolves to a digest pin, with an optional identifier and an optional mount and run-and-collect I/O declaration.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An optional step identifier, unique within the rung-3 step set.",
+                    "minLength": 1
+                  },
+                  "image": {
+                    "type": "string",
+                    "description": "An OCI image reference for the per-step sibling tool. Pre-freeze this may be a fixed-version tag (for example registry.example.com/aws-cli:2). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+                    "minLength": 1
+                  },
+                  "mount": {
+                    "type": "object",
+                    "description": "An optional mount declaration for the step's input I/O (ADR-0027 mount boundary).",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "description": "The mount path inside the per-step image.",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "collect": {
+                    "type": "object",
+                    "description": "An optional run-and-collect declaration for the step's output I/O (ADR-0027 run-and-collect boundary).",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "type": "string",
+                        "description": "The path inside the per-step image whose contents are collected as the step output.",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -146,14 +146,13 @@ aileron:
 }
 
 // TestExecutionEnvironmentRungValidity locks the rung composition rules at the
-// schema boundary: rung-1-only and rung-2-only are valid, declaring both
-// rung-1 and rung-2 is rejected (the existing exclusivity guarantee), and a
-// rung-3-only declaration is now valid (a reserved, build-deferred slot it is
-// freeze's job to report, not the schema's job to forbid). rung-3 alongside
-// rung-1 is also permitted: rung-3 is a reserved slot and does not weaken the
-// rung-1/rung-2 exclusivity. A present-but-empty executionEnvironment ({}) is
-// rejected: declaring the key obliges naming at least one rung (key omission,
-// not an empty block, is how a skill says it has no execution environment).
+// schema boundary: rung-1-only, rung-2-only, and rung-3-only are each valid,
+// and the three rungs are mutually exclusive. Declaring any two together is
+// rejected (rung-3 is now a built image rung, so it excludes rung-1 and rung-2
+// just as they exclude each other). A malformed rung-3 (empty steps) is
+// rejected. A present-but-empty executionEnvironment ({}) is rejected:
+// declaring the key obliges naming exactly one rung (key omission, not an empty
+// block, is how a skill says it has no execution environment).
 func TestExecutionEnvironmentRungValidity(t *testing.T) {
 	valid := map[string]string{
 		"rung1 only": `      rung1Image:
@@ -161,14 +160,17 @@ func TestExecutionEnvironmentRungValidity(t *testing.T) {
 		"rung2 only": `      rung2CapabilityUnits:
         features:
           - ghcr.io/example/aileron-feature-metrics-cli:1`,
-		"rung3 only (reserved, build-deferred)": `      rung3PerStepImages:
+		"rung3 only": `      rung3PerStepImages:
         steps:
           - image: registry.example.com/per-step-tool:1`,
-		"rung3 alongside rung1": `      rung1Image:
-        ref: registry.example.com/runner:1.4
-      rung3PerStepImages:
+		"rung3 with id and io": `      rung3PerStepImages:
         steps:
-          - image: registry.example.com/per-step-tool:1`,
+          - id: convert
+            image: registry.example.com/per-step-tool:1
+            mount:
+              path: /work
+            collect:
+              path: /work/out`,
 	}
 	for name, env := range valid {
 		t.Run("valid/"+name, func(t *testing.T) {
@@ -184,6 +186,13 @@ func TestExecutionEnvironmentRungValidity(t *testing.T) {
       rung2CapabilityUnits:
         features:
           - ghcr.io/example/aileron-feature-metrics-cli:1`,
+		"rung3 alongside rung1 rejected": `      rung1Image:
+        ref: registry.example.com/runner:1.4
+      rung3PerStepImages:
+        steps:
+          - image: registry.example.com/per-step-tool:1`,
+		"rung3 with empty steps rejected": `      rung3PerStepImages:
+        steps: []`,
 		"empty executionEnvironment rejected": `      {}`,
 	}
 	for name, env := range invalid {

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -329,11 +329,9 @@ func TestExecutionEnvironmentRung1AndRung2MutuallyExclusive(t *testing.T) {
 }
 
 // TestExecutionEnvironmentRung3OnlyAccepted: an execution environment that
-// declares only the reserved rung3PerStepImages slot (neither rung1Image nor
-// rung2CapabilityUnits) is valid. The schema permits the reserved slot;
-// freeze parses it and reports it as build-deferred rather than building
-// anything (#1510, ADR-0027). An execution environment with no image rung is
-// no longer a schema rejection.
+// declares only the rung3PerStepImages rung (neither rung1Image nor
+// rung2CapabilityUnits) is valid. Rung three is a built image rung: freeze
+// resolves each per-step sibling image to a digest pin (#1732, ADR-0027).
 func TestExecutionEnvironmentRung3OnlyAccepted(t *testing.T) {
 	sch := compileSchema(t)
 	inst := validExampleInstance(t)
@@ -347,6 +345,41 @@ func TestExecutionEnvironmentRung3OnlyAccepted(t *testing.T) {
 	}
 	if err := sch.Validate(inst); err != nil {
 		t.Fatalf("a rung-3-only execution environment must validate:\n%v", err)
+	}
+}
+
+// TestExecutionEnvironmentRung3ExcludesRung1: rung three is now a built image
+// rung, so it is mutually exclusive with rung one and rung two just as they
+// exclude each other. Declaring rung-3 alongside rung-1 is rejected.
+func TestExecutionEnvironmentRung3ExcludesRung1(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	env := requires["executionEnvironment"].(map[string]any)
+	delete(env, "rung2CapabilityUnits")
+	env["rung1Image"] = map[string]any{"ref": "registry.example.com/runner:1.4"}
+	env["rung3PerStepImages"] = map[string]any{
+		"steps": []any{map[string]any{"image": "registry.example.com/per-step-tool:1"}},
+	}
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("declaring rung3PerStepImages alongside rung1Image must be rejected")
+	}
+}
+
+// TestExecutionEnvironmentRung3EmptyStepsRejected: rung three requires a
+// non-empty steps array. An empty steps array is malformed and rejected.
+func TestExecutionEnvironmentRung3EmptyStepsRejected(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	env := requires["executionEnvironment"].(map[string]any)
+	delete(env, "rung1Image")
+	delete(env, "rung2CapabilityUnits")
+	env["rung3PerStepImages"] = map[string]any{"steps": []any{}}
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("a rung-3 declaration with an empty steps array must be rejected")
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends the Flight Plan freeze image path to build and pin rung-3 per-step tool
images to content-addressed `sha256:` digests, instead of reporting
`rung3PerStepImages` as a reserved, build-deferred slot. Rung three now seals to
a signed image assertion like rung-1 and rung-2 (ADR-0027).

- **Schema (source of truth):** tightened `rung3PerStepImages` in
  `internal/flightplan/manifest/flight-plan-manifest.schema.json` from a loosely
  typed reserved slot to a concrete shape (`steps[]` with required `image`,
  optional `id`/`mount`/`collect`), made the three rungs mutually exclusive in the
  `oneOf`, and regenerated the byte-identical derived copy at
  `docs/schema/flight-plan-manifest.schema.json` (guarded by the schema-drift
  test `TestEmbeddedSchemaMatchesDoc`).
- **Freeze (`internal/flightplan/freeze/images.go`):** the rung-3 branch now
  resolves each step's image through the existing `DigestResolver` seam and emits
  one `ImagePin` per step, flowing into `resolvedImages` so the plan content hash
  and signature cover the pins. Tag-shaped (non-digest) resolutions are rejected
  via the existing `digestPattern` hard error. `rung3StepImages` rejects
  malformed declarations (non-mapping, missing/empty steps, non-string/empty
  image) rather than stringifying them.
- **ADR-0027:** rung three updated from Deferred to built; the remaining
  out-of-scope item is narrowed to per-step launch-time dispatch (mount +
  run-and-collect runtime), not the freeze-time pin.

## Test plan

- `task build` — passed (Go binaries + docs site).
- `task test` — passed (Go + docs suites).
- `internal/flightplan/freeze` coverage 88.0% (> 80%).
- New/updated tests cover the acceptance criteria: per-step digest pinning via a
  fake `DigestResolver` (`TestResolveImages_Rung3ResolvesPerStepDigests`,
  `TestRun_Rung3PinsAndSigns`), tag-rejection
  (`TestResolveImages_Rung3RejectsTagNotDigest`), mutual exclusivity
  (`TestResolveImages_Rung3AlongsideRung1Rejected`,
  `TestExecutionEnvironmentRung3ExcludesRung1`), malformed-manifest guards, and
  schema-drift (`TestEmbeddedSchemaMatchesDoc`).

Closes #1732
