### PR TITLE
fix(cli): offer a shared unbound capability once per add-suite run

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -2978,9 +2978,16 @@ type actionAddOptions struct {
 // fragment the OAuth dances across each install, which is the very
 // disruption ADR-0006 / #726 was avoiding when it chose against a
 // mid-install reauthorize prompt.
+//
+// unboundCapabilities does the same for the fresh bind offer (#1803):
+// every action in a suite that shares one credential capability
+// reports it unbound, so a per-action offer would repeat the same
+// question N times. The suite loop dedupes across entries and asks
+// once at the tail, next to the stale-binding batch.
 type actionInstallOutcome struct {
-	status        actionInstallStatus
-	staleBindings []staleBindingWire
+	status              actionInstallStatus
+	staleBindings       []staleBindingWire
+	unboundCapabilities []unboundCapabilityWire
 }
 
 type actionInstallStatus string
@@ -3252,18 +3259,14 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 		return 1
 	}
 	var resp struct {
-		Name                string `json:"name"`
-		Fqn                 string `json:"fqn"`
-		Version             string `json:"version"`
-		Source              string `json:"source"`
-		Path                string `json:"path"`
-		AlreadyInstalled    bool   `json:"already_installed"`
-		UnboundCapabilities []struct {
-			ConnectorFQN string  `json:"connector_fqn"`
-			Kind         string  `json:"kind"`
-			Scope        *string `json:"scope,omitempty"`
-		} `json:"unbound_capabilities,omitempty"`
-		NewlyStaleBindings []staleBindingWire `json:"newly_stale_bindings,omitempty"`
+		Name                string                  `json:"name"`
+		Fqn                 string                  `json:"fqn"`
+		Version             string                  `json:"version"`
+		Source              string                  `json:"source"`
+		Path                string                  `json:"path"`
+		AlreadyInstalled    bool                    `json:"already_installed"`
+		UnboundCapabilities []unboundCapabilityWire `json:"unbound_capabilities,omitempty"`
+		NewlyStaleBindings  []staleBindingWire      `json:"newly_stale_bindings,omitempty"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
@@ -3284,63 +3287,78 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 	fmt.Fprintf(stdout, "%s: %s\n  source: %s\n  path: %s\n",
 		verb, resp.Name, resp.Source, resp.Path)
 
-	// Hand stale-binding transitions back to the suite path through
-	// the per-entry outcome so the loop can offer one batch prompt at
-	// the end — installOneAction itself only prompts in the
-	// non-suite-consented path so a single-action install still gets
-	// the inline prompt.
+	// Hand stale-binding transitions and unbound capabilities back to
+	// the suite path through the per-entry outcome so the loop can
+	// offer one deduplicated batch prompt for each at the end —
+	// installOneAction itself only prompts in the non-suite-consented
+	// path so a single-action install still gets the inline prompt.
 	if opts.outcome != nil {
 		opts.outcome.staleBindings = resp.NewlyStaleBindings
+		opts.outcome.unboundCapabilities = resp.UnboundCapabilities
 	}
 
-	if opts.noBind || len(resp.UnboundCapabilities) == 0 {
-		if len(resp.UnboundCapabilities) > 0 {
-			fmt.Fprintln(stdout, "")
-			fmt.Fprintln(stdout, "Action has unbound credential capabilities:")
-			for _, u := range resp.UnboundCapabilities {
-				fmt.Fprintf(stdout, "  - %s (%s)\n", u.ConnectorFQN, u.Kind)
-			}
-			fmt.Fprintln(stdout, "Run `aileron binding setup <connector-FQN>` for each before invoking the action.")
-		}
-		// Even when --no-bind suppresses the prompt, surface the
-		// stale-binding list so a scripted install path doesn't
-		// silently drop the signal. Skipped under suite-consented
-		// installs because the suite loop owns the batch prompt.
-		if !opts.suiteConsented {
-			promptReauthorizeStaleBindings(resp.NewlyStaleBindings, opts.yes, opts.noBind, stdin, stdout, stderr)
-		}
+	// Suite-consented installs defer both credential conversations to
+	// the suite loop, which dedupes across all entries and presents
+	// one batch prompt for each at the tail (#741 for stale-binding
+	// reauthorization, #1803 for fresh bind offers); a per-action
+	// prompt here would repeat the same question once per entry and
+	// undo that batching.
+	if opts.suiteConsented {
 		return 0
 	}
 
-	// Prompt the user to bind each unbound capability now.
-	for _, u := range resp.UnboundCapabilities {
+	promptBindUnboundCapabilities(resp.UnboundCapabilities, opts.noBind, stdin, stdout, stderr)
+	promptReauthorizeStaleBindings(resp.NewlyStaleBindings, opts.yes, opts.noBind, stdin, stdout, stderr)
+	return 0
+}
+
+// promptBindUnboundCapabilities walks an unbound-capability list
+// emitted by the install endpoint and, for each entry, offers to
+// drop into `aileron binding setup <connector-FQN>` inline. Shared
+// by the single-action tail of installOneAction (inline, per
+// install) and the suite tail of installSuiteEntries (once per run,
+// over the set deduplicated across every entry — #1803). Because the
+// suite path asks over the deduplicated set exactly once at the
+// tail, a declined capability is never re-asked by the same run.
+//
+// Behavior (unchanged from the pre-#1803 inline loop):
+//
+//   - noBind suppresses the prompt entirely but still prints the
+//     list so a scripted install retains the signal in stdout.
+//   - Otherwise, each capability gets its own Y/n defaulting to yes.
+//     "n" prints a hint pointing at the standalone `aileron binding
+//     setup` verb and the loop continues; a failed setup is reported
+//     and the loop continues — partial bind is better than aborting,
+//     the user can retry the failing one later.
+func promptBindUnboundCapabilities(unbound []unboundCapabilityWire, noBind bool, stdin io.Reader, stdout, stderr io.Writer) {
+	if len(unbound) == 0 {
+		return
+	}
+	if noBind {
+		fmt.Fprintln(stdout, "")
+		fmt.Fprintln(stdout, "Action has unbound credential capabilities:")
+		for _, u := range unbound {
+			fmt.Fprintf(stdout, "  - %s (%s)\n", u.ConnectorFqn, u.Kind)
+		}
+		fmt.Fprintln(stdout, "Run `aileron binding setup <connector-FQN>` for each before invoking the action.")
+		return
+	}
+	for _, u := range unbound {
 		fmt.Fprintln(stdout, "")
 		desc := u.Kind
 		if u.Scope != nil && *u.Scope != "" {
 			desc = u.Kind + " — " + *u.Scope
 		}
 		answer := promptLine(stdin, stdout,
-			fmt.Sprintf("This action needs %s access for %s. Set up now? [Y/n]: ", desc, u.ConnectorFQN))
+			fmt.Sprintf("This action needs %s access for %s. Set up now? [Y/n]: ", desc, u.ConnectorFqn))
 		if strings.EqualFold(answer, "n") || strings.EqualFold(answer, "no") {
-			fmt.Fprintf(stdout, "  Skipped. Run `aileron binding setup %s` later.\n", u.ConnectorFQN)
+			fmt.Fprintf(stdout, "  Skipped. Run `aileron binding setup %s` later.\n", u.ConnectorFqn)
 			continue
 		}
-		if rc := runBindingSetup([]string{u.ConnectorFQN}, stdin, stdout, stderr); rc != 0 {
-			fmt.Fprintf(stderr, "  binding setup for %s exited %d\n", u.ConnectorFQN, rc)
-			// Continue to the next capability — partial bind is
-			// better than aborting; the user can retry the failing
-			// one later.
+		if rc := runBindingSetup([]string{u.ConnectorFqn}, stdin, stdout, stderr); rc != 0 {
+			fmt.Fprintf(stderr, "  binding setup for %s exited %d\n", u.ConnectorFqn, rc)
 		}
 	}
-
-	// Suite-consented installs defer the stale-binding prompt to the
-	// suite loop, which dedupes across all entries and presents one
-	// batch prompt at the tail; a per-action prompt here would
-	// fragment the OAuth dances and undo that batching.
-	if !opts.suiteConsented {
-		promptReauthorizeStaleBindings(resp.NewlyStaleBindings, opts.yes, opts.noBind, stdin, stdout, stderr)
-	}
-	return 0
 }
 
 // promptReauthorizeStaleBindings walks a stale-binding list emitted
@@ -3672,13 +3690,17 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, hubSuiteFQ
 	// pending ref into actionInstallStatusCancelled; preview-failed
 	// refs stay failed regardless. The trustState carries the
 	// authorities resolved in phase 1.
-	results, staleBindings := runSuiteInstallLoop(refs, previews, opts, trust, cancelled, stdin, stdout, stderr)
-	// Phase 4 (#741): one batch reauthorize prompt for the
-	// deduplicated set of bindings the install loop transitioned to
-	// `stale`. Cancellation skips this — no install ran, so no
-	// transitions to surface. opts.yes / opts.noBind are respected
-	// the same way as in the single-action path.
+	results, staleBindings, unboundCaps := runSuiteInstallLoop(refs, previews, opts, trust, cancelled, stdin, stdout, stderr)
+	// Phase 4 (#741, #1803): one batch bind offer for the
+	// deduplicated set of capabilities the installs reported unbound,
+	// then one batch reauthorize prompt for the deduplicated set of
+	// bindings the install loop transitioned to `stale`. Ordering
+	// mirrors the single-action tail (fresh binds before
+	// reauthorization). Cancellation skips both — no install ran, so
+	// nothing to surface. opts.yes / opts.noBind are respected the
+	// same way as in the single-action path.
 	if !cancelled {
+		promptBindUnboundCapabilities(unboundCaps, opts.noBind, stdin, stdout, stderr)
 		promptReauthorizeStaleBindings(staleBindings, opts.yes, opts.noBind, stdin, stdout, stderr)
 	}
 	return renderSuiteSummary(stdout, results)
@@ -3951,15 +3973,19 @@ type suiteInstallResult struct {
 // just fail again.
 //
 // Returns the per-ref result list plus the deduplicated set of
-// bindings the loop flipped to `stale` across every install (#741).
-// Suite-consented entries defer their per-install reauthorize prompt
-// to the caller, which presents a single batch prompt at the tail
-// instead of N fragmented browser hand-offs — the disruption #726
-// flagged when it chose against a mid-install reauthorize prompt.
-func runSuiteInstallLoop(refs []cstore.Ref, previews []suiteRefPreview, opts actionAddOptions, trust *trustState, cancelled bool, stdin *bufio.Reader, stdout, stderr io.Writer) ([]suiteInstallResult, []staleBindingWire) {
+// bindings the loop flipped to `stale` across every install (#741)
+// and the deduplicated set of capabilities the installs reported
+// unbound (#1803). Suite-consented entries defer their per-install
+// reauthorize and fresh-bind prompts to the caller, which presents a
+// single batch prompt for each at the tail instead of N fragmented
+// hand-offs — the disruption #726 flagged when it chose against a
+// mid-install reauthorize prompt.
+func runSuiteInstallLoop(refs []cstore.Ref, previews []suiteRefPreview, opts actionAddOptions, trust *trustState, cancelled bool, stdin *bufio.Reader, stdout, stderr io.Writer) ([]suiteInstallResult, []staleBindingWire, []unboundCapabilityWire) {
 	results := make([]suiteInstallResult, 0, len(refs))
 	var aggregate []staleBindingWire
 	seen := make(map[string]struct{})
+	var unbound []unboundCapabilityWire
+	seenUnbound := make(map[string]struct{})
 	for i, ref := range refs {
 		fmt.Fprintln(stdout)
 		fmt.Fprintf(stdout, "── [%d/%d] %s\n", i+1, len(refs), ref.String())
@@ -3989,8 +4015,24 @@ func runSuiteInstallLoop(refs []cstore.Ref, previews []suiteRefPreview, opts act
 			seen[sb.Name] = struct{}{}
 			aggregate = append(aggregate, sb)
 		}
+		for _, u := range outcome.unboundCapabilities {
+			// Dedupe by (connector_fqn, kind, scope): every action
+			// that shares one credential capability reports the same
+			// tuple, and we want to offer the bind exactly once at
+			// the tail (#1803).
+			scope := ""
+			if u.Scope != nil {
+				scope = *u.Scope
+			}
+			key := u.ConnectorFqn + "\x00" + u.Kind + "\x00" + scope
+			if _, ok := seenUnbound[key]; ok {
+				continue
+			}
+			seenUnbound[key] = struct{}{}
+			unbound = append(unbound, u)
+		}
 	}
-	return results, aggregate
+	return results, aggregate, unbound
 }
 
 // renderSuiteSummary prints the per-ref outcome list + the rolled-up

--- a/cmd/aileron/unbound_capability_prompt_test.go
+++ b/cmd/aileron/unbound_capability_prompt_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Tests for the #1803 fix: a suite whose actions share one credential
+// capability gets exactly one bind offer per add-suite run, batched at
+// the suite tail next to the #741 stale-binding reauthorize prompt,
+// instead of one identical offer per action. The single-action inline
+// behavior (covered by TestRunAction_AddAutoPromptsForUnboundCapabilities
+// and friends in main_test.go) is unchanged.
+
+// unboundSuiteServer stands up a fake daemon for a suite install
+// where every action's install response reports the unbound
+// capabilities returned by unboundFor(fqn) (a JSON array literal).
+// It returns counters for the binding-setup endpoints so tests can
+// assert how many setups ran.
+func unboundSuiteServer(t *testing.T, unboundFor func(fqn string) string) (initHits, setupHits *int) {
+	t.Helper()
+	withSeededKeyring(t, "github://acme/conn")
+	var inits, setups int
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch r.URL.Path {
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{
+				"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p",
+				"unbound_capabilities":%s
+			}`, lastSegment(req.FQN), req.FQN, unboundFor(req.FQN))
+		case "/bindings/setup/oauth2/init":
+			inits++
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			fmt.Fprint(w, `{"error":{"code":"not_oauth2"}}`)
+		case "/bindings/setup":
+			setups++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"created":[{"name":"api_key/conn-a/work","kind":"api_key","service":"conn-a","identity":"work","connector_fqn":"github://acme/conn-a","created_at":"2024-01-01T00:00:00Z"}]}`)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	})
+	return &inits, &setups
+}
+
+// sharedCapability reports the same (connector, kind, scope) tuple
+// for every action in the suite — the shape of the Athena repro in
+// #1803 (N actions, one connector, one credential).
+func sharedCapability(string) string {
+	return `[{"connector_fqn":"github://acme/conn-a","kind":"api_key","scope":"read"}]`
+}
+
+const sharedCapabilitySuite = `
+name = "shared-cap-suite"
+description = "Three actions, one shared credential capability."
+
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
+`
+
+// TestRunActionAddSuite_SharedUnboundCapabilityOffersOnce_Accept: the
+// headline #1803 regression. Three actions all report the same
+// (connector, kind, scope) unbound capability; the run asks "Set up
+// now?" exactly once, at the suite tail, and accepting runs binding
+// setup exactly once. Pre-fix, the offer fired inside each per-action
+// install: three prompts for one capability.
+func TestRunActionAddSuite_SharedUnboundCapabilityOffersOnce_Accept(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, sharedCapabilitySuite)
+	initHits, setupHits := unboundSuiteServer(t, sharedCapability)
+
+	// Suite consent "y", one bind offer "y", identity "work", api_key value "k".
+	stdin := strings.NewReader("y\ny\nwork\nk\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "Set up now?"); got != 1 {
+		t.Errorf("expected exactly 1 bind offer for a shared capability, got %d:\n%s", got, out)
+	}
+	if *initHits != 1 {
+		t.Errorf("oauth2/init hits = %d, want 1", *initHits)
+	}
+	if *setupHits != 1 {
+		t.Errorf("bindings/setup hits = %d, want 1", *setupHits)
+	}
+	if !strings.Contains(out, "Created: api_key/conn-a/work") {
+		t.Errorf("stdout missing binding-created line:\n%s", out)
+	}
+	// The offer must land at the tail, after the last per-action
+	// install line — not inline inside an entry.
+	lastEntry := strings.LastIndex(out, "── [3/3]")
+	offer := strings.Index(out, "Set up now?")
+	if lastEntry == -1 || offer < lastEntry {
+		t.Errorf("bind offer should follow the last install entry (entry at %d, offer at %d):\n%s", lastEntry, offer, out)
+	}
+}
+
+// TestRunActionAddSuite_SharedUnboundCapabilityOffersOnce_Decline: a
+// declined capability is asked exactly once per run. The decline
+// prints the binding-setup hint once and never re-asks; no setup
+// endpoint is hit.
+func TestRunActionAddSuite_SharedUnboundCapabilityOffersOnce_Decline(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, sharedCapabilitySuite)
+	initHits, setupHits := unboundSuiteServer(t, sharedCapability)
+
+	// Suite consent "y", decline the single bind offer.
+	stdin := strings.NewReader("y\nn\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "Set up now?"); got != 1 {
+		t.Errorf("expected exactly 1 bind offer, got %d:\n%s", got, out)
+	}
+	if got := strings.Count(out, "Skipped. Run `aileron binding setup github://acme/conn-a` later."); got != 1 {
+		t.Errorf("expected the decline hint exactly once, got %d:\n%s", got, out)
+	}
+	if *initHits != 0 || *setupHits != 0 {
+		t.Errorf("decline must not call binding setup (init=%d setup=%d)", *initHits, *setupHits)
+	}
+}
+
+// TestRunActionAddSuite_NoBindPrintsDedupedCapabilityListOnce:
+// --no-bind suppresses the offer but must still surface the signal —
+// once, over the deduplicated set, at the suite tail. Pre-fix the
+// list printed inside every per-action install.
+func TestRunActionAddSuite_NoBindPrintsDedupedCapabilityListOnce(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, sharedCapabilitySuite)
+	initHits, setupHits := unboundSuiteServer(t, sharedCapability)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{"--yes", "--no-bind", manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "Action has unbound credential capabilities:"); got != 1 {
+		t.Errorf("expected the unbound list header exactly once, got %d:\n%s", got, out)
+	}
+	if got := strings.Count(out, "- github://acme/conn-a (api_key)"); got != 1 {
+		t.Errorf("expected the capability listed exactly once, got %d:\n%s", got, out)
+	}
+	if strings.Contains(out, "Set up now?") {
+		t.Errorf("--no-bind must not prompt:\n%s", out)
+	}
+	if *initHits != 0 || *setupHits != 0 {
+		t.Errorf("--no-bind must not call binding setup (init=%d setup=%d)", *initHits, *setupHits)
+	}
+}
+
+// TestRunActionAddSuite_DistinctCapabilitiesEachGetOneOffer: the
+// dedup key is (connector_fqn, kind, scope) — a different connector
+// or kind is a different conversation and survives the collapse.
+// foo and bar share conn-a/api_key (collapses to one), baz adds
+// conn-b/oauth2 (its own offer): two offers total, in declaration
+// order.
+func TestRunActionAddSuite_DistinctCapabilitiesEachGetOneOffer(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, sharedCapabilitySuite)
+	initHits, setupHits := unboundSuiteServer(t, func(fqn string) string {
+		if lastSegment(fqn) == "baz" {
+			return `[{"connector_fqn":"github://acme/conn-a","kind":"api_key","scope":"read"},
+				{"connector_fqn":"github://acme/conn-b","kind":"oauth2"}]`
+		}
+		return sharedCapability(fqn)
+	})
+
+	// Suite consent "y", decline both offers — this test pins the
+	// offer count and identity, not the setup flow.
+	stdin := strings.NewReader("y\nn\nn\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "Set up now?"); got != 2 {
+		t.Errorf("expected exactly 2 bind offers for 2 distinct capabilities, got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, "needs api_key — read access for github://acme/conn-a") {
+		t.Errorf("missing conn-a offer:\n%s", out)
+	}
+	if !strings.Contains(out, "needs oauth2 access for github://acme/conn-b") {
+		t.Errorf("missing conn-b offer:\n%s", out)
+	}
+	if *initHits != 0 || *setupHits != 0 {
+		t.Errorf("declines must not call binding setup (init=%d setup=%d)", *initHits, *setupHits)
+	}
+}
+
+// TestPromptBindUnboundCapabilities_EmptyListIsNoOp: the canonical
+// happy path is "everything already bound"; the helper must not emit
+// any output when there is nothing to offer.
+func TestPromptBindUnboundCapabilities_EmptyListIsNoOp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	promptBindUnboundCapabilities(nil, false, strings.NewReader(""), &stdout, &stderr)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("empty list must be silent; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

`aileron action add-suite` fired the fresh unbound-capability bind offer inside every per-action install, so a suite of N actions sharing one credential capability (the Athena repro: 15 actions, one `(connector, aws_sigv4)` capability) produced up to N identical "Set up now?" prompts. Its two sibling prompts already had suite-level batching (shared `trustState` for publisher trust; #741 tail-batched stale-binding reauthorization); this brings the bind offer in line with the #741 shape:

- Under `suiteConsented`, `installOneAction` no longer prompts (or prints the `--no-bind` list) inline; it hands `resp.UnboundCapabilities` back through a new `unboundCapabilities` field on `actionInstallOutcome`, the same channel as `outcome.staleBindings`.
- `runSuiteInstallLoop` aggregates and dedupes the capabilities by `(connector_fqn, kind, scope)` alongside the existing seen-by-name stale-binding dedup, and returns the deduped set.
- `installSuiteEntries` phase 4 presents one batched bind offer at the suite tail, immediately before `promptReauthorizeStaleBindings`, mirroring the single-action ordering (fresh binds before reauthorization).
- The inline prompt loop is extracted into a shared `promptBindUnboundCapabilities` helper (reusing the existing `unboundCapabilityWire` type), preserving single-action inline behavior and the `--no-bind` (print list once) / `--yes` semantics unchanged.

A declined capability is asked exactly once per run by construction: the suite path asks once, over the deduped set, at the tail.

Out of scope (per the issue): `add-suite --region/--access-key-id` flag passthrough, which the issue calls a natural companion but not the core ask.

## Test plan

- [x] New regression tests in `cmd/aileron/unbound_capability_prompt_test.go`, verified to fail against the pre-fix `main.go` (three prompts fired, one per action) and pass after:
  - suite of 3 actions sharing one capability asks "Set up now?" exactly once, at the tail, and accepting runs binding setup exactly once
  - declining prints the `aileron binding setup` hint exactly once and never re-asks; no setup endpoint hit
  - `--no-bind` prints the deduped capability list exactly once at the tail
  - distinct `(connector, kind, scope)` tuples each keep their own offer (2 offers for 2 distinct capabilities across 3 actions)
  - `promptBindUnboundCapabilities` is silent on an empty list
- [x] Single-action inline behavior covered by existing tests (`TestRunAction_AddAutoPromptsForUnboundCapabilities`, `TestRunAction_AddDeclineDoesNotBindButPrintsHint`, `TestRunAction_AddNoBindFlagSkipsPrompt`) — all still green
- [x] Full `cmd/aileron` package: `go test ./...` green; `go build` / `go vet` / `gofmt` clean
- [x] CodeRabbit review on the diff: 0 findings

Closes #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNuk4Jwbp1LD7HKGmYVFmR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Suite installs now batch prompts for newly discovered credential capabilities, reducing repeated confirmations during `add-suite`.
  * Unbound capabilities are deduplicated, so shared capabilities are shown and handled once.

* **Bug Fixes**
  * Improved handling of suite installs so credential setup and reauthorization prompts appear at the right time.
  * `--no-bind` now still shows the capability list once, without triggering setup prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->