### PR TITLE
feat(flightplan): emit tool-step output.materialized provenance

### DIFF
--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -7936,6 +7936,44 @@ func TestRunAuditShow_RendersFullMaterializedRecord(t *testing.T) {
 	}
 }
 
+// TestRunAuditShow_RendersToolStepProvenance locks the #1762 acceptance
+// guarantee that `audit show` renders a rung-3 tool-step output.materialized
+// event verbatim, including aileron.step.kind:"tool" and the pinned
+// aileron.step.image, through the SAME show surface the connector path uses.
+func TestRunAuditShow_RendersToolStepProvenance(t *testing.T) {
+	prev := auditGetFetcher
+	auditGetFetcher = func(_ string) (*auditEventWire, int, error) {
+		return &auditEventWire{
+			AuditID:   "tool-out",
+			EventType: "output.materialized",
+			Timestamp: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			Payload: map[string]any{
+				"aileron.output.name":         "extract.txt",
+				"aileron.output.content_hash": "sha256:cafe",
+				"aileron.step.kind":           "tool",
+				"aileron.step.image":          "registry.example.com/tool-a:1@sha256:beef",
+			},
+		}, http.StatusOK, nil
+	}
+	defer func() { auditGetFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"audit", "show", "tool-out"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"aileron.step.kind",
+		"aileron.step.image",
+		"registry.example.com/tool-a:1@sha256:beef",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
 // TestRunAuditShow_NotFoundExitsNonZero: 404 from the daemon translates
 // to a non-zero exit and a stderr line naming the missing id.
 func TestRunAuditShow_NotFoundExitsNonZero(t *testing.T) {

--- a/internal/audit/mem_events_test.go
+++ b/internal/audit/mem_events_test.go
@@ -188,6 +188,42 @@ func TestListEvents_FilterByOutputNameMatchesMaterialized(t *testing.T) {
 	}
 }
 
+// TestListEvents_ToolStepOutputIsQueryableByExistingFilters proves the store is
+// producer-agnostic (#1762): an output.materialized event produced by a rung-3
+// tool step — carrying aileron.step.kind:"tool" and aileron.step.image alongside
+// the standard output name/content_hash — is found by the SAME --content-hash and
+// --output filters the connector path uses, with no new query path. A different
+// content-hash does not match (negative).
+func TestListEvents_ToolStepOutputIsQueryableByExistingFilters(t *testing.T) {
+	const toolDigest = "sha256:0011223344556677"
+	store := seedEvents(t,
+		audit.Event{
+			EventID:   "tool-out",
+			EventType: model.EventType("output.materialized"),
+			Payload: map[string]any{
+				"aileron.output.name":         "extract.txt",
+				"aileron.output.content_hash": toolDigest,
+				"aileron.step.kind":           "tool",
+				"aileron.step.image":          "registry.example.com/tool-a:1@sha256:beef",
+			},
+			Timestamp: time.Now(),
+		},
+	)
+
+	byHash, _ := store.ListEvents(context.Background(), audit.EventFilter{ContentHash: toolDigest})
+	if len(byHash) != 1 || byHash[0].EventID != "tool-out" {
+		t.Errorf("--content-hash must surface the tool-step record, got %+v", byHash)
+	}
+	byName, _ := store.ListEvents(context.Background(), audit.EventFilter{OutputName: "extract.txt"})
+	if len(byName) != 1 || byName[0].EventID != "tool-out" {
+		t.Errorf("--output must surface the tool-step record, got %+v", byName)
+	}
+	miss, _ := store.ListEvents(context.Background(), audit.EventFilter{ContentHash: "sha256:deadbeef"})
+	if len(miss) != 0 {
+		t.Errorf("a different content-hash must not match, got %+v", miss)
+	}
+}
+
 func TestListEvents_FilterByContentHashIsExact(t *testing.T) {
 	const digest = "sha256:0123456789abcdef"
 	store := seedEvents(t,

--- a/internal/flightplan/runtime/audit.go
+++ b/internal/flightplan/runtime/audit.go
@@ -187,9 +187,26 @@ func buildOutputRecord(o materializedOutput, prov launchProvenance, dispatchBySt
 		"aileron.plan.signature_status": prov.SignatureStatus,
 		"aileron.invocation.id":         prov.InvocationID,
 	}
+	// A tool-materialized output (rung-3 dispatch, issue #1762) overrides the
+	// step-kind with the literal "tool" and records the pinned image. StepKind
+	// stays a closed 3-member enum (the no-LLM guarantee); tool dispatch is
+	// orthogonal to Kind, so the tool marker is the pinned image on the
+	// materialized output, not a new enum member. The image is the
+	// content-addressed `ref@sha256:<hex>` pin, which fully identifies what ran
+	// (the baked-in entrypoint). No aileron.step.command is synthesized — the
+	// rung-3 model carries no command; the pin IS the executed-command identity.
+	// aileron.step.calls[] (per-egress attribution, Half B) is out of scope and
+	// omitted entirely.
+	if o.ToolImage != "" {
+		fields["aileron.step.kind"] = "tool"
+		fields["aileron.step.image"] = o.ToolImage
+	}
 	// The transform name is meaningful only for a transform step; omit it for an
-	// action-call so the record does not carry an empty value.
-	if o.StepKind == KindTransform && o.Transform != "" {
+	// action-call so the record does not carry an empty value. A tool step's
+	// output is the collected blob, never a transform result, so a tool step
+	// never carries aileron.step.transform even if its Kind happens to be
+	// transform (the rung-3 dispatch is checked before the kind branches).
+	if o.ToolImage == "" && o.StepKind == KindTransform && o.Transform != "" {
 		fields["aileron.step.transform"] = o.Transform
 	}
 	// The input walk-back: the producing step's bindings, each hashed. Present

--- a/internal/flightplan/runtime/audit_test.go
+++ b/internal/flightplan/runtime/audit_test.go
@@ -174,6 +174,97 @@ func TestBuildOutputRecord_ActionCallOmitsTransform(t *testing.T) {
 	}
 }
 
+func TestBuildOutputRecord_ToolStepCarriesImageAndKind(t *testing.T) {
+	// A tool-materialized output (rung-3 dispatch, #1762) carries the literal
+	// step.kind="tool" (overriding the closed StepKind enum), the pinned image,
+	// the collected-output content_hash, the input walk-back, and the plan /
+	// invocation identity — every other field identical to the connector path.
+	// It carries NO aileron.step.transform, NO aileron.step.calls, and NO
+	// aileron.step.command.
+	prov := launchProvenance{
+		Skill: "rung3-plan", ContentHash: "sha256:plan", SignedBy: "sha256:key",
+		SignatureStatus: "verified", InvocationID: "inv-9",
+	}
+	inputValue := map[string]any{"payload": "hello"}
+	o := materializedOutput{
+		StepID:   "extract",
+		StepKind: KindTransform, // rung-3 dispatch is checked before the kind branch; Kind is incidental.
+		Artifact: Artifact{Name: "extract.txt", MimeType: "text/plain", Content: []byte("collected"), Digest: "sha256:abc"},
+		Binds: map[string]Binding{
+			"payload": {Kind: BindInput, Raw: "inputs.payload", Name: "payload"},
+		},
+		Resolved:  map[string]any{"payload": inputValue},
+		ToolImage: "registry.example.com/tool-a:1@" + digestA,
+	}
+	rec := buildOutputRecord(o, prov, nil, nil)
+	f := rec.Fields
+
+	if f["aileron.step.kind"] != "tool" {
+		t.Errorf("step.kind = %v, want the literal tool", f["aileron.step.kind"])
+	}
+	if f["aileron.step.image"] != "registry.example.com/tool-a:1@"+digestA {
+		t.Errorf("step.image = %v, want the pinned ref@digest", f["aileron.step.image"])
+	}
+	if f["aileron.output.content_hash"] != "sha256:abc" {
+		t.Errorf("content_hash = %v, want the Artifact.Digest verbatim", f["aileron.output.content_hash"])
+	}
+	// The input walk-back is present with the bound input's content_hash.
+	inputs, ok := f["aileron.step.inputs"].([]map[string]any)
+	if !ok || len(inputs) != 1 {
+		t.Fatalf("step.inputs = %v, want one entry", f["aileron.step.inputs"])
+	}
+	wantHash, err := canonicalValueDigest(inputValue)
+	if err != nil {
+		t.Fatalf("canonicalValueDigest: %v", err)
+	}
+	if inputs[0]["content_hash"] != wantHash {
+		t.Errorf("step.inputs[0] content_hash = %v, want %v", inputs[0]["content_hash"], wantHash)
+	}
+	// Plan / invocation identity present.
+	if f["aileron.plan.content_hash"] != "sha256:plan" || f["aileron.invocation.id"] != "inv-9" ||
+		f["aileron.step.id"] != "extract" {
+		t.Errorf("plan/invocation/step identity incomplete: %v", f)
+	}
+	// A tool step carries none of these.
+	if _, present := f["aileron.step.transform"]; present {
+		t.Error("a tool step record must not carry aileron.step.transform")
+	}
+	if _, present := f["aileron.step.calls"]; present {
+		t.Error("aileron.step.calls[] (Half B) must be absent")
+	}
+	if _, present := f["aileron.step.command"]; present {
+		t.Error("aileron.step.command must not be synthesized")
+	}
+}
+
+func TestBuildOutputRecord_NonToolOutputOmitsImage(t *testing.T) {
+	// A connector/transform output (ToolImage == "") still emits its own StepKind
+	// and NO aileron.step.image — the regression guard that the image key is
+	// tool-only.
+	for _, tc := range []struct {
+		name string
+		kind StepKind
+	}{
+		{"transform", KindTransform},
+		{"action-call", KindActionCall},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o := materializedOutput{
+				StepID:   "s",
+				StepKind: tc.kind,
+				Artifact: Artifact{Name: "o.json", Digest: "sha256:d"},
+			}
+			rec := buildOutputRecord(o, launchProvenance{}, nil, nil)
+			if rec.Fields["aileron.step.kind"] != string(tc.kind) {
+				t.Errorf("step.kind = %v, want %v", rec.Fields["aileron.step.kind"], tc.kind)
+			}
+			if _, present := rec.Fields["aileron.step.image"]; present {
+				t.Error("a non-tool output record must not carry aileron.step.image")
+			}
+		})
+	}
+}
+
 func TestEmitAudit_OneOutputRecordPerArtifact(t *testing.T) {
 	// emitAudit emits exactly one RecordKindOutput per st.outputs entry, then the
 	// launch summary. This includes a transform-only materializing output with no

--- a/internal/flightplan/runtime/execute.go
+++ b/internal/flightplan/runtime/execute.go
@@ -58,6 +58,16 @@ type materializedOutput struct {
 	// the exact inputs that produced it — by hash, never by inlining the
 	// dataset.
 	Resolved map[string]any
+	// ToolImage is the pinned `ref@sha256:<hex>` tool image, set ONLY when the
+	// producing step dispatched a rung-3 tool image (step.ToolDispatch != nil).
+	// It is empty for every non-tool (in-process action-call or transform)
+	// step. Its presence is the discriminator the audit layer uses to flip
+	// `aileron.step.kind` to the literal "tool" and to record
+	// `aileron.step.image` with this pin. The content-addressed pin fully and
+	// verifiably identifies what ran (the image's baked-in entrypoint), so it
+	// carries the executed-command identity a rung-3 dispatch has (there is no
+	// separate command in the rung-3 model, issue #1762).
+	ToolImage string
 }
 
 // reachRecord captures one rung-3 dispatch's declared network reach for the
@@ -183,10 +193,28 @@ func (x *executor) execute(ctx context.Context, inputs ResolvedInputs) (execStat
 				// inputs are precisely what produced this artifact.
 				Binds:    step.binds(),
 				Resolved: resolved,
+				// Carry the pinned tool image ONLY when this step dispatched a
+				// rung-3 tool (issue #1762). Empty for every non-tool step; its
+				// presence flips the audit record's step.kind to "tool" and adds
+				// aileron.step.image. The rung-3 model carries no separate
+				// command, so the content-addressed pin is the executed-command
+				// identity.
+				ToolImage: toolImage(step),
 			})
 		}
 	}
 	return st, nil
+}
+
+// toolImage returns the step's pinned `ref@sha256:<hex>` tool image when the
+// step dispatched a rung-3 tool, or "" for any in-process (action-call or
+// transform) step. It is the tool-materialized discriminator the audit layer
+// reads to distinguish a tool-produced output from a connector/transform one.
+func toolImage(step Step) string {
+	if step.ToolDispatch == nil {
+		return ""
+	}
+	return step.ToolDispatch.Image
 }
 
 // runActionCall dispatches an action-call through the enforced boundary and

--- a/internal/flightplan/runtime/tooldispatch_test.go
+++ b/internal/flightplan/runtime/tooldispatch_test.go
@@ -540,6 +540,187 @@ func setExtractContract(p *Plan, tc *TrustContract) {
 	p.Steps[0].ToolDispatch.TrustContract = tc
 }
 
+// --- Unit 1 (#1762): tool provenance threaded onto materializedOutput ---
+
+// toolMaterializePlan builds a single-step rung-3 plan whose tool step (extract)
+// materializes a declared file-map output. The tool runner returns a file-map
+// carrier as the collected output, so the existing materialize path produces one
+// artifact. It is the fixture for proving a tool-materialized output carries the
+// pinned image (ToolImage) and the collected-output digest.
+func toolMaterializePlan() *Plan {
+	mb := func(s string) Binding { b, _ := ParseBinding(s); return b }
+	p := &Plan{
+		Name:    "rung3-plan",
+		Actions: map[string]Action{},
+		Outputs: map[string]Output{
+			"extract.txt": {Name: "extract.txt", MimeType: "text/plain", Encoding: EncodingUTF8, Target: PublishFile, Path: "extract.txt"},
+		},
+		Inputs: []Input{
+			{Name: "payload", Type: "string", Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: "hello"}},
+		},
+		Steps: []Step{
+			{
+				ID:                 "extract",
+				Kind:               KindTransform,
+				Bindings:           map[string]Binding{"payload": mb("inputs.payload")},
+				Outputs:            []string{"result"},
+				MaterializesOutput: "extract.txt",
+				ToolDispatch: &ToolDispatch{
+					Image:       "registry.example.com/tool-a:1@" + digestA,
+					MountPath:   "/work",
+					CollectPath: "/work/out",
+				},
+			},
+		},
+	}
+	order, err := topoSort(p, map[string]int{"extract": 0})
+	if err != nil {
+		panic(err)
+	}
+	p.Order = order
+	return p
+}
+
+// toolFileMap is the file-map carrier a tool image "collects": the shape the
+// materialize path expects for a utf-8 file output.
+func toolFileMap(content string) map[string]any {
+	return map[string]any{
+		"path": "extract.txt", "mimeType": "text/plain", "encoding": "utf-8", "content": content,
+	}
+}
+
+// TestExecute_ToolMaterializedOutputCarriesImage proves a rung-3 tool step that
+// materializes an output captures a materializedOutput whose ToolImage is the
+// pinned ref@digest and whose Artifact.Digest is the collected-output digest.
+// This is the discriminator the audit layer reads to emit kind="tool".
+func TestExecute_ToolMaterializedOutputCarriesImage(t *testing.T) {
+	p := toolMaterializePlan()
+	runner := &fakeToolRunner{outputs: map[string]any{"extract": toolFileMap("collected-bytes\n")}}
+	x := &executor{plan: p, enforcer: &enforcer{}, transform: NewTransformRegistry(), toolRunner: runner}
+
+	st, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{"payload": "hello"}})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(st.outputs) != 1 {
+		t.Fatalf("outputs = %d, want exactly 1 materialized output", len(st.outputs))
+	}
+	o := st.outputs[0]
+	if o.ToolImage != "registry.example.com/tool-a:1@"+digestA {
+		t.Errorf("ToolImage = %q, want the pinned ref@digest", o.ToolImage)
+	}
+	// The captured artifact digest is the digest of the collected output content.
+	wantDigest := contentDigest([]byte("collected-bytes\n"))
+	if o.Artifact.Digest != wantDigest {
+		t.Errorf("Artifact.Digest = %q, want the collected-output digest %q", o.Artifact.Digest, wantDigest)
+	}
+}
+
+// TestExecute_NonToolMaterializedOutputHasEmptyToolImage is the regression guard
+// that the tool marker is tool-only: a plain transform materializing step
+// captures a materializedOutput with ToolImage == "".
+func TestExecute_NonToolMaterializedOutputHasEmptyToolImage(t *testing.T) {
+	mb := func(s string) Binding { b, _ := ParseBinding(s); return b }
+	p := &Plan{
+		Name:    "transform-plan",
+		Actions: map[string]Action{},
+		Outputs: map[string]Output{
+			"out.txt": {Name: "out.txt", MimeType: "text/plain", Encoding: EncodingUTF8, Target: PublishFile, Path: "out.txt"},
+		},
+		Inputs: []Input{
+			{Name: "payload", Type: "string", Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: "hi"}},
+		},
+		Steps: []Step{
+			{
+				ID:                 "render",
+				Kind:               KindTransform,
+				Transform:          "mk",
+				Bindings:           map[string]Binding{"payload": mb("inputs.payload")},
+				Outputs:            []string{"file"},
+				MaterializesOutput: "out.txt",
+			},
+		},
+	}
+	order, err := topoSort(p, map[string]int{"render": 0})
+	if err != nil {
+		t.Fatalf("topoSort: %v", err)
+	}
+	p.Order = order
+
+	reg := NewTransformRegistry()
+	reg.Register("mk", func(_ map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{
+			"path": "out.txt", "mimeType": "text/plain", "encoding": "utf-8", "content": "plain\n",
+		}}, nil
+	})
+	x := &executor{plan: p, enforcer: &enforcer{}, transform: reg, toolRunner: nil}
+
+	st, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{"payload": "hi"}})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(st.outputs) != 1 {
+		t.Fatalf("outputs = %d, want 1", len(st.outputs))
+	}
+	if st.outputs[0].ToolImage != "" {
+		t.Errorf("ToolImage = %q, want empty for a non-tool step", st.outputs[0].ToolImage)
+	}
+}
+
+// --- Unit 3 (#1762): end-to-end emit through the recording sink ---
+
+// TestEmitAudit_ToolStepEmitsToolProvenance proves the full path emits exactly
+// one output.materialized record for a rung-3 tool step, carrying kind="tool",
+// the pinned image, the collected-output content_hash, and the input walk-back,
+// and NO aileron.step.calls anywhere. The assertion is on the emitted record
+// (the contract), not implementation internals.
+func TestEmitAudit_ToolStepEmitsToolProvenance(t *testing.T) {
+	p := toolMaterializePlan()
+	runner := &fakeToolRunner{outputs: map[string]any{"extract": toolFileMap("collected-bytes\n")}}
+	x := &executor{plan: p, enforcer: &enforcer{}, transform: NewTransformRegistry(), toolRunner: runner}
+
+	st, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{"payload": "hello"}})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	sink := &recordingSink{}
+	prov := launchProvenance{Skill: "rung3-plan", ContentHash: "sha256:plan", InvocationID: "inv-1"}
+	emitAudit(context.Background(), sink, st, prov)
+
+	var out *AuditRecord
+	for i := range sink.records {
+		if sink.records[i].Kind == RecordKindOutput {
+			if out != nil {
+				t.Fatal("more than one output.materialized record emitted")
+			}
+			out = &sink.records[i]
+		}
+	}
+	if out == nil {
+		t.Fatal("no output.materialized record emitted for the tool step")
+	}
+	f := out.Fields
+	if f["aileron.step.kind"] != "tool" {
+		t.Errorf("step.kind = %v, want tool", f["aileron.step.kind"])
+	}
+	if f["aileron.step.image"] != "registry.example.com/tool-a:1@"+digestA {
+		t.Errorf("step.image = %v, want the pinned ref@digest", f["aileron.step.image"])
+	}
+	if f["aileron.output.content_hash"] != contentDigest([]byte("collected-bytes\n")) {
+		t.Errorf("content_hash = %v, want the collected-output digest", f["aileron.output.content_hash"])
+	}
+	if _, present := f["aileron.step.inputs"]; !present {
+		t.Error("tool step record must carry aileron.step.inputs (the input walk-back)")
+	}
+	if _, present := f["aileron.step.calls"]; present {
+		t.Error("aileron.step.calls[] is out of scope (Half B) and must be absent")
+	}
+	if _, present := f["aileron.step.command"]; present {
+		t.Error("aileron.step.command is not synthesized; the pin is the command identity")
+	}
+}
+
 // --- Unit 2 (#1784): declared reach captured at rung-3 dispatch ---
 
 // TestExecute_ToolDispatchCapturesDeclaredReach proves a rung-3 step whose


### PR DESCRIPTION
## Summary

Rung-3 tool-step outputs now emit the **same** `output.materialized` audit record the connector path emits (#1752/#1753/#1754), sourced for the tool path from the pinned image digest plus the step's declared I/O, with `aileron.step.kind = "tool"` and `aileron.step.image = <ref@sha256:hex>`.

This is **Half A** of #1762. Half B (`aileron.step.calls[]` per-egress attribution) is out of scope and the field is omitted entirely, not stubbed.

### What changed

- **`materializedOutput` carries the tool marker** (`internal/flightplan/runtime/execute.go`). A new `ToolImage` field is populated from `step.ToolDispatch.Image` at materialize time, non-empty **only** for a rung-3 tool step. Its presence is the discriminator the audit layer reads.
- **`buildOutputRecord` emits tool provenance** (`internal/flightplan/runtime/audit.go`). When `ToolImage != ""`, the record sets the literal `aileron.step.kind = "tool"` (overriding the closed `StepKind` enum) and `aileron.step.image = <pin>`, and suppresses `aileron.step.transform`. Every other field (content_hash, step.inputs walk-back, plan/invocation identity, actor) is identical to the connector path — same `RecordKindOutput`, same sink, same store filter, same `--content-hash`/`--output` query surface. No parallel emit/query path.

### Key decisions (from the plan)

- **No new `StepKind` enum member.** `StepKind` stays a closed 3-member enum (its whole point is the structural no-LLM guarantee). Tool dispatch is orthogonal to `Kind`, so the tool marker is the pinned image on the materialized output, and `buildOutputRecord` emits the literal string `"tool"`.
- **`aileron.step.image` is the full `ref@sha256:<hex>` pin** (verbatim from the verified lock), which fully and verifiably identifies what ran (the image's baked-in entrypoint).
- **No OpenAPI / gen change.** `AuditRecord.Fields` is `map[string]any`; the event and filters are field-shaped, not schema-bound to producer kind.

### ⚠️ Reviewer flag — `aileron.step.command` is OMITTED, not synthesized

The readiness brief lists an `aileron.step.command` field. **That field does not exist anywhere in the rung-3 model** — not in the schema, the DTO (`rung3StepDTO`), `ToolDispatch`, or `ToolRunSpec`. A rung-3 tool image runs its baked-in entrypoint; the content-addressed pin **is** the executed-command identity. Synthesizing a `command` string would violate the omit-rather-than-guess discipline that governs `auditFieldValue`/`buildStepInputs`/`resolveActor` throughout `audit.go`. The acceptance walk-back (output-digest → tool image + inputs → signed plan) is fully satisfied by `image` + `inputs`.

If review insists on a command field, the correct fix is a **separate issue** that adds a command/args to the rung-3 schema, DTO, and runner — that is net-new surface, not this issue's "assemble provenance from what dispatch already knows" scope. This PR does not touch the schema.

## Test plan

New tests, all asserting on the emitted record / filtered event (the contract), never implementation internals:

- **Unit 1** (`tooldispatch_test.go`): a tool step that materializes an output captures `ToolImage == <pin>` with `Artifact.Digest` == the collected-output digest; a plain transform materializing step captures `ToolImage == ""` (regression guard).
- **Unit 2** (`audit_test.go`): `buildOutputRecord` for a tool output emits `kind="tool"`, `step.image`, `content_hash`, the input walk-back, plan/invocation identity, and NO `step.transform` / `step.calls` / `step.command`; a non-tool output (transform + action-call) omits `step.image` and keeps its own kind.
- **Unit 3** (`tooldispatch_test.go`): end-to-end through the recording sink — exactly one `output.materialized` record with the tool provenance; no `step.calls`.
- **Unit 4** (`internal/audit/mem_events_test.go` + `cmd/aileron/main_test.go`): the producer-agnostic store finds a tool-step-shaped event by `--content-hash` and `--output` (negative case for a different hash); `audit show` renders `aileron.step.kind: tool` and the pinned `aileron.step.image`.

Verification:

```
go test ./internal/flightplan/runtime/ ./internal/audit/ ./cmd/aileron/   # all green
go test -cover ./internal/flightplan/runtime/                              # 90.9%; buildOutputRecord + toolImage 100%
```

Pre-PR review: ran the local `coderabbit` CLI. Two minor findings (a CLI assertion that could match the AuditID substring; an ignored `topoSort` error in a test) fixed before publishing; the re-review confirming clean was rate-limited, but both fixes are mechanical and verified green.

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit output now shows provenance details for tool-based steps, including the step kind and pinned tool image.
  * Tool-generated outputs are now surfaced consistently in audit views and command output.

* **Bug Fixes**
  * Fixed audit records so tool materializations include the correct output hash and tool provenance.
  * Improved filtering so tool-step outputs can be found using existing audit search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->