### PR TITLE
fix(app): carry trust identity on foreign_token_not_swapped audit event

### DIFF
--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -777,10 +777,11 @@ func (s *apiServer) recordSandboxProxyTrustDenied(r *http.Request, source string
 // (non-sentinel) token. The proxy did not swap it: it forwarded the
 // request unchanged with no real credential injected. The payload
 // carries the matched host pattern, scheme, and upstream
-// destination/status; it never carries the foreign token, the sentinel,
-// the real credential, or the credential-ref. nil-recorder safe like its
-// siblings.
-func (s *apiServer) recordSandboxProxyForeignTokenNotSwapped(r *http.Request, source, hostPattern, scheme string, upstream *url.URL, upstreamStatus int) string {
+// destination/status, plus the optional trust-contract effect and
+// plan/step/tool identity triple when the binding declares them (#1735);
+// it never carries the foreign token, the sentinel, the real credential,
+// or the credential-ref. nil-recorder safe like its siblings.
+func (s *apiServer) recordSandboxProxyForeignTokenNotSwapped(r *http.Request, source string, hb binding.HostBinding, upstream *url.URL, upstreamStatus int) string {
 	if s.auditRecorder == nil {
 		if s.newID != nil {
 			return s.newID()
@@ -793,13 +794,14 @@ func (s *apiServer) recordSandboxProxyForeignTokenNotSwapped(r *http.Request, so
 		"aileron.proxy.source":          source,
 		"aileron.proxy.decision":        "foreign_token_not_swapped",
 		"aileron.proxy.method":          r.Method,
-		"aileron.proxy.binding.host":    hostPattern,
-		"aileron.proxy.binding.scheme":  scheme,
+		"aileron.proxy.binding.host":    hb.HostPattern,
+		"aileron.proxy.binding.scheme":  hb.Scheme,
 		"aileron.proxy.upstream.scheme": upstream.Scheme,
 		"aileron.proxy.upstream.host":   upstream.Host,
 		"aileron.proxy.upstream.path":   sandboxProxyUpstreamPath(upstream),
 		"aileron.proxy.upstream.status": upstreamStatus,
 	}
+	addHostBindingTrustIdentity(payload, hb)
 	if sessionID := strings.TrimSpace(r.Header.Get("X-Aileron-Session-Id")); sessionID != "" {
 		payload["aileron.session.id"] = sessionID
 	}

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -300,7 +300,7 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 			return true
 		}
 		defer resp.body.Close()
-		s.recordSandboxProxyForeignTokenNotSwapped(decrypted, sandboxProxySourceTransparentConnectTLS, hb.HostPattern, hb.Scheme, upstream, resp.statusCode)
+		s.recordSandboxProxyForeignTokenNotSwapped(decrypted, sandboxProxySourceTransparentConnectTLS, hb, upstream, resp.statusCode)
 		writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, resp.resp, resp.bodyBytes)
 		return true
 	case sentinelSwapInject:

--- a/internal/app/sandbox_proxy_audit_shape_test.go
+++ b/internal/app/sandbox_proxy_audit_shape_test.go
@@ -277,6 +277,10 @@ var (
 		},
 		allowedFields: []string{
 			"aileron.session.id",
+			"aileron.trust.effect",
+			"aileron.plan.id",
+			"aileron.step.id",
+			"aileron.tool.name",
 		},
 		forbiddenSubstrs: []string{
 			"lin_secret", "Bearer ", "Authorization",
@@ -514,7 +518,11 @@ func TestSandboxProxyAuditShape_ForeignTokenNotSwappedConforms(t *testing.T) {
 	req.Header.Set("X-Aileron-Session-Id", "session-shape-test")
 	req.Method = http.MethodGet
 	upstream, _ := url.Parse("https://api.github.com/user")
-	srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200)
+	hb := mustAuditShapeBinding(t, "api.github.com", "bearer",
+		binding.WithTrustContract("read", []string{"secret-host.example.test"}),
+		binding.WithToolIdentity("plan-7", "step-3", "linear.create_issue"),
+	)
+	srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, hb, upstream, 200)
 	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1", len(events))
@@ -522,20 +530,41 @@ func TestSandboxProxyAuditShape_ForeignTokenNotSwappedConforms(t *testing.T) {
 	if events[0].EventType != model.EventTypeSandboxProxyForeignTokenNotSwapped {
 		t.Fatalf("event type = %q", events[0].EventType)
 	}
-	sandboxProxyForeignTokenNotSwappedShape.validate(t, events[0].Payload)
+	p := events[0].Payload
+	sandboxProxyForeignTokenNotSwappedShape.validate(t, p)
+	if got := p["aileron.trust.effect"]; got != "read" {
+		t.Errorf("trust.effect = %v, want read", got)
+	}
+	if got := p["aileron.plan.id"]; got != "plan-7" {
+		t.Errorf("plan.id = %v, want plan-7", got)
+	}
+	if got := p["aileron.step.id"]; got != "step-3" {
+		t.Errorf("step.id = %v, want step-3", got)
+	}
+	if got := p["aileron.tool.name"]; got != "linear.create_issue" {
+		t.Errorf("tool.name = %v, want linear.create_issue", got)
+	}
+	payloadJSON, _ := json.Marshal(p)
+	// The AllowedHosts values and the credential-ref must never appear.
+	for _, forbidden := range []string{"secret-host.example.test", "api_key/github/octocat"} {
+		if strings.Contains(string(payloadJSON), forbidden) {
+			t.Errorf("payload leaked %q: %s", forbidden, payloadJSON)
+		}
+	}
 }
 
 func TestSandboxProxyAuditShape_ForeignTokenNotSwappedNilRecorderIsIDSafe(t *testing.T) {
 	upstream, _ := url.Parse("https://api.github.com/user")
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	hb := mustAuditShapeBinding(t, "api.github.com", "bearer")
 
 	srv := &apiServer{newID: func() string { return "minted-id" }}
-	if got := srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200); got != "minted-id" {
+	if got := srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, hb, upstream, 200); got != "minted-id" {
 		t.Errorf("audit id = %q, want minted-id", got)
 	}
 
 	srvNoID := &apiServer{}
-	if got := srvNoID.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200); strings.TrimSpace(got) == "" {
+	if got := srvNoID.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, hb, upstream, 200); strings.TrimSpace(got) == "" {
 		t.Error("audit id must be non-empty even with no recorder and no newID")
 	}
 }


### PR DESCRIPTION
## Summary

`recordSandboxProxyForeignTokenNotSwapped` took `(hostPattern, scheme)` and never stamped the trust-contract effect or the plan/step/tool identity triple. A foreign-token forward on a bound sentinel-swap host therefore emitted a `sandbox.proxy.foreign_token_not_swapped` audit event missing the `aileron.trust.effect` + `aileron.plan.id`/`aileron.step.id`/`aileron.tool.name` addressing that its sibling events `binding_injected` and `trust_denied` already carry (#1735).

The trust gate runs before the sentinel-swap branch, so the identity was available at this seam but dropped on the floor.

Changes:
- Thread the matched `binding.HostBinding` into `recordSandboxProxyForeignTokenNotSwapped` and call the existing `addHostBindingTrustIdentity` helper, mirroring `recordSandboxProxyBindingInjected`.
- Update the single production call site in `handlers_sandbox_forward_proxy.go`.
- Extend `sandboxProxyForeignTokenNotSwappedShape.allowedFields` with the four optional identity fields.
- Update the two nil-recorder test call sites and enrich the conformance test to assert the identity triple is surfaced and that no AllowedHosts value or credential-ref leaks.

The identity fields are optional and only appear when the matched binding declares them, so no schema/doc field enumeration required updating. No credential bytes, sentinel, or credential-ref are added to the payload.

## Test plan

- `go build ./...` (internal module) passes.
- `go vet ./app/` clean.
- `go test ./app/` passes (full package, 22.9s).
- Targeted: `go test ./app/ -run 'ForeignTokenNotSwapped|BindingInjected|TrustDenied|SandboxProxyAuditShape'` green. The conformance test now fails before the change (identity fields absent) and passes after.

Relates to #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)