### PR TITLE
feat(flightplan): emit per-step output.materialized audit event

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -263,20 +263,28 @@ type daemonAuditSink struct {
 }
 
 func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) string {
-	eventType := string(model.EventTypeFlightPlanLaunch)
-	if rec.ActionRef != "" {
+	// The record kind is the explicit discriminator (#1752): an output record
+	// carries a flat `aileron.*` payload (top-level attributes, matching the
+	// vault.user.credential.* convention), while action/launch records keep
+	// their existing nested pay["fields"]/actionRef/sink shape so those event
+	// shapes don't churn.
+	var eventType string
+	var payload map[string]any
+	switch rec.Kind {
+	case runtime.RecordKindOutput:
+		eventType = string(model.EventTypeOutputMaterialized)
+		payload = rec.Fields
+		if payload == nil {
+			// A well-formed output record always carries fields, but guard so an
+			// empty record posts an object payload rather than a JSON null.
+			payload = map[string]any{}
+		}
+	case runtime.RecordKindAction:
 		eventType = string(model.EventTypeFlightPlanLaunchAction)
-	}
-
-	payload := map[string]any{}
-	if rec.ActionRef != "" {
-		payload["actionRef"] = rec.ActionRef
-	}
-	if len(rec.Fields) > 0 {
-		payload["fields"] = rec.Fields
-	}
-	if rec.Sink != "" {
-		payload["sink"] = rec.Sink
+		payload = actionOrLaunchPayload(rec)
+	default: // runtime.RecordKindLaunch
+		eventType = string(model.EventTypeFlightPlanLaunch)
+		payload = actionOrLaunchPayload(rec)
 	}
 
 	body, err := json.Marshal(auditIngestRequest{
@@ -318,6 +326,24 @@ func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) st
 		return ""
 	}
 	return out.AuditID
+}
+
+// actionOrLaunchPayload builds the nested payload shape shared by the
+// per-action and per-launch summary records: actionRef and sink when present,
+// and the declared audit fields under a "fields" key. The output.materialized
+// record does NOT use this shape; it surfaces its flat aileron.* map directly.
+func actionOrLaunchPayload(rec runtime.AuditRecord) map[string]any {
+	payload := map[string]any{}
+	if rec.ActionRef != "" {
+		payload["actionRef"] = rec.ActionRef
+	}
+	if len(rec.Fields) > 0 {
+		payload["fields"] = rec.Fields
+	}
+	if rec.Sink != "" {
+		payload["sink"] = rec.Sink
+	}
+	return payload
 }
 
 func (s daemonAuditSink) logErr(format string, args ...any) {

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -520,6 +520,7 @@ func TestDaemonAuditSink_PostsLaunchSummary(t *testing.T) {
 	})
 
 	id := daemonAuditSink{stderr: io.Discard}.Record(context.Background(), runtime.AuditRecord{
+		Kind:   runtime.RecordKindLaunch,
 		Fields: map[string]any{"artifacts": 1},
 	})
 	if id != "audit-summary" {
@@ -530,6 +531,45 @@ func TestDaemonAuditSink_PostsLaunchSummary(t *testing.T) {
 	}
 	if _, ok := gotBody.Payload["actionRef"]; ok {
 		t.Errorf("summary payload must omit actionRef: %+v", gotBody.Payload)
+	}
+}
+
+// TestDaemonAuditSink_PostsOutputMaterializedFlatPayload proves a
+// RecordKindOutput record maps to the output.materialized event type and
+// surfaces its flat aileron.* map as the top-level payload (no "fields"
+// nesting), matching the vault.user.credential.* convention (#1752).
+func TestDaemonAuditSink_PostsOutputMaterializedFlatPayload(t *testing.T) {
+	var gotBody auditIngestRequest
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"audit_id":"audit-output"}`))
+	})
+
+	id := daemonAuditSink{stderr: io.Discard}.Record(context.Background(), runtime.AuditRecord{
+		Kind: runtime.RecordKindOutput,
+		Fields: map[string]any{
+			"aileron.output.name":         "digest.csv",
+			"aileron.output.content_hash": "sha256:abc",
+			"aileron.step.kind":           "transform",
+		},
+	})
+	if id != "audit-output" {
+		t.Errorf("Record returned %q, want audit-output", id)
+	}
+	if gotBody.EventType != string(model.EventTypeOutputMaterialized) {
+		t.Errorf("event_type = %q, want %q", gotBody.EventType, model.EventTypeOutputMaterialized)
+	}
+	// The flat aileron.* keys are top-level payload attributes, not nested under
+	// "fields".
+	if gotBody.Payload["aileron.output.content_hash"] != "sha256:abc" {
+		t.Errorf("payload.aileron.output.content_hash = %v, want it at top level", gotBody.Payload["aileron.output.content_hash"])
+	}
+	if _, nested := gotBody.Payload["fields"]; nested {
+		t.Errorf("output payload must be flat, not nested under fields: %+v", gotBody.Payload)
+	}
+	if gotBody.Payload["aileron.step.kind"] != "transform" {
+		t.Errorf("payload.aileron.step.kind = %v", gotBody.Payload["aileron.step.kind"])
 	}
 }
 
@@ -604,6 +644,84 @@ func TestRunSkillLaunch_InProcessRecordsAuditToDaemon(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Audit records:") {
 		t.Errorf("stdout missing audit count: %q", stdout.String())
+	}
+}
+
+// TestRunSkillLaunch_InProcessEmitsOutputMaterializedPerArtifact is the #1752
+// acceptance + regression path. The worked example materializes two outputs:
+// digest.csv from a `transform` step and filed_issue.json from an action-call
+// step. The launch must POST exactly one output.materialized event per
+// materialized artifact (two total), each carrying the correct aileron.step.kind,
+// and each output's aileron.output.content_hash must equal the digest the launch
+// printed to stdout (the dashboard hash equals the stdout digest).
+func TestRunSkillLaunch_InProcessEmitsOutputMaterializedPerArtifact(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeNoImageForLaunch(t, storeDir)
+
+	var mu sync.Mutex
+	var outputPayloads []map[string]any
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/run"):
+			w.WriteHeader(http.StatusOK)
+			if strings.Contains(r.URL.Path, "query_series") {
+				_, _ = w.Write([]byte(`{"result":"{\"path\":\"digest.csv\",\"mimeType\":\"text/csv\",\"encoding\":\"utf-8\",\"content\":\"name\\ncpu\\n\"}"}`))
+			} else {
+				_, _ = w.Write([]byte(`{"result":"{\"path\":\"filed_issue.json\",\"mimeType\":\"application/json\",\"encoding\":\"utf-8\",\"content\":\"{}\"}"}`))
+			}
+		case r.URL.Path == "/v1/audit" && r.Method == http.MethodPost:
+			var body auditIngestRequest
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body.EventType == string(model.EventTypeOutputMaterialized) {
+				mu.Lock()
+				outputPayloads = append(outputPayloads, body.Payload)
+				mu.Unlock()
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"audit_id":"audit-landed"}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	stubLaunchSeams(t, daemonDispatcher{}, true)
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{})
+	origRun := launchSeamForTest
+	launchSeamForTest = fakeCLISeam{}
+	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Exactly one output.materialized per materialized artifact (two total).
+	if len(outputPayloads) != 2 {
+		t.Fatalf("output.materialized events = %d, want exactly 2 (one per materialized artifact)", len(outputPayloads))
+	}
+
+	kinds := map[string]bool{}
+	for _, p := range outputPayloads {
+		kind, _ := p["aileron.step.kind"].(string)
+		kinds[kind] = true
+		hash, _ := p["aileron.output.content_hash"].(string)
+		if hash == "" {
+			t.Errorf("output event missing content_hash: %+v", p)
+			continue
+		}
+		// The audited content hash must equal the digest printed to stdout.
+		if !strings.Contains(stdout.String(), hash) {
+			t.Errorf("content_hash %q not present in launch stdout:\n%s", hash, stdout.String())
+		}
+	}
+	// The two materialized outputs come from a transform step and an action-call
+	// step; both kinds must be represented.
+	if !kinds["transform"] || !kinds["action-call"] {
+		t.Errorf("output step kinds = %v, want both transform and action-call", kinds)
 	}
 }
 

--- a/internal/flightplan/freeze/launch.go
+++ b/internal/flightplan/freeze/launch.go
@@ -1,6 +1,8 @@
 package freeze
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -27,6 +29,14 @@ type VerifiedFrozen struct {
 	// populated on the verified path: a tampered digest changes the recomputed
 	// content hash and refuses before this field is read.
 	ResolvedImages []ImagePin
+	// SignerFingerprint is the `sha256:<hex>` fingerprint of the verified
+	// author public-key PEM (the same `pubPEM` the ed25519 signature verified
+	// against). It is the honest signer identity the audit trail carries:
+	// there is no human signer name in the system, so the key fingerprint is
+	// the stable identity value. It is only ever populated on the verified
+	// path, alongside a successful signature check, so the fingerprint names
+	// the key that actually attested the frozen unit.
+	SignerFingerprint string
 }
 
 // VerifyFrozen is the Launch-time verification gate (ADR-0027, #1509/#1511).
@@ -133,7 +143,22 @@ func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, 
 	if len(manifestLock.ResolvedImages) > 0 {
 		pins = append([]ImagePin(nil), manifestLock.ResolvedImages...)
 	}
-	return VerifiedFrozen{SkillMD: verified, ContentHash: recorded, ResolvedImages: pins}, nil
+	return VerifiedFrozen{
+		SkillMD:           verified,
+		ContentHash:       recorded,
+		ResolvedImages:    pins,
+		SignerFingerprint: signerFingerprint(pubPEM),
+	}, nil
+}
+
+// signerFingerprint returns the `sha256:<hex>` fingerprint of the verified
+// public-key PEM. It is computed only after Verify succeeds, so the value
+// names the key that actually attested the frozen unit. The same PEM bytes
+// always yield the same fingerprint, and a different key yields a different
+// one, which is what makes it a stable audit identity.
+func signerFingerprint(pubPEM []byte) string {
+	sum := sha256.Sum256(pubPEM)
+	return contentHashPrefix + hex.EncodeToString(sum[:])
 }
 
 // lockFromManifest parses the `aileron.lock` block of a frozen SKILL.md into a

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -59,6 +59,52 @@ func TestVerifyFrozen_ExposesResolvedImagesForRung2(t *testing.T) {
 	}
 }
 
+func TestVerifyFrozen_ExposesSignerFingerprint(t *testing.T) {
+	// A successful verification surfaces a `sha256:`-prefixed fingerprint of the
+	// verified author public key. It is the honest signer identity (there is no
+	// human signer name), computed over the same pubPEM the signature verified.
+	res := freezeExample(t)
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen: %v", err)
+	}
+	if !strings.HasPrefix(v.SignerFingerprint, "sha256:") {
+		t.Errorf("SignerFingerprint = %q, want a sha256: prefix", v.SignerFingerprint)
+	}
+	if len(v.SignerFingerprint) != len("sha256:")+64 {
+		t.Errorf("SignerFingerprint = %q, want sha256: + 64 hex chars", v.SignerFingerprint)
+	}
+	// The fingerprint is stable: verifying the same artifacts yields the same value.
+	v2, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen (second): %v", err)
+	}
+	if v2.SignerFingerprint != v.SignerFingerprint {
+		t.Errorf("fingerprint not stable: %q vs %q", v.SignerFingerprint, v2.SignerFingerprint)
+	}
+}
+
+func TestVerifyFrozen_SignerFingerprintDiffersPerKey(t *testing.T) {
+	// A different signing key yields a different fingerprint, so the value names
+	// the specific key that attested the unit.
+	a := freezeExample(t)
+	b := freezeExample(t)
+	va, err := VerifyFrozen(a.FrozenManifest, a.Lockfile, a.Signature, a.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen a: %v", err)
+	}
+	vb, err := VerifyFrozen(b.FrozenManifest, b.Lockfile, b.Signature, b.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen b: %v", err)
+	}
+	if bytes.Equal(a.PublicKey, b.PublicKey) {
+		t.Skip("freeze reused a key; cannot assert per-key difference")
+	}
+	if va.SignerFingerprint == vb.SignerFingerprint {
+		t.Errorf("different keys produced the same fingerprint %q", va.SignerFingerprint)
+	}
+}
+
 func TestVerifyFrozen_ExposesResolvedImagesForRung1(t *testing.T) {
 	// A rung-1 unit names a whole prebuilt image; freeze resolves it to a
 	// digest pin. The verified pin must carry both the ref and the digest.

--- a/internal/flightplan/runtime/audit.go
+++ b/internal/flightplan/runtime/audit.go
@@ -57,14 +57,39 @@ func buildActionRecord(d actionDispatch) AuditRecord {
 			fields[f] = v
 		}
 	}
-	return AuditRecord{ActionRef: d.ActionRef, Fields: fields, Sink: d.Sink}
+	return AuditRecord{Kind: RecordKindAction, ActionRef: d.ActionRef, Fields: fields, Sink: d.Sink}
 }
 
-// emitAudit records every per-action audit record plus one per-launch summary
-// record through the sink, returning the minted record ids in order. The sink
-// is the customer-owned audit store (wired by the CLI). A nil sink emits
-// nothing and returns no ids.
-func emitAudit(ctx context.Context, sink AuditSink, st execState) []string {
+// signatureStatusVerified is the single `aileron.plan.signature_status` value
+// the runtime records. Reaching runPlan means LoadVerified → freeze.VerifyFrozen
+// succeeded (both the ed25519 signature and the content-hash gate passed), so a
+// plan that runs is, by construction, verified. Single-sourced here so the
+// constant is not restated at each call site.
+const signatureStatusVerified = "verified"
+
+// launchProvenance is the per-launch identity threaded onto each
+// output.materialized record: the frozen skill name, its verified content hash,
+// the verified signer key fingerprint, the signature status, and a
+// launch-scoped invocation id that correlates every record from one launch.
+type launchProvenance struct {
+	// Skill is the frozen skill name (plan.Name).
+	Skill string
+	// ContentHash is the verified `sha256:<hex>` content hash of the frozen unit.
+	ContentHash string
+	// SignedBy is the `sha256:<hex>` fingerprint of the verified author key.
+	SignedBy string
+	// SignatureStatus is the verification status ("verified").
+	SignatureStatus string
+	// InvocationID is the launch-scoped uuid correlating this launch's records.
+	InvocationID string
+}
+
+// emitAudit records every per-action audit record, then one output.materialized
+// record per materialized artifact, then one per-launch summary record through
+// the sink, returning the minted record ids in order. The sink is the
+// customer-owned audit store (wired by the CLI). A nil sink emits nothing and
+// returns no ids.
+func emitAudit(ctx context.Context, sink AuditSink, st execState, prov launchProvenance) []string {
 	if sink == nil {
 		return nil
 	}
@@ -72,37 +97,66 @@ func emitAudit(ctx context.Context, sink AuditSink, st execState) []string {
 	for _, d := range st.dispatches {
 		ids = append(ids, sink.Record(ctx, buildActionRecord(d)))
 	}
-	// Per-launch summary: resolved inputs → materialized artifacts, by
-	// reference. Data inputs are recorded by their source binding, never the
-	// dataset inline.
+	// One per-output provenance record per materialized artifact, whether the
+	// materializing step was an action-call or a transform (#1752).
+	for _, o := range st.outputs {
+		ids = append(ids, sink.Record(ctx, buildOutputRecord(o, prov)))
+	}
+	// Per-launch summary: resolved input source bindings, by reference. Data
+	// inputs are recorded by their source binding, never the dataset inline.
 	ids = append(ids, sink.Record(ctx, buildLaunchRecord(st)))
 	return ids
 }
 
-// buildLaunchRecord builds the per-launch resolved-inputs→outputs record. It
-// references source-input reads by their resolved binding and records each
-// materialized output by name, path, and content digest, never inline data.
-// The sha256 digest is the ADR-0027 snapshot identifier: it binds the output
-// name to the exact bytes the run produced so a past launch is independently
-// verifiable (hash the loose output file, compare to the recorded digest)
-// without duplicating the dataset in the audit.
-func buildLaunchRecord(st execState) AuditRecord {
-	artifacts := make([]map[string]any, 0, len(st.artifacts))
-	for _, a := range st.artifacts {
-		artifacts = append(artifacts, map[string]any{
-			"name":   a.Name,
-			"path":   a.Path,
-			"sha256": a.Digest,
-		})
+// buildOutputRecord builds one per-output provenance record (#1752) for a
+// materialized artifact. The flat `aileron.*` field map carries the output's
+// identity (name, mime, content hash, byte count), the originating step's
+// provenance (id, kind, and — for a transform — the transform applied), and the
+// launch's plan/invocation identity. The content hash is Artifact.Digest
+// verbatim (the same `sha256:<hex>` printed at launch), so the audited hash
+// equals the stdout digest for free. The transform key is present only for a
+// transform step, so an action-call output does not carry an empty transform.
+func buildOutputRecord(o materializedOutput, prov launchProvenance) AuditRecord {
+	fields := map[string]any{
+		"aileron.output.name": o.Artifact.Name,
+		// Path is the artifact's declared on-disk path (empty for a retained
+		// target:none output). It carries the write-location provenance the old
+		// launch-summary array used to hold, so removing that array loses nothing.
+		"aileron.output.path":           o.Artifact.Path,
+		"aileron.output.mime":           o.Artifact.MimeType,
+		"aileron.output.content_hash":   o.Artifact.Digest,
+		"aileron.output.bytes":          len(o.Artifact.Content),
+		"aileron.step.id":               o.StepID,
+		"aileron.step.kind":             string(o.StepKind),
+		"aileron.plan.skill":            prov.Skill,
+		"aileron.plan.content_hash":     prov.ContentHash,
+		"aileron.plan.signed_by":        prov.SignedBy,
+		"aileron.plan.signature_status": prov.SignatureStatus,
+		"aileron.invocation.id":         prov.InvocationID,
 	}
+	// The transform name is meaningful only for a transform step; omit it for an
+	// action-call so the record does not carry an empty value.
+	if o.StepKind == KindTransform && o.Transform != "" {
+		fields["aileron.step.transform"] = o.Transform
+	}
+	return AuditRecord{Kind: RecordKindOutput, Fields: fields}
+}
+
+// buildLaunchRecord builds the per-launch resolved-inputs record. It references
+// source-input reads by their resolved binding, never the dataset inline. The
+// per-materialized-output provenance (name, hash, bytes, step) now lives on the
+// individual output.materialized records (#1752), so the summary no longer
+// lumps the outputs into an array; it keeps the input source bindings the
+// per-output records do not carry.
+func buildLaunchRecord(st execState) AuditRecord {
 	sources := map[string]any{}
 	for name, sb := range st.inputs.SourceBindings {
 		sources[name] = map[string]any{"actionRef": sb.ActionRef, "select": sb.Select}
 	}
 	return AuditRecord{
+		Kind: RecordKindLaunch,
 		Fields: map[string]any{
 			"sourceInputBindings": sources,
-			"materializedOutputs": artifacts,
 		},
 	}
 }

--- a/internal/flightplan/runtime/audit_test.go
+++ b/internal/flightplan/runtime/audit_test.go
@@ -1,6 +1,9 @@
 package runtime
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestBuildActionRecord_OnlyDeclaredFields(t *testing.T) {
 	d := actionDispatch{
@@ -71,41 +74,146 @@ func TestApprovalDecisionAudit(t *testing.T) {
 	}
 }
 
-func TestBuildLaunchRecord_BindsOutputToDigest(t *testing.T) {
-	// The per-launch record ties each materialized output name to its content
-	// digest and path, a reference (no inline bytes) inside the ADR-0027 audit
-	// boundary. This is what makes a past launch independently verifiable.
+func TestBuildActionRecord_KindIsAction(t *testing.T) {
+	// The action record carries the explicit action kind so the CLI sink maps it
+	// to flightplan.launch.action without re-inferring from ActionRef.
+	rec := buildActionRecord(actionDispatch{ActionRef: "aileron:m.read", Effect: EffectRead})
+	if rec.Kind != RecordKindAction {
+		t.Errorf("action record Kind = %v, want RecordKindAction", rec.Kind)
+	}
+}
+
+func TestBuildLaunchRecord_KeepsSourcesDropsOutputsArray(t *testing.T) {
+	// The per-launch summary now keeps only the resolved input source bindings;
+	// per-materialized-output provenance moved to individual output.materialized
+	// records (#1752), so the summary no longer lumps outputs into an array.
 	st := execState{
-		inputs: ResolvedInputs{SourceBindings: map[string]SourceBinding{}},
+		inputs: ResolvedInputs{SourceBindings: map[string]SourceBinding{
+			"series": {ActionRef: "aileron:metrics.query_series", Select: "series"},
+		}},
 		artifacts: []Artifact{
 			{Name: "chains.json", Path: "chains.json", Content: []byte(`{"a":1}`), Digest: "sha256:deadbeef", Written: true},
-			{Name: "kept.json", Content: []byte(`{}`), Digest: "sha256:cafe", Written: false},
 		},
 	}
 	rec := buildLaunchRecord(st)
-	outs, ok := rec.Fields["materializedOutputs"].([]map[string]any)
+	if rec.Kind != RecordKindLaunch {
+		t.Errorf("launch record Kind = %v, want RecordKindLaunch", rec.Kind)
+	}
+	if _, present := rec.Fields["materializedOutputs"]; present {
+		t.Error("launch summary must no longer lump outputs into materializedOutputs")
+	}
+	sources, ok := rec.Fields["sourceInputBindings"].(map[string]any)
 	if !ok {
-		t.Fatalf("materializedOutputs = %T, want []map[string]any", rec.Fields["materializedOutputs"])
+		t.Fatalf("sourceInputBindings = %T, want map[string]any", rec.Fields["sourceInputBindings"])
 	}
-	if len(outs) != 2 {
-		t.Fatalf("want 2 recorded outputs, got %d", len(outs))
+	sb, ok := sources["series"].(map[string]any)
+	if !ok || sb["actionRef"] != "aileron:metrics.query_series" || sb["select"] != "series" {
+		t.Errorf("sourceInputBindings[series] = %v", sources["series"])
 	}
-	if outs[0]["name"] != "chains.json" || outs[0]["path"] != "chains.json" || outs[0]["sha256"] != "sha256:deadbeef" {
-		t.Errorf("output 0 = %v", outs[0])
+}
+
+func TestBuildOutputRecord_TransformCarriesFullProvenance(t *testing.T) {
+	// A transform-materialized output surfaces as its own event with the step's
+	// kind/transform, the content hash equal to Artifact.Digest verbatim, the
+	// byte count, and the full plan/invocation identity.
+	prov := launchProvenance{
+		Skill: "weekly-metrics-digest", ContentHash: "sha256:plan", SignedBy: "sha256:key",
+		SignatureStatus: "verified", InvocationID: "inv-123",
 	}
-	// The retained (unwritten) output is still recorded by name + digest.
-	if outs[1]["name"] != "kept.json" || outs[1]["sha256"] != "sha256:cafe" {
-		t.Errorf("output 1 = %v", outs[1])
+	content := []byte("name\ncpu\n")
+	o := materializedOutput{
+		StepID:    "render_csv",
+		StepKind:  KindTransform,
+		Transform: "html-render",
+		Artifact:  Artifact{Name: "digest.csv", Path: "digest.csv", MimeType: "text/csv", Content: content, Digest: "sha256:abc"},
 	}
-	// The record references each output by name/path/sha256 only, never the
-	// dataset bytes inline (ADR-0027 boundary).
-	for _, o := range outs {
-		if len(o) != 3 {
-			t.Errorf("recorded output must carry only name/path/sha256, got %v", o)
+	rec := buildOutputRecord(o, prov)
+	if rec.Kind != RecordKindOutput {
+		t.Fatalf("Kind = %v, want RecordKindOutput", rec.Kind)
+	}
+	f := rec.Fields
+	if f["aileron.output.name"] != "digest.csv" || f["aileron.output.mime"] != "text/csv" {
+		t.Errorf("output identity fields = %v", f)
+	}
+	if f["aileron.output.path"] != "digest.csv" {
+		t.Errorf("output.path = %v, want the artifact's on-disk path", f["aileron.output.path"])
+	}
+	if f["aileron.output.content_hash"] != "sha256:abc" {
+		t.Errorf("content_hash = %v, want the Artifact.Digest verbatim", f["aileron.output.content_hash"])
+	}
+	if f["aileron.output.bytes"] != len(content) {
+		t.Errorf("bytes = %v, want %d", f["aileron.output.bytes"], len(content))
+	}
+	if f["aileron.step.id"] != "render_csv" || f["aileron.step.kind"] != "transform" {
+		t.Errorf("step provenance = %v", f)
+	}
+	if f["aileron.step.transform"] != "html-render" {
+		t.Errorf("step.transform = %v, want html-render", f["aileron.step.transform"])
+	}
+	if f["aileron.plan.skill"] != "weekly-metrics-digest" || f["aileron.plan.content_hash"] != "sha256:plan" ||
+		f["aileron.plan.signed_by"] != "sha256:key" || f["aileron.plan.signature_status"] != "verified" ||
+		f["aileron.invocation.id"] != "inv-123" {
+		t.Errorf("plan/invocation provenance = %v", f)
+	}
+}
+
+func TestBuildOutputRecord_ActionCallOmitsTransform(t *testing.T) {
+	// An action-call materialized output carries step.kind=action-call and does
+	// NOT carry a step.transform key (there is no transform for an action-call).
+	o := materializedOutput{
+		StepID:   "file_issue",
+		StepKind: KindActionCall,
+		Artifact: Artifact{Name: "filed_issue.json", MimeType: "application/json", Content: []byte("{}"), Digest: "sha256:d"},
+	}
+	rec := buildOutputRecord(o, launchProvenance{})
+	if rec.Fields["aileron.step.kind"] != "action-call" {
+		t.Errorf("step.kind = %v, want action-call", rec.Fields["aileron.step.kind"])
+	}
+	if _, present := rec.Fields["aileron.step.transform"]; present {
+		t.Error("an action-call output record must not carry aileron.step.transform")
+	}
+}
+
+func TestEmitAudit_OneOutputRecordPerArtifact(t *testing.T) {
+	// emitAudit emits exactly one RecordKindOutput per st.outputs entry, then the
+	// launch summary. This includes a transform-only materializing output with no
+	// action dispatch present (the transform case the issue targets).
+	st := execState{
+		inputs: ResolvedInputs{SourceBindings: map[string]SourceBinding{}},
+		outputs: []materializedOutput{
+			{StepID: "render_csv", StepKind: KindTransform, Transform: "html-render",
+				Artifact: Artifact{Name: "digest.csv", Content: []byte("x"), Digest: "sha256:1"}},
+		},
+	}
+	sink := &recordingSink{}
+	ids := emitAudit(context.Background(), sink, st, launchProvenance{InvocationID: "inv"})
+
+	var outputRecords, launchRecords int
+	for _, r := range sink.records {
+		switch r.Kind {
+		case RecordKindOutput:
+			outputRecords++
+		case RecordKindLaunch:
+			launchRecords++
 		}
-		if _, hasContent := o["content"]; hasContent {
-			t.Error("the launch record must not carry artifact content inline")
-		}
+	}
+	if outputRecords != 1 {
+		t.Errorf("output records = %d, want exactly 1 (one per materialized artifact)", outputRecords)
+	}
+	if launchRecords != 1 {
+		t.Errorf("launch summary records = %d, want exactly 1", launchRecords)
+	}
+	if len(ids) != len(sink.records) {
+		t.Errorf("emitAudit returned %d ids for %d records", len(ids), len(sink.records))
+	}
+}
+
+func TestEmitAudit_NilSinkEmitsNothing(t *testing.T) {
+	// A nil sink emits nothing and returns no ids (the audit is a companion, not
+	// a hard dependency).
+	st := execState{outputs: []materializedOutput{{StepID: "s", StepKind: KindTransform}}}
+	if ids := emitAudit(context.Background(), nil, st, launchProvenance{}); ids != nil {
+		t.Errorf("nil sink returned ids = %v, want nil", ids)
 	}
 }
 

--- a/internal/flightplan/runtime/execute.go
+++ b/internal/flightplan/runtime/execute.go
@@ -17,6 +17,28 @@ type execState struct {
 	dispatches []actionDispatch
 	// artifacts records materialized output artifacts, in execution order.
 	artifacts []Artifact
+	// outputs records each materialized artifact together with the step that
+	// produced it, in execution order. Unlike artifacts (kept for writing and
+	// the run result), outputs carries the originating step's id/kind/transform
+	// so the audit can emit one `output.materialized` record per artifact with
+	// full provenance. It is populated for BOTH action-call and transform
+	// materializing steps, since the materialize block keys off
+	// step.MaterializesOutput (kind-agnostic).
+	outputs []materializedOutput
+}
+
+// materializedOutput pairs one materialized artifact with the provenance of the
+// step that produced it, so the per-output audit record can name the
+// originating step and (for a transform) the transform applied.
+type materializedOutput struct {
+	// StepID is the id of the step that materialized the artifact.
+	StepID string
+	// StepKind is the step's kind (action-call or transform).
+	StepKind StepKind
+	// Transform is the transform name, set only for a KindTransform step.
+	Transform string
+	// Artifact is the materialized artifact (name, mime, content, digest).
+	Artifact Artifact
 }
 
 // actionDispatch records one action-call's enforced outcome for the audit.
@@ -102,6 +124,16 @@ func (x *executor) execute(ctx context.Context, inputs ResolvedInputs) (execStat
 				return st, err
 			}
 			st.artifacts = append(st.artifacts, art)
+			// Capture the artifact with its originating step's provenance. This
+			// block fires for both action-call and transform materializing
+			// steps (it keys off step.MaterializesOutput, not step.Kind), so a
+			// transform-materialized output is captured with no new branch.
+			st.outputs = append(st.outputs, materializedOutput{
+				StepID:    step.ID,
+				StepKind:  step.Kind,
+				Transform: step.Transform,
+				Artifact:  art,
+			})
 		}
 	}
 	return st, nil

--- a/internal/flightplan/runtime/execute_test.go
+++ b/internal/flightplan/runtime/execute_test.go
@@ -107,7 +107,7 @@ func runFixture(t *testing.T, opts Options) (RunResult, *dispatchRouter, *record
 	if opts.Seam != nil {
 		o.Seam = opts.Seam
 	}
-	res, err := runPlan(context.Background(), p, "sha256:test", o)
+	res, err := runPlan(context.Background(), p, "sha256:test", "sha256:signer", o)
 	if err != nil {
 		t.Fatalf("runPlan: %v", err)
 	}
@@ -159,6 +159,70 @@ func TestExecute_WriteThreadsIdempotencyKey(t *testing.T) {
 	writeArgs := disp.calls[1].args
 	if _, ok := writeArgs[idempotencyKeyField]; !ok {
 		t.Error("the write action (idempotencyKey:true) must thread a stable key")
+	}
+}
+
+func TestExecute_CapturesMaterializedOutputProvenance(t *testing.T) {
+	// The fixture materializes two outputs: digest.csv from a transform step and
+	// filed_issue.json from an action-call step. execute must capture one
+	// st.outputs entry per materialized artifact, each carrying the originating
+	// step's id/kind (and the transform name for the transform step). This is the
+	// kind-agnostic capture that makes the transform output auditable (#1752).
+	p := fixturePlan()
+	// Name the transform on the materializing transform step so the captured
+	// provenance carries a concrete transform name (mirrors `transform:
+	// html-render`). render_csv is the transform step (index 1).
+	for i := range p.Steps {
+		if p.Steps[i].ID == "render_csv" {
+			p.Steps[i].Transform = "html-render"
+		}
+	}
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {
+			"path": "filed_issue.json", "mimeType": "application/json", "encoding": "utf-8",
+			"content": `{"url":"https://tracker.example.com/issues/1"}`,
+		},
+	}}
+	reg := NewTransformRegistry()
+	reg.Register("html-render", func(_ map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{
+			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
+		}}, nil
+	})
+	x := &executor{
+		plan:      p,
+		enforcer:  &enforcer{dispatcher: disp, approver: &fakeApprover{decision: Decision{Approved: true}}},
+		transform: reg,
+		seam:      fakeSeam{out: map[string]any{"issue_body": "A short digest."}},
+	}
+	st, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{"window_days": 7}})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(st.outputs) != 2 {
+		t.Fatalf("captured %d outputs, want 2 (transform + action-call)", len(st.outputs))
+	}
+	byStep := map[string]materializedOutput{}
+	for _, o := range st.outputs {
+		byStep[o.StepID] = o
+	}
+	csv, ok := byStep["render_csv"]
+	if !ok {
+		t.Fatal("transform materializing step render_csv was not captured")
+	}
+	if csv.StepKind != KindTransform || csv.Transform != "html-render" {
+		t.Errorf("transform output = kind %q transform %q, want transform/html-render", csv.StepKind, csv.Transform)
+	}
+	if csv.Artifact.Name != "digest.csv" {
+		t.Errorf("transform artifact name = %q", csv.Artifact.Name)
+	}
+	issue, ok := byStep["file_issue"]
+	if !ok {
+		t.Fatal("action-call materializing step file_issue was not captured")
+	}
+	if issue.StepKind != KindActionCall {
+		t.Errorf("action-call output kind = %q, want action-call", issue.StepKind)
 	}
 }
 

--- a/internal/flightplan/runtime/load.go
+++ b/internal/flightplan/runtime/load.go
@@ -27,6 +27,11 @@ type LoadedPlan struct {
 	// The pins come from the verified manifest lock block, so the digest booted
 	// is exactly the one the author signature attested.
 	ResolvedImages []freeze.ImagePin
+	// SignerFingerprint is the `sha256:<hex>` fingerprint of the verified
+	// author public key (from freeze.VerifyFrozen). It is threaded into the
+	// launch audit as the plan's signer identity (#1752). Populated only on the
+	// verified path, so it names the key that actually attested this unit.
+	SignerFingerprint string
 }
 
 // LoadVerified loads a frozen skill version from the store, verifies it
@@ -68,8 +73,9 @@ func verifyAndDecode(fv store.FrozenVersion) (LoadedPlan, error) {
 		return LoadedPlan{}, err
 	}
 	return LoadedPlan{
-		Plan:           plan,
-		ContentHash:    verified.ContentHash,
-		ResolvedImages: verified.ResolvedImages,
+		Plan:              plan,
+		ContentHash:       verified.ContentHash,
+		ResolvedImages:    verified.ResolvedImages,
+		SignerFingerprint: verified.SignerFingerprint,
 	}, nil
 }

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -159,6 +159,11 @@ func TestLoadVerified_UntamperedLoads(t *testing.T) {
 	if !strings.HasPrefix(lp.ContentHash, "sha256:") {
 		t.Errorf("content hash = %q", lp.ContentHash)
 	}
+	// The verified signer fingerprint surfaces on the LoadedPlan so the launch
+	// audit can record the plan's signer identity (#1752).
+	if !strings.HasPrefix(lp.SignerFingerprint, "sha256:") {
+		t.Errorf("SignerFingerprint = %q, want a sha256: prefix surfaced from verification", lp.SignerFingerprint)
+	}
 }
 
 func TestLoadVerified_PropagatesResolvedImages(t *testing.T) {

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	"github.com/google/uuid"
 )
 
 // Options configures a launch. The Store + Name + Version select the frozen
@@ -99,13 +100,15 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	if hasWholePlanImage(lp.ResolvedImages) {
 		return runInImage(ctx, lp, opts)
 	}
-	return runPlan(ctx, lp.Plan, lp.ContentHash, opts)
+	return runPlan(ctx, lp.Plan, lp.ContentHash, lp.SignerFingerprint, opts)
 }
 
 // runPlan executes an already-loaded, verified plan. It is factored out so
 // tests drive the full Phase A/B/materialize/audit pipeline from an in-memory
-// plan without a store on disk, while Run handles the load+verify gate.
-func runPlan(ctx context.Context, plan *Plan, contentHash string, opts Options) (RunResult, error) {
+// plan without a store on disk, while Run handles the load+verify gate. The
+// signerFingerprint is the verified author-key fingerprint threaded onto the
+// per-output audit records as the plan's signer identity (#1752).
+func runPlan(ctx context.Context, plan *Plan, contentHash, signerFingerprint string, opts Options) (RunResult, error) {
 	clk := opts.Clock
 	if clk == nil {
 		clk = SystemClock{}
@@ -128,9 +131,20 @@ func runPlan(ctx context.Context, plan *Plan, contentHash string, opts Options) 
 	x := &executor{plan: plan, enforcer: enf, transform: reg, seam: opts.Seam, toolRunner: opts.ToolImageRunner}
 	st, runErr := x.execute(ctx, inputs)
 
+	// Mint a launch-scoped invocation id so every audit record from this launch
+	// correlates. Provenance is fixed for the launch: reaching runPlan means the
+	// verify gate passed, so the signature status is "verified".
+	prov := launchProvenance{
+		Skill:           plan.Name,
+		ContentHash:     contentHash,
+		SignedBy:        signerFingerprint,
+		SignatureStatus: signatureStatusVerified,
+		InvocationID:    uuid.NewString(),
+	}
+
 	// Emit the audit regardless of run outcome so a mid-run denial is recorded
 	// (the audit is an append-only companion, not gated on success).
-	auditIDs := emitAudit(ctx, opts.Audit, st)
+	auditIDs := emitAudit(ctx, opts.Audit, st, prov)
 
 	if runErr != nil {
 		return RunResult{}, runErr

--- a/internal/flightplan/runtime/run_extra_test.go
+++ b/internal/flightplan/runtime/run_extra_test.go
@@ -72,7 +72,7 @@ func TestRun_InProcessPipelineFromLoadedPlan(t *testing.T) {
 		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
 	}}
 
-	res, err := runPlan(context.Background(), lp.Plan, lp.ContentHash, Options{
+	res, err := runPlan(context.Background(), lp.Plan, lp.ContentHash, lp.SignerFingerprint, Options{
 		Dispatcher: disp,
 		Approver:   &fakeApprover{decision: Decision{Approved: true}},
 		Seam:       fakeSeam{out: map[string]any{"issue_body": "x"}},

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -68,7 +68,7 @@ func TestRun_StructuralNoLLMGuarantee(t *testing.T) {
 	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
 		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "x", "mimeType": "text/csv"}}, nil
 	})
-	_, err := runPlan(context.Background(), p, "h", Options{
+	_, err := runPlan(context.Background(), p, "h", "sha256:signer", Options{
 		Dispatcher: &dispatchRouter{results: map[string]map[string]any{
 			"aileron:metrics.query_series": {"series": []any{}},
 		}},
@@ -91,7 +91,7 @@ func TestRun_DeniedApprovalAbortsAndAudits(t *testing.T) {
 	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
 		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "x", "mimeType": "text/csv"}}, nil
 	})
-	_, err := runPlan(context.Background(), p, "h", Options{
+	_, err := runPlan(context.Background(), p, "h", "sha256:signer", Options{
 		Dispatcher: &dispatchRouter{results: map[string]map[string]any{
 			"aileron:metrics.query_series": {"series": []any{}},
 			"aileron:tracker.create_issue": {"path": "filed_issue.json", "encoding": "utf-8", "content": "{}", "mimeType": "application/json"},

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -56,14 +56,38 @@ type Approver interface {
 	Approve(ctx context.Context, req ApprovalRequest) (Decision, error)
 }
 
+// AuditRecordKind is the closed set of runtime audit record kinds. It is the
+// explicit discriminator the CLI sink switches on to map each record to an
+// internal/model.EventType, so the runtime stays free of an internal/model
+// import while the third (output) kind is explicit rather than overloaded onto
+// ActionRef.
+type AuditRecordKind int
+
+const (
+	// RecordKindAction is one per-action-call dispatch record.
+	RecordKindAction AuditRecordKind = iota
+	// RecordKindLaunch is the per-launch summary record.
+	RecordKindLaunch
+	// RecordKindOutput is one per-materialized-output provenance record (#1752),
+	// emitted for both action-call and transform materializing steps.
+	RecordKindOutput
+)
+
 // AuditRecord is one customer-owned audit entry. Fields holds exactly the
 // declared audit.fields for the action (data reads referenced by resolved
 // binding, never the dataset inline; ADR-0027 audit boundary).
 type AuditRecord struct {
+	// Kind is the record's kind, the explicit discriminator the CLI sink maps
+	// to a model.EventType (RecordKindAction → flightplan.launch.action,
+	// RecordKindLaunch → flightplan.launch, RecordKindOutput →
+	// output.materialized).
+	Kind AuditRecordKind
 	// ActionRef is the action the record describes, or "" for a per-launch
-	// summary record.
+	// summary or per-output record.
 	ActionRef string
-	// Fields holds the declared audit field values.
+	// Fields holds the declared audit field values. For a RecordKindOutput
+	// record it holds the flat `aileron.*` attribute map the sink surfaces as
+	// the top-level event payload.
 	Fields map[string]any
 	// Sink is the customer-owned sink reference from the trust contract.
 	Sink string

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -402,4 +402,14 @@ const (
 	// "flightplan-launch"}.
 	EventTypeFlightPlanLaunchAction EventType = "flightplan.launch.action"
 	EventTypeFlightPlanLaunch       EventType = "flightplan.launch"
+
+	// EventTypeOutputMaterialized is one per-output-per-step provenance event
+	// (#1752). The in-process launch runtime emits exactly one such record for
+	// each materialized artifact, whether the materializing step is an
+	// action-call or a transform (a `transform: html-render` output surfaces as
+	// its own event rather than being lumped into the launch summary). The
+	// flat `aileron.*` payload carries the output's content hash, mime, byte
+	// count, and originating step provenance plus the plan/invocation identity.
+	// Actor is {type: service, id: "flightplan-launch"}.
+	EventTypeOutputMaterialized EventType = "output.materialized"
 )


### PR DESCRIPTION
## Summary

Part of umbrella #1750. Adds a dedicated `output.materialized` audit event, emitted once per materialized artifact on the in-process launch path, so a `transform: html-render` output surfaces as its own auditable event instead of being invisible in `aileron audit list`.

Today only action-call steps append dispatch records, and every materialized output is lumped into the launch summary's `materializedOutputs` array. A transform that materializes an output therefore has no per-output event carrying its content hash, mime, byte count, and originating step provenance. This change fixes that.

### What changed

- **New record kind, not a new SPI.** Adds an explicit `AuditRecordKind` discriminator (`RecordKindAction` / `RecordKindLaunch` / `RecordKindOutput`) to the runtime's `AuditRecord`. The CLI sink switches on it to map each record to a `model.EventType`, so the runtime stays free of an `internal/model` import (mirrors the current design) and the third kind is explicit rather than overloaded onto `ActionRef`.
- **New event type** `EventTypeOutputMaterialized = "output.materialized"`, actor `{service, flightplan-launch}`.
- **Kind-agnostic capture.** `execState.outputs` records each materialized artifact with its step id/kind/transform, populated in the single materialize block that already fires for both action-call and transform steps (keys off `step.MaterializesOutput`, so the transform case works with no new branch).
- **Flat `aileron.*` payload** on the output record: `output.name/path/mime/content_hash/bytes`, `step.id/kind/transform` (transform only when it's a transform step), `plan.skill/content_hash/signed_by/signature_status`, `invocation.id`. The sink surfaces it as the top-level payload (matching the `vault.user.credential.*` convention); action/launch records keep their existing nested `payload["fields"]` shape.
- **`content_hash` = `Artifact.Digest` verbatim**, the same `sha256:<hex>` printed to stdout at launch, so the audited hash equals the stdout digest by construction.
- **Signer identity:** `freeze.VerifyFrozen` now computes a `sha256:<hex>` `SignerFingerprint` over the verified public-key PEM, surfaced on `LoadedPlan` and threaded in as `aileron.plan.signed_by`. There is no human signer name in the system, so a key fingerprint is the honest identity value. `signature_status` is the constant `"verified"` (reaching `runPlan` means the verify gate passed). `invocation.id` is a per-launch uuid correlating the launch's records.

### Flagged for review

- The launch summary **drops** the lumped `materializedOutputs` array (the "instead of lumping into one launch summary" instruction read literally). No back-compat shim (pre-release). The array's write-location provenance is preserved by adding `aileron.output.path` to each per-output record (per CodeRabbit), so nothing is lost. The acceptance criteria ("exactly one `output.materialized` per artifact") hold either way. Reversible if review prefers keeping the array alongside the per-output records.
- `aileron.invocation.id` is applied to the `output.materialized` record only, per the brief; propagating it onto action/launch records is a possible follow-up.

### Scope

In scope: in-process `runPlan` path only (matches #1764's scope). Not changed: `POST /v1/audit` handler, OpenAPI spec (`event_type` is free-form), approval/idempotency (no new write surface). Out of scope: the image-boot path reaching the host daemon (#1759).

## Test plan

- `internal/flightplan/freeze` — `VerifyFrozen` returns a stable, `sha256:`-prefixed fingerprint that differs per key.
- `internal/flightplan/runtime` — `LoadedPlan` surfaces the fingerprint; the executor captures one `st.outputs` entry per materialized artifact (transform + action-call) with the right kind/transform; `buildOutputRecord` carries full provenance for a transform output and omits `step.transform` for an action-call; `content_hash == Artifact.Digest`; `bytes == len(content)`; `buildLaunchRecord` no longer carries `materializedOutputs` but keeps `sourceInputBindings`; `emitAudit` emits exactly one `RecordKindOutput` per output (including a transform-only plan) plus one summary; nil sink emits nothing.
- `cmd/aileron` — the sink maps `RecordKindOutput` to `output.materialized` with a flat (non-nested, non-null) payload; a full in-process launch of the worked example POSTs exactly two `output.materialized` events (one transform-kind, one action-call-kind), and each event's `aileron.output.content_hash` equals a digest printed to stdout (acceptance criterion). Existing action/launch-summary POST assertions still pass.
- `go build ./...`, `gofmt` clean, `go test` green across `internal/flightplan/...`, `internal/model`, `cmd/aileron`. Coverage: runtime 90.0%, freeze 88.3%, cmd/aileron 86.2%. No `server.gen.go` drift (no spec change).

Closes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
