### PR TITLE
docs(proxybinding): reconcile EmitMechanisms inject comment with sigv4-resign

### DIFF
--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -54,8 +54,11 @@ import (
 const SchemaVersion = "v1"
 
 // EmitMechanisms is the closed set of emit-mechanism values a descriptor
-// may declare at load time. "inject" injects unconditionally at the proxy
-// (the client emits a no-credential request). "sentinel-swap" plants a
+// may declare at load time. "inject" adds the credential at the proxy and
+// covers two client shapes: a request that arrives with no credential (the
+// proxy adds one), and a self-signing client such as `aws`/botocore that
+// emits a placeholder-signed request the `sigv4-resign` scheme strips and
+// re-signs with the vault credential at the boundary. "sentinel-swap" plants a
 // non-secret sentinel the proxy swaps for the real credential at egress;
 // a sentinel-swap binding must declare a `sentinel` block naming the
 // placeholder value and the env-var name the launcher plants it under. A


### PR DESCRIPTION
## Summary

Reconciles the `EmitMechanisms` doc-comment in `internal/proxybinding/descriptor.go` with the `sigv4-resign` self-signing case that ADR-0019 now documents. The comment previously described `"inject"` as only "the client emits a no-credential request," but ADR-0019 (updated in #1740) documents two `inject` sub-cases: a no-credential request, and a self-signing client (`aws`/botocore) that emits a placeholder-signed request the `sigv4-resign` scheme strips and re-signs at the boundary. The code comment now reflects both, matching the ADR taxonomy.

Comment-only change; no behavior change.

Closes #1737

### Residual #1737 triage (findings re-judged against shipped code)
- **P2 — descriptor.go comment unreconciled:** FIX_NOW → this PR.
- **P2 — ADR-0019 self-signing/sentinel-swap/residual-exception taxonomy:** RESOLVED. The shipped ADR (§ lines 98–110) already reconciles the three paragraphs coherently.
- **P2 — duplicate SigV4 validator (drift risk):** Resolved as an explicit **keep-separate** decision — the integration validator (`validateSigV4`) is build-tagged off the default suite, so the second validator is genuinely additive coverage; extracting a shared helper would couple a build-tagged test to the default suite for no correctness gain.
- **P2 — PR framing for #1734:** MOOT — #1734 already merged (PR #1740).

## Test plan
- `go vet ./internal/proxybinding/` — clean
- `go build ./internal/proxybinding/` — clean
- `go test ./internal/proxybinding/` — pass
- Comment-only; full CI validates no wider impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified user-facing guidance for the `"inject"` emit mechanism, including how it behaves for different client request shapes.
  * Improved explanation of the `sigv4-resign` flow so the request is described more clearly at the proxy boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->