### PR TITLE
test(audit): lock content_hash filter excludes plan-level content_hash key

### DIFF
--- a/internal/audit/mem_events_test.go
+++ b/internal/audit/mem_events_test.go
@@ -228,6 +228,35 @@ func TestListEvents_FilterByContentHashIsExact(t *testing.T) {
 	}
 }
 
+// TestListEvents_FilterByContentHashIgnoresPlanKey locks that the
+// ContentHash filter matches only on `aileron.output.content_hash` and
+// never on `aileron.plan.content_hash`. The plan-level content hash is a
+// real key emitted by the flight-plan runtime (see
+// internal/flightplan/runtime/audit.go), so a matcher that read it would
+// return output.materialized events whose OUTPUT hash differs from the
+// requested digest.
+func TestListEvents_FilterByContentHashIgnoresPlanKey(t *testing.T) {
+	const digest = "sha256:0123456789abcdef"
+	store := seedEvents(t,
+		// Plan hash equals the requested digest, but the output hash
+		// differs — this event must NOT be returned.
+		audit.Event{
+			EventID:   "plan-hash-only",
+			EventType: model.EventType("output.materialized"),
+			Payload: map[string]any{
+				"aileron.output.name":         "report.pdf",
+				"aileron.plan.content_hash":   digest,
+				"aileron.output.content_hash": "sha256:ffff",
+			},
+			Timestamp: time.Now(),
+		},
+	)
+	got, _ := store.ListEvents(context.Background(), audit.EventFilter{ContentHash: digest})
+	if len(got) != 0 {
+		t.Errorf("plan-level content_hash must not match output filter, got %+v", got)
+	}
+}
+
 func TestListEvents_OutputFiltersCompose(t *testing.T) {
 	t0 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	const digest = "sha256:cafe"


### PR DESCRIPTION
## Summary

The `ContentHash` field on `EventFilter` is matched only against the
`aileron.output.content_hash` payload key (internal/audit/mem.go:100).
`aileron.plan.content_hash` is a distinct, real payload key emitted by the
flight-plan runtime (internal/flightplan/runtime/audit.go:159). The matcher
is correct today, but no test seeded a plan-hash key, so nothing locked the
exclusion — a regression that made the matcher fall back to the plan hash
would have gone uncaught.

This adds one additive regression test, `TestListEvents_FilterByContentHashIgnoresPlanKey`,
seeding an `output.materialized` event whose `aileron.plan.content_hash`
equals the requested digest while its `aileron.output.content_hash` differs,
and asserts `ListEvents(EventFilter{ContentHash: digest})` returns nothing.

No production code changes.

## Test plan

- `go test ./internal/audit/` — passes.
- New test fails if the matcher were to read `aileron.plan.content_hash`
  (plan hash == digest would then wrongly match), passes with the current
  output-only matcher.

Closes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)