### PR TITLE
fix(cli): stand the vault state machine down when AILERON_API_URL provides the daemon

### DIFF
--- a/cmd/aileron/vault_state.go
+++ b/cmd/aileron/vault_state.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -37,6 +38,24 @@ import (
 // because flag parsing belongs to the dispatched command. The env var
 // path remains active either way.
 func ensureVaultUnlocked(passphraseFile string, stderr io.Writer) error {
+	// An externally provided daemon stands the state machine down. The
+	// four states below manage the lifecycle of the LOCAL ~/.aileron
+	// daemon — spawn, vault init, unlock — but AILERON_API_URL means some
+	// other owner manages that daemon and its vault. The load-bearing
+	// case is the image-boot launch path (#1731): the host CLI runs this
+	// state machine itself and THEN injects AILERON_API_URL/AILERON_TOKEN
+	// into the booted container (#1759), so by the time the in-container
+	// re-entry starts, the host daemon's vault is already unlocked. The
+	// container has no ~/.aileron discovery, so without this gate the
+	// re-entry misclassifies as first-run and dies prompting for a new
+	// vault passphrase on a TTY the container doesn't have. If the
+	// env-provided daemon's vault IS locked, the dispatched command
+	// surfaces the daemon's vault-locked error — the correct shape for
+	// "the daemon's owner hasn't unlocked it."
+	if strings.TrimSpace(os.Getenv("AILERON_API_URL")) != "" {
+		return nil
+	}
+
 	stateDir, err := defaultStateDir()
 	if err != nil {
 		return err

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -131,6 +131,36 @@ func TestBypassesVault(t *testing.T) {
 // --- ensureVaultUnlocked: state machine ---
 
 // State 1: daemon running, vault unlocked → no-op.
+// Externally provided daemon: AILERON_API_URL set → the whole state
+// machine stands down. This is the image-boot re-entry contract (#1731 /
+// #1759): the host runs the state machine, then injects the daemon
+// coordinates into the container; the in-container CLI has no ~/.aileron
+// discovery and must not classify that as first-run (it would prompt for
+// a NEW vault passphrase on a TTY the container doesn't have).
+func TestEnsureVaultUnlocked_EnvProvidedDaemon_StandsDown(t *testing.T) {
+	scopeHomeAndAPIURL(t)
+	t.Setenv("AILERON_API_URL", "http://host.docker.internal:51434/v1")
+
+	withVaultStateSeams(t, vaultStateFakes{
+		discoveryRead: func(string) (discovery.Info, error) {
+			t.Error("discovery should not be read when AILERON_API_URL is set")
+			return discovery.Info{}, errors.New("unreachable")
+		},
+		postUnlock: func(string, string) error {
+			t.Error("postVaultUnlock should not be called when AILERON_API_URL is set")
+			return nil
+		},
+	})
+
+	var stderr bytes.Buffer
+	if err := ensureVaultUnlocked("", &stderr); err != nil {
+		t.Fatalf("ensureVaultUnlocked: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
 func TestEnsureVaultUnlocked_RunningUnlocked_NoOp(t *testing.T) {
 	scopeHomeAndAPIURL(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- The image-boot launch path (#1731) re-enters the aileron CLI inside the pinned container with `AILERON_API_URL`/`AILERON_TOKEN` injected (#1759) so the inner run reaches the host daemon — but `ensureVaultUnlocked` only consulted `~/.aileron` discovery. The container has none, so the inner re-entry misclassified as first-run and died prompting for a **new** vault passphrase on a TTY the container doesn't have, failing every image-boot launch.
- Fix: when `AILERON_API_URL` is set, the vault state machine stands down entirely. An env-provided daemon means some other owner manages that daemon and its vault; the host CLI already ran the state machine before booting the image. If that daemon's vault is actually locked, the dispatched command surfaces the daemon's vault-locked error, which is the correct shape.
- This mirrors the precedence the injection side already has: `resolveDaemonRootURL` prefers `AILERON_API_URL` over discovery.

Found by running a sealed Flight Plan end-to-end on the image-boot path (first real workload through #1730).

## Test plan
- [x] New regression test `TestEnsureVaultUnlocked_EnvProvidedDaemon_StandsDown`: env set → no discovery read, no unlock POST, no stderr output. Fails before the fix (fake discovery `t.Error` fires), passes after.
- [x] Full `go test ./cmd/aileron/` green.
- [x] Verified live: an image-boot launch on this binary proceeds past the vault gate (see verification comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sUjkxyPusyc7FivV3rQpL