### PR TITLE
docs(flightplan): note full-daemon-token injection is deliberate on image-boot path

### DIFF
--- a/cmd/aileron/skill_launch_proxy.go
+++ b/cmd/aileron/skill_launch_proxy.go
@@ -206,6 +206,16 @@ func resolveDaemonRootURL(stateDir string) (string, bool) {
 // yields a token: the CONNECT handshake authenticates password=daemonToken, so
 // a missing token means the proxy would 407 and the dispatch must stay
 // passthrough.
+//
+// The token resolved here is the FULL daemon token, and daemonImageEnv.Env
+// injects it verbatim as AILERON_TOKEN into the booted container. This differs
+// from the agent-sandbox path (internal/launch/launcher.go:720-726), which
+// injects a session-scoped caveat token carrying only the capabilities the
+// session uses. Injecting the full token on the Flight Plan image-boot path is
+// a deliberate, readiness-brief-sanctioned choice: this path has no
+// session-caveat minting step, so no narrowed token exists to hand the
+// container. Future hardening could mint a session-scoped caveat token for the
+// image boot and inject that here instead.
 func resolveDaemonProxyToken(stateDir string) (string, bool) {
 	if t := strings.TrimSpace(os.Getenv("AILERON_TOKEN")); t != "" {
 		return t, true


### PR DESCRIPTION
## Summary

Adds a doc comment to `resolveDaemonProxyToken` in `cmd/aileron/skill_launch_proxy.go` recording a deliberate design choice surfaced by the plan review for #1759.

`resolveDaemonProxyToken` resolves the **full** daemon token, and `daemonImageEnv.Env` injects it verbatim as `AILERON_TOKEN` into the booted Flight Plan container. This differs from the agent-sandbox path (`internal/launch/launcher.go:720-726`), which injects a **session-scoped caveat** token carrying only the capabilities the session uses. The existing doc comments already cover config-presence-vs-liveness gating and the connection-refused regression, but none recorded that the full-token injection is intentional rather than an oversight.

The new comment states that injecting the full token on the image-boot path is a deliberate, readiness-brief-sanctioned choice — this path has no session-caveat minting step, so no narrowed token exists to hand the container — and notes that future hardening could mint and inject a session-scoped token instead.

This is a purely additive doc-comment change. No behavior change.

## Test plan

- `go build ./cmd/aileron/...` — passes
- `go vet ./cmd/aileron/` — passes
- `gofmt -l cmd/aileron/skill_launch_proxy.go` — clean
- `go test ./cmd/aileron/ -run 'DaemonProxyToken|DaemonImageEnv|LaunchProxy|ResolveDaemon'` — passes

No new tests: doc-comment-only change with no behavior to assert on.

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
