### PR TITLE
feat(flightplan): reach host daemon audit trail from image-boot launch

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -28,7 +28,14 @@ var newLaunchAuditSink = func(stderr io.Writer) runtime.AuditSink { return daemo
 // verified pinned rung-1/rung-2 image and runs the plan inside it (#1731). It
 // is a package-level seam so CLI tests swap in a fake that records the exact
 // image string and never touches Docker, mirroring the other launch seams.
-var newLaunchImageRunner = func() runtime.ImageRunner { return containerImageRunner{} }
+// The production runner injects the daemon-backed env resolver so the
+// re-entered in-container launch reaches the SAME host daemon action + audit
+// boundary and its records surface in the host `aileron audit list` (#1759).
+// The resolver stays passthrough (injects no env) when no daemon config is
+// resolvable, gating on config presence, so a no-daemon launch still boots.
+var newLaunchImageRunner = func() runtime.ImageRunner {
+	return containerImageRunner{daemonEnv: daemonImageEnv{}}
+}
 
 // newLaunchToolImageRunner returns the production tool-image runner that
 // dispatches a rung-3 step to its pinned sibling tool image with mount → run →

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -31,7 +31,22 @@ import (
 // out-dir writable, then re-enters the aileron binary against the bind-mounted
 // unit so the in-container run reaches the same daemon action boundary over the
 // existing network wiring.
-type containerImageRunner struct{}
+//
+// Daemon-audit reachability (#1759): when daemonEnv is non-nil it injects the
+// host daemon coordinates (AILERON_API_URL + AILERON_TOKEN) into the booted
+// container's env so the re-entered `aileron skill launch` reaches the SAME host
+// daemon action + audit boundary — a record emitted inside the image then
+// surfaces in the host `aileron audit list`. Without it the inner binary sees no
+// daemon env and resolves/spawns an ephemeral in-container daemon nothing on the
+// host can query. A zero-value runner has daemonEnv == nil and injects no env,
+// keeping the CLI unit tests deterministic irrespective of any live ~/.aileron
+// daemon; production wires the daemon-backed resolver via newLaunchImageRunner.
+type containerImageRunner struct {
+	// daemonEnv, when non-nil, resolves the daemon env injected into the boot so
+	// the in-container launch reaches the host daemon. nil (the zero value) is
+	// passthrough (no injected env).
+	daemonEnv imageDaemonEnv
+}
 
 // containerRunFlightPlan boots the pinned image and runs the plan inside it. It
 // is a package variable purely for symmetry with sandboxRunContainer; the
@@ -46,7 +61,7 @@ var containerRunFlightPlan = func(ctx context.Context, runtimeName string, stdou
 	}.Run(ctx, opts)
 }
 
-func (containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
+func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
 	if spec.Image == "" {
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: image runner requires a pinned image")
 	}
@@ -98,6 +113,28 @@ func (containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) 
 		Command: command,
 		Name:    flightPlanContainerName(spec),
 	}
+
+	// Daemon-audit reachability (#1759): inject the host daemon coordinates so the
+	// re-entered in-container launch posts its actions + audit records to the SAME
+	// host daemon rather than an ephemeral in-container one. The resolver is
+	// spawn-free and gates on config presence: when no daemon URL/token resolves
+	// it returns ok=false and the boot carries no injected env, keeping a
+	// no-daemon launch working. --add-host host.docker.internal:host-gateway is
+	// inherited unconditionally from the shared Builder.Run path on docker+linux
+	// (runtime.go runArgs), so the rewritten host is reachable without any new
+	// emission here.
+	if r.daemonEnv != nil {
+		if env, ok := r.daemonEnv.Env(runtimeName); ok {
+			if opts.Env == nil {
+				opts.Env = env
+			} else {
+				for k, v := range env {
+					opts.Env[k] = v
+				}
+			}
+		}
+	}
+
 	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, os.Stderr, opts); err != nil {
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: run pinned image %q: %w", spec.Image, err)
 	}

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -93,6 +93,127 @@ func TestContainerImageRunner_BootsExactImageWithMounts(t *testing.T) {
 	}
 }
 
+// fakeImageDaemonEnv is a canned imageDaemonEnv for the runner tests: it returns
+// the recorded env map and ok flag so the runner's RunOptions.Env wiring is
+// asserted with no live daemon and no Docker.
+type fakeImageDaemonEnv struct {
+	env        map[string]string
+	ok         bool
+	gotRuntime string
+	callCount  int
+}
+
+func (f *fakeImageDaemonEnv) Env(runtimeName string) (map[string]string, bool) {
+	f.callCount++
+	f.gotRuntime = runtimeName
+	return f.env, f.ok
+}
+
+// TestContainerImageRunner_InjectsDaemonEnv proves that when a daemon-env
+// resolver is wired and resolves, the booted container carries the host daemon
+// coordinates so the re-entered in-container launch reaches the host daemon
+// action + audit boundary (#1759).
+func TestContainerImageRunner_InjectsDaemonEnv(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	fake := &fakeImageDaemonEnv{
+		env: map[string]string{
+			"AILERON_API_URL": "http://host.docker.internal:48123/v1",
+			"AILERON_TOKEN":   "daemon-token",
+		},
+		ok: true,
+	}
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+	}
+	if _, err := (containerImageRunner{daemonEnv: fake}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fake.callCount != 1 {
+		t.Fatalf("resolver called %d times, want 1", fake.callCount)
+	}
+	// The resolver is passed the resolved runtime name so it can host-rewrite the
+	// daemon URL for that runtime.
+	if fake.gotRuntime == "" {
+		t.Error("resolver must be passed the resolved runtime name")
+	}
+	if got.Env["AILERON_API_URL"] != "http://host.docker.internal:48123/v1" {
+		t.Errorf("AILERON_API_URL = %q, want the host-rewritten /v1 daemon URL", got.Env["AILERON_API_URL"])
+	}
+	if got.Env["AILERON_TOKEN"] != "daemon-token" {
+		t.Errorf("AILERON_TOKEN = %q, want the daemon token", got.Env["AILERON_TOKEN"])
+	}
+}
+
+// TestContainerImageRunner_PassthroughWhenNoDaemonConfig proves that when the
+// resolver reports ok=false (no daemon config), the boot carries no injected env
+// so a no-daemon launch is unaffected (#1759).
+func TestContainerImageRunner_PassthroughWhenNoDaemonConfig(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	fake := &fakeImageDaemonEnv{ok: false}
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+	}
+	if _, err := (containerImageRunner{daemonEnv: fake}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(got.Env) != 0 {
+		t.Errorf("RunOptions.Env = %v, want no injected env on the passthrough (ok=false) boot", got.Env)
+	}
+}
+
+// TestContainerImageRunner_ZeroValueInjectsNoEnv proves the zero-value runner
+// (daemonEnv == nil) injects no env, so the CLI unit tests stay deterministic
+// irrespective of any live ~/.aileron daemon (#1759).
+func TestContainerImageRunner_ZeroValueInjectsNoEnv(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+	}
+	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(got.Env) != 0 {
+		t.Errorf("RunOptions.Env = %v, want no injected env on the zero-value runner", got.Env)
+	}
+}
+
+// TestNewLaunchImageRunner_WiresDaemonEnvResolver proves the production seam
+// wires the daemon-backed env resolver so production boots carry the host daemon
+// coordinates (#1759), mirroring newLaunchToolImageRunner's proxy wiring.
+func TestNewLaunchImageRunner_WiresDaemonEnvResolver(t *testing.T) {
+	runner, ok := newLaunchImageRunner().(containerImageRunner)
+	if !ok {
+		t.Fatalf("newLaunchImageRunner returned %T, want containerImageRunner", newLaunchImageRunner())
+	}
+	if _, ok := runner.daemonEnv.(daemonImageEnv); !ok {
+		t.Errorf("daemonEnv = %T, want daemonImageEnv (the production resolver)", runner.daemonEnv)
+	}
+}
+
 // stubContainerToolBoot swaps the single real-Docker call site for the tool
 // image runner with a recorder that also simulates the tool writing its output
 // to the collect mount, so the runner's spec-construction and collect-readback

--- a/cmd/aileron/skill_launch_image_audit_integration_test.go
+++ b/cmd/aileron/skill_launch_image_audit_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration_sandbox
+
+// Real-container end-to-end coverage for the Flight Plan image-boot audit-trail
+// reachability contract (#1759).
+//
+// This test proves the load-bearing #1759 contract: a record emitted by the
+// re-entered `aileron skill launch` INSIDE the booted rung-1/rung-2 image
+// surfaces on the HOST daemon's audit trail. The image-boot path injects the
+// host daemon coordinates (AILERON_API_URL + AILERON_TOKEN, host-rewritten to
+// host.docker.internal, /v1-suffixed) into the container so the inner launch
+// posts its actions + audit records to the SAME host daemon rather than an
+// ephemeral in-container one nothing on the host can query.
+//
+// Unlike the CLI unit tests (which assert the RunOptions.Env the runner
+// constructs with a fake resolver and no Docker), this test drives a real
+// container boot through containerImageRunner.Run against a LIVE host daemon,
+// then queries that daemon's GET /v1/audit to assert the launch record landed
+// on the host store.
+//
+// FORBIDDEN (the #1757 mirror-test failure mode): this test must NOT re-drive
+// the host-side audit sink as a proxy for container delivery. It observes the
+// host daemon's store directly, so a boot that failed to reach the host daemon
+// FAILS rather than passing on a locally-driven sink.
+//
+// The wiring is env-driven so one body serves the CI job and a local run:
+//
+//	AILERON_SANDBOX_FLIGHTPLAN_IMAGE  pinned rung-1/rung-2 image ref to boot
+//	AILERON_API_URL                   live host daemon API base (with /v1)
+//	AILERON_TOKEN                     host daemon auth token
+//	AILERON_SANDBOX_FLIGHTPLAN_UNIT   frozen unit name to launch inside the image
+//	AILERON_SANDBOX_FLIGHTPLAN_STORE  host store dir holding the frozen unit
+//
+// Per repo policy (no skip-when-unsupported) this test is FAIL-FAST: absence of
+// Docker, the env, or a reachable daemon is a job-configuration FAILURE, not a
+// t.Skip. CI's integration_sandbox job provisions the toolchain, boots a host
+// daemon, freezes a unit into the store, and sets the env.
+//
+// Run with:
+//
+//	go test -tags=integration_sandbox -run TestFlightPlanImageAuditReachesHost ./cmd/aileron/...
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+)
+
+// TestFlightPlanImageAuditReachesHost boots a real pinned Flight Plan image and
+// asserts a record emitted by the in-container launch surfaces on the HOST
+// daemon's audit trail (#1759).
+func TestFlightPlanImageAuditReachesHost(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		// Fail-fast, not skip: repo policy forbids skip-when-unsupported. The CI
+		// job documents `docker` as a prerequisite.
+		t.Fatalf("docker not on PATH; install Docker to run this integration test: %v", err)
+	}
+
+	image := strings.TrimSpace(os.Getenv("AILERON_SANDBOX_FLIGHTPLAN_IMAGE"))
+	if image == "" {
+		t.Fatalf("AILERON_SANDBOX_FLIGHTPLAN_IMAGE must name the pinned rung-1/rung-2 image to boot (required, not skipped)")
+	}
+	apiURL := strings.TrimSpace(os.Getenv("AILERON_API_URL"))
+	token := strings.TrimSpace(os.Getenv("AILERON_TOKEN"))
+	if apiURL == "" || token == "" {
+		t.Fatalf("AILERON_API_URL and AILERON_TOKEN must point at a live host daemon (required, not skipped)")
+	}
+	unit := strings.TrimSpace(os.Getenv("AILERON_SANDBOX_FLIGHTPLAN_UNIT"))
+	if unit == "" {
+		t.Fatalf("AILERON_SANDBOX_FLIGHTPLAN_UNIT must name the frozen unit to launch (required, not skipped)")
+	}
+	storeDir := strings.TrimSpace(os.Getenv("AILERON_SANDBOX_FLIGHTPLAN_STORE"))
+	if storeDir == "" {
+		t.Fatalf("AILERON_SANDBOX_FLIGHTPLAN_STORE must point at the host store holding the frozen unit (required, not skipped)")
+	}
+
+	// Point the process store seam at the host store the CI job froze the unit
+	// into, so the boot mounts the exact verified bytes.
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	// Snapshot the host audit trail before the boot so the post-boot assertion
+	// keys on the NEW record rather than any pre-existing one.
+	before := hostAuditCount(t, apiURL, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// Boot the real image through the production runner, which injects the host
+	// daemon coordinates. daemonImageEnv resolves them from AILERON_API_URL /
+	// AILERON_TOKEN set above (spawn-free), host-rewrites the loopback host to
+	// host.docker.internal, and re-appends /v1.
+	if _, err := (containerImageRunner{daemonEnv: daemonImageEnv{}}).Run(ctx, runtime.ImageRunSpec{
+		Image: image,
+		Name:  unit,
+	}); err != nil {
+		t.Fatalf("image boot failed: %v", err)
+	}
+
+	// The in-container launch posts over HTTP to the host daemon; poll the host
+	// audit trail until the new record lands or the deadline passes. Observing
+	// the HOST store directly is the whole point: a boot that reached only an
+	// ephemeral in-container daemon leaves this count unchanged and FAILS.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if hostAuditCount(t, apiURL, token) > before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no new host audit record after image boot: the in-container launch did not reach the host daemon (before=%d)", before)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// hostAuditCount queries the live host daemon's GET /v1/audit and returns the
+// number of records it reports, so the test can assert a NEW record landed on
+// the host store after the image boot.
+func hostAuditCount(t *testing.T, apiURL, token string) int {
+	t.Helper()
+	// Bound the request so a stalled daemon can't hang the fail-fast poll loop:
+	// a hung GET would otherwise block the test until the whole go-test timeout
+	// rather than failing the reachability assertion promptly.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(apiURL, "/")+"/audit", nil)
+	if err != nil {
+		t.Fatalf("build audit list request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("query host audit trail: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("host daemon returned %d for GET /audit: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	// The audit list response wraps the records under an "events" (or "records")
+	// array; count whichever is present so the assertion is robust to the exact
+	// key. A decode failure is a job-config/daemon-shape failure, not a skip.
+	var envelope struct {
+		Events  []json.RawMessage `json:"events"`
+		Records []json.RawMessage `json:"records"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode host audit list %q: %v", string(raw), err)
+	}
+	if len(envelope.Events) > 0 {
+		return len(envelope.Events)
+	}
+	return len(envelope.Records)
+}

--- a/cmd/aileron/skill_launch_proxy.go
+++ b/cmd/aileron/skill_launch_proxy.go
@@ -124,6 +124,69 @@ func (daemonToolProxyBootstrapper) Prepare(runtimeName, stepID string) (toolProx
 	return toolProxyBootstrap{Env: env, Mount: prepared.CAMount}, cleanup, true, nil
 }
 
+// imageDaemonEnv is the seam the Flight Plan image-boot path (#1759) uses to
+// inject the host daemon coordinates into the booted container's environment so
+// the re-entered `aileron skill launch` inside the image reaches the SAME host
+// daemon action + audit boundary rather than resolving/spawning an ephemeral
+// in-container daemon nothing on the host can query. It is injected onto
+// containerImageRunner rather than read from ambient config: a zero-value runner
+// has daemonEnv == nil and stays passthrough (no injected env), which keeps the
+// CLI unit tests deterministic irrespective of any live ~/.aileron daemon.
+// Production wires the daemon-backed resolver via newLaunchImageRunner.
+type imageDaemonEnv interface {
+	// Env resolves the daemon env map (AILERON_API_URL + AILERON_TOKEN) for a
+	// container boot on the named runtime, WITHOUT spawning a daemon. ok=false
+	// means daemon config is absent (URL or token unresolvable) and the boot must
+	// carry no injected env rather than break a no-daemon launch.
+	Env(runtimeName string) (map[string]string, bool)
+}
+
+// daemonImageEnv is the production imageDaemonEnv. It resolves the daemon base
+// URL + auth token from AILERON_API_URL / AILERON_TOKEN or ~/.aileron discovery
+// WITHOUT triggering a daemon spawn (it reads env/discovery only), so a launch
+// with no running daemon stays passthrough rather than forcing a daemon boot.
+//
+// Activation gates on daemon-config PRESENCE (token + base URL), not on daemon
+// LIVENESS: a stale ~/.aileron discovery entry (token present) with no daemon
+// actually listening still injects env, and the inner launch's audit POST fails
+// with connection-refused — a regression versus the ephemeral in-container
+// daemon. Config-presence gating is accepted; liveness-probing / fail-open is
+// deferred to a follow-up, mirroring daemonToolProxyBootstrapper.
+type daemonImageEnv struct{}
+
+func (daemonImageEnv) Env(runtimeName string) (map[string]string, bool) {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return nil, false
+	}
+	root, ok := resolveDaemonRootURL(stateDir)
+	if !ok {
+		return nil, false
+	}
+	token, ok := resolveDaemonProxyToken(stateDir)
+	if !ok {
+		return nil, false
+	}
+	return map[string]string{
+		"AILERON_API_URL": daemonImageAPIURL(root, runtimeName),
+		"AILERON_TOKEN":   token,
+	}, true
+}
+
+// daemonImageAPIURL builds the AILERON_API_URL injected into the booted
+// container: the daemon root (no /v1) is loopback-rewritten to
+// host.docker.internal so the in-container process reaches the host-bound
+// daemon, then the /v1 API prefix is appended. The inner launch's
+// bindingAPIBaseURL uses this value directly as `base + "/actions/..."` and
+// `base + "/audit"`, so the injected value MUST carry the /v1 suffix (the host
+// rewrite is applied to the host portion only and preserves the path). This is
+// the container-facing analogue of internal/launch's daemonAPIBaseURL over
+// ContainerURLForRuntime.
+func daemonImageAPIURL(root, runtimeName string) string {
+	rewritten := launch.ContainerURLForRuntime(root, runtimeName)
+	return strings.TrimRight(rewritten, "/") + "/v1"
+}
+
 // resolveDaemonRootURL resolves the daemon root URL (WITHOUT the /v1 suffix)
 // from AILERON_API_URL or discovery, without spawning a daemon. It returns
 // ok=false when neither source yields a URL.

--- a/cmd/aileron/skill_launch_proxy_test.go
+++ b/cmd/aileron/skill_launch_proxy_test.go
@@ -199,3 +199,92 @@ func TestSanitizeSessionSegment(t *testing.T) {
 		}
 	}
 }
+
+func TestDaemonImageEnv_RewritesHostAndAppendsV1FromEnv(t *testing.T) {
+	withHomeAndEnv(t)
+	// A loopback AILERON_API_URL carrying the /v1 API prefix, no daemon spawn.
+	t.Setenv("AILERON_API_URL", "http://127.0.0.1:48123/v1")
+	t.Setenv("AILERON_TOKEN", "env-token")
+
+	env, ok := daemonImageEnv{}.Env("docker")
+	if !ok {
+		t.Fatal("Env must resolve when URL + token are set")
+	}
+	// The injected URL is host.docker.internal-rewritten and carries the /v1
+	// suffix the inner bindingAPIBaseURL uses directly as base + "/audit".
+	if got := env["AILERON_API_URL"]; got != "http://host.docker.internal:48123/v1" {
+		t.Errorf("AILERON_API_URL = %q, want host.docker.internal-rewritten /v1 URL", got)
+	}
+	if got := env["AILERON_TOKEN"]; got != "env-token" {
+		t.Errorf("AILERON_TOKEN = %q, want the resolved daemon token", got)
+	}
+}
+
+func TestDaemonImageEnv_ResolvesFromDiscovery(t *testing.T) {
+	stateDir := withHomeAndEnv(t)
+	// Discovery carries a loopback root URL (no /v1) + token; no daemon spawn.
+	writeDiscovery(t, stateDir, "http://localhost:55555", "discovery-token")
+
+	env, ok := daemonImageEnv{}.Env("docker")
+	if !ok {
+		t.Fatal("Env must resolve from discovery when env is unset")
+	}
+	if got := env["AILERON_API_URL"]; got != "http://host.docker.internal:55555/v1" {
+		t.Errorf("AILERON_API_URL = %q, want host.docker.internal-rewritten /v1 URL", got)
+	}
+	if got := env["AILERON_TOKEN"]; got != "discovery-token" {
+		t.Errorf("AILERON_TOKEN = %q, want the discovery token", got)
+	}
+}
+
+func TestDaemonImageEnv_NonLoopbackHostUnchanged(t *testing.T) {
+	withHomeAndEnv(t)
+	// A non-loopback host must not be rewritten, but must still carry /v1.
+	t.Setenv("AILERON_API_URL", "https://daemon.internal.example:8721")
+	t.Setenv("AILERON_TOKEN", "t")
+
+	env, ok := daemonImageEnv{}.Env("docker")
+	if !ok {
+		t.Fatal("Env must resolve for a non-loopback host")
+	}
+	if got := env["AILERON_API_URL"]; got != "https://daemon.internal.example:8721/v1" {
+		t.Errorf("AILERON_API_URL = %q, want the non-loopback host unchanged with /v1", got)
+	}
+}
+
+func TestDaemonImageEnv_NoURLPassthrough(t *testing.T) {
+	withHomeAndEnv(t)
+	// Neither env nor discovery yields a URL: passthrough (no injected env).
+	t.Setenv("AILERON_TOKEN", "t")
+
+	if env, ok := (daemonImageEnv{}).Env("docker"); ok || env != nil {
+		t.Errorf("Env = (%v, %v), want (nil, false) when no URL resolves", env, ok)
+	}
+}
+
+func TestDaemonImageEnv_NoTokenPassthrough(t *testing.T) {
+	withHomeAndEnv(t)
+	// A URL but no token: the daemon action/audit POST would be unauthenticated,
+	// so the resolver stays passthrough.
+	t.Setenv("AILERON_API_URL", "http://127.0.0.1:48123/v1")
+
+	if env, ok := (daemonImageEnv{}).Env("docker"); ok || env != nil {
+		t.Errorf("Env = (%v, %v), want (nil, false) when no token resolves", env, ok)
+	}
+}
+
+func TestDaemonImageAPIURL(t *testing.T) {
+	cases := map[string]string{
+		// loopback roots (no /v1) are rewritten and get /v1 appended
+		"http://127.0.0.1:48123":  "http://host.docker.internal:48123/v1",
+		"http://localhost:48123":  "http://host.docker.internal:48123/v1",
+		"http://127.0.0.1:48123/": "http://host.docker.internal:48123/v1",
+		// non-loopback host is left as-is, /v1 appended
+		"https://daemon.example:8721": "https://daemon.example:8721/v1",
+	}
+	for in, want := range cases {
+		if got := daemonImageAPIURL(in, "docker"); got != want {
+			t.Errorf("daemonImageAPIURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The Flight Plan **image-boot** path re-enters `aileron skill launch` inside a container but injected **no daemon env**. `containerImageRunner.Run` built its `RunOptions` with no `Env`, so the inner binary's `bindingAPIBaseURL` / `daemonAuthToken` saw no `AILERON_API_URL` / `AILERON_TOKEN` and fell through to resolving/spawning an **ephemeral in-container daemon** nothing on the host could query. A record emitted via the image boot never appeared in the host `aileron audit list`.

This threads the host daemon coordinates into the booted container so the inner launch posts its actions + audit records to the **same host daemon**, mirroring the agent-sandbox injection in `internal/launch/launcher.go` and — structurally — the way #1769 threaded a proxy bootstrapper into the tool runner.

### What changed

- **Resolver seam on `containerImageRunner`** (`skill_launch_container.go`): new injectable `imageDaemonEnv` field wired into `RunOptions.Env`, mirroring `containerToolImageRunner{proxy: ...}`. A zero-value runner has `daemonEnv == nil` and injects no env (passthrough), keeping CLI unit tests deterministic irrespective of any live `~/.aileron` daemon.
- **Production `daemonImageEnv`** (`skill_launch_proxy.go`): resolves URL + token from `AILERON_API_URL` / `AILERON_TOKEN` or `~/.aileron` discovery **without spawning a daemon**, reusing the existing `resolveDaemonRootURL` / `resolveDaemonProxyToken`. Builds `AILERON_API_URL` = daemon root loopback-rewritten to `host.docker.internal` via `launch.ContainerURLForRuntime`, then `/v1` appended (the inner `bindingAPIBaseURL` uses the value directly as `base + "/audit"`, so it must carry `/v1`). Gates on config presence: no daemon URL/token -> no injected env, so a no-daemon boot still works.
- **Production wiring** (`skill_launch.go`): `newLaunchImageRunner` returns `containerImageRunner{daemonEnv: daemonImageEnv{}}`.
- **`--add-host host.docker.internal:host-gateway` is inherited** unchanged from the shared `Builder.Run` path on docker+linux (`runtime.go` `runArgs`); no new emission.
- **Build-tagged e2e skeleton** (`skill_launch_image_audit_integration_test.go`, `//go:build integration_sandbox`): fail-fast, asserts a record from the image boot surfaces on the **host** audit store, observed via the host daemon's `GET /v1/audit` — never a re-driven sink (the #1757 mirror-test failure mode).

### Scope

No SPI (`ImageRunSpec`), OpenAPI, or generated-file change. The daemon stays the single audit writer; the inner launch posts to the existing `POST /v1/audit`. Versions stay 0.0.x.

**Accepted gap (consistent with #1769):** activation gates on daemon-config *presence*, not liveness. A stale discovery entry with no live daemon still injects env, and the mixed-source pairing (env URL + discovery token) mirrors the existing `daemonToolProxyBootstrapper` resolver behavior. Liveness-probing / single-source atomicity is deferred, matching the established rung-3 path.

## Test plan

- `go test ./cmd/aileron/` — new resolver + runner wiring; all pass.
  - `containerImageRunner` injects the host-rewritten `/v1` URL + token when the resolver resolves; passthrough (no env) when `ok=false`; zero-value runner injects nothing.
  - `daemonImageEnv.Env` from env and from discovery; non-loopback host unchanged; no-URL and no-token both passthrough; `daemonImageAPIURL` host-rewrite + `/v1` cases.
  - `newLaunchImageRunner` wires the production resolver.
- `go test ./internal/flightplan/... ./internal/launch/...` — green, no regressions.
- Coverage on new lines: `daemonImageAPIURL` 100%, `daemonImageEnv.Env` 90% (only the unreachable `defaultStateDir` error path uncovered), runner env branch exercised — >80%.
- `integration_sandbox` e2e is a fail-fast skeleton gated behind the tag; it does not block the mergeable core (Units 1-3) and runs in CI's `integration_sandbox` job where Docker + a host daemon are provisioned.
- Pre-PR: `coderabbit` CLI review run; the one in-scope finding (unbounded HTTP poll in the new integration test) was fixed with a request/client timeout.

Closes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)
