### PR TITLE
fix(flightplan): keep the image-boot re-entry in-process instead of re-booting the pin

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
@@ -127,6 +128,11 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		// plan inside it. When the frozen unit pins no image, the runtime never
 		// touches this seam and stays on the in-process path.
 		ImageRunner: newLaunchImageRunner(),
+		// InPinnedImage: the image-boot re-entry runs with the sentinel its
+		// booting runner injected; it is already inside the certified
+		// environment and must run the plan in-process, not boot the pin
+		// again.
+		InPinnedImage: os.Getenv(envSkillImageBooted) != "",
 		// ToolImageRunner dispatches each rung-3 step to its pinned sibling tool
 		// image with mount → run → collect I/O. The plan orchestration stays
 		// in-process; only the per-step tool dispatch shells out.

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -48,6 +48,13 @@ type containerImageRunner struct {
 	daemonEnv imageDaemonEnv
 }
 
+// envSkillImageBooted marks the image-boot re-entry (#1731). The image runner
+// injects it into every whole-plan boot, and runSkillLaunch reads it into
+// runtime.Options.InPinnedImage so the in-container re-entry runs the plan
+// in-process instead of booting the verified pin a second time (which would
+// recurse — the image carries no nested container runtime).
+const envSkillImageBooted = "AILERON_SKILL_IMAGE_BOOTED"
+
 // containerRunFlightPlan boots the pinned image and runs the plan inside it. It
 // is a package variable purely for symmetry with sandboxRunContainer; the
 // production launch swaps the whole runtime.ImageRunner via newLaunchImageRunner
@@ -112,6 +119,11 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		Volumes: volumes,
 		Command: command,
 		Name:    flightPlanContainerName(spec),
+		// The sentinel tells the in-container re-entry it is ALREADY inside
+		// the booted pin: it must run the plan in-process rather than boot
+		// the pin again (which would recurse — the image carries no nested
+		// container runtime, and with one it would never terminate).
+		Env: map[string]string{envSkillImageBooted: "1"},
 	}
 
 	// Daemon-audit reachability (#1759): inject the host daemon coordinates so the

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -150,6 +150,9 @@ func TestContainerImageRunner_InjectsDaemonEnv(t *testing.T) {
 	if got.Env["AILERON_TOKEN"] != "daemon-token" {
 		t.Errorf("AILERON_TOKEN = %q, want the daemon token", got.Env["AILERON_TOKEN"])
 	}
+	if got.Env[envSkillImageBooted] != "1" {
+		t.Errorf("%s = %q, want the boot sentinel alongside the daemon env", envSkillImageBooted, got.Env[envSkillImageBooted])
+	}
 }
 
 // TestContainerImageRunner_PassthroughWhenNoDaemonConfig proves that when the
@@ -172,14 +175,16 @@ func TestContainerImageRunner_PassthroughWhenNoDaemonConfig(t *testing.T) {
 	if _, err := (containerImageRunner{daemonEnv: fake}).Run(context.Background(), spec); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(got.Env) != 0 {
-		t.Errorf("RunOptions.Env = %v, want no injected env on the passthrough (ok=false) boot", got.Env)
+	// Only the boot sentinel: no daemon coordinates on the passthrough boot.
+	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the passthrough (ok=false) boot", got.Env)
 	}
 }
 
 // TestContainerImageRunner_ZeroValueInjectsNoEnv proves the zero-value runner
-// (daemonEnv == nil) injects no env, so the CLI unit tests stay deterministic
-// irrespective of any live ~/.aileron daemon (#1759).
+// (daemonEnv == nil) injects no daemon env, so the CLI unit tests stay
+// deterministic irrespective of any live ~/.aileron daemon (#1759). The boot
+// sentinel is still present: every whole-plan boot marks the re-entry.
 func TestContainerImageRunner_ZeroValueInjectsNoEnv(t *testing.T) {
 	storeDir := t.TempDir()
 	origStore := skillStoreDir
@@ -196,8 +201,8 @@ func TestContainerImageRunner_ZeroValueInjectsNoEnv(t *testing.T) {
 	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(got.Env) != 0 {
-		t.Errorf("RunOptions.Env = %v, want no injected env on the zero-value runner", got.Env)
+	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the zero-value runner", got.Env)
 	}
 }
 

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -51,6 +51,15 @@ type Options struct {
 	// is unset, that step is an explicit error, never a silent skip (mirrors the
 	// ImageRunner nil-guard discipline: a declared tool dispatch must be entered).
 	ToolImageRunner ToolImageRunner
+	// InPinnedImage marks this run as already executing INSIDE the verified
+	// pinned rung-1/rung-2 image — the image-boot re-entry (#1731). It routes
+	// a whole-plan-pinned unit onto the in-process path instead of booting the
+	// pin again: inside the container, in-process IS the certified
+	// environment, and re-booting would recurse (the image carries no nested
+	// container runtime, and with one it would never terminate). The CLI sets
+	// this from the AILERON_SKILL_IMAGE_BOOTED sentinel the image runner
+	// injects into the boot env.
+	InPinnedImage bool
 
 	// Clock supplies the single launch-time read for dynamic inputs. Nil uses
 	// SystemClock.
@@ -97,7 +106,10 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	// individual step shells out to its tool image (#1733). So the boot branch
 	// fires only for whole-plan pins (no per-step StepID); rung-3 stays on
 	// runPlan, where the executor dispatches each tool step through the seam.
-	if hasWholePlanImage(lp.ResolvedImages) {
+	// The image-boot re-entry (InPinnedImage) also stays in-process: it is
+	// already running inside the booted pin, so in-process IS the certified
+	// environment and booting again would recurse.
+	if hasWholePlanImage(lp.ResolvedImages) && !opts.InPinnedImage {
 		return runInImage(ctx, lp, opts)
 	}
 	return runPlan(ctx, lp.Plan, lp.ContentHash, lp.SignerFingerprint, opts)

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -217,3 +217,48 @@ func TestRun_NoRungStaysInProcess(t *testing.T) {
 		t.Errorf("in-process RunResult.ContentHash = %q, want the verified hash", res.ContentHash)
 	}
 }
+
+// TestRun_InPinnedImageReentryStaysInProcess proves the image-boot re-entry
+// guard: a rung-pinned unit launched with InPinnedImage (the in-container
+// re-entry, #1731) drives the in-process pipeline and never touches the
+// ImageRunner. Without the guard the re-entry would boot the pin again and
+// recurse — the failure mode is "no container runtime found on PATH" inside
+// the booted image.
+func TestRun_InPinnedImageReentryStaysInProcess(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	fake := &fakeImageRunner{}
+	res, err := Run(context.Background(), Options{
+		Store:         s,
+		Name:          "weekly-metrics-digest",
+		Version:       "test",
+		ImageRunner:   fake,
+		InPinnedImage: true,
+		Dispatcher:    disp,
+		Approver:      &fakeApprover{decision: Decision{Approved: true}},
+		Seam:          fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:         FixedClock{},
+		Transforms:    reg,
+		OutDir:        t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run re-entry path: %v", err)
+	}
+	if fake.called {
+		t.Fatal("the image-boot re-entry must not boot the pin again")
+	}
+	if !strings.HasPrefix(res.ContentHash, "sha256:") {
+		t.Errorf("re-entry RunResult.ContentHash = %q, want the verified hash", res.ContentHash)
+	}
+}


### PR DESCRIPTION
## Summary
- The whole-plan image boot (#1731) re-enters `aileron skill launch` inside the pinned container, but the re-entered run loads the same verified lock, sees the same `resolvedImages` pin, and takes the boot branch **again** — the launch path was recursive by omission. In practice the inner boot dies with `no container runtime found on PATH` (the runner image carries no docker); with docker-in-docker it would never terminate.
- Fix: the booting runner injects an `AILERON_SKILL_IMAGE_BOOTED=1` sentinel into every whole-plan boot; `runSkillLaunch` reads it into the new `runtime.Options.InPinnedImage`, which routes a whole-plan-pinned unit onto the in-process path. Inside the container, in-process **is** the certified environment — the attestation is honored by the outer boot, not by booting twice.
- Sibling to #1799 (vault gate stands down on env-provided daemon): both are in-container re-entry gaps found by the first real workload through the #1730 launch path.

## Test plan
- [x] New `TestRun_InPinnedImageReentryStaysInProcess`: rung-pinned store-backed unit + `InPinnedImage` → in-process pipeline runs, ImageRunner never touched. Fails before the fix, passes after.
- [x] `TestContainerImageRunner_*` updated: every whole-plan boot carries the sentinel (alongside daemon env, on passthrough, and on the zero-value runner).
- [x] `go test ./internal/flightplan/runtime/ ./cmd/aileron/` green.
- [x] Verified live: an image-boot launch with this binary baked into the runner image (see verification comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sUjkxyPusyc7FivV3rQpL