### PR TITLE
feat(images): bake the version-stamped aileron CLI into the published sandbox-base

### DIFF
--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - ".github/workflows/sandbox-base.yml"
       - "images/sandbox-base/**"
-      # The published image now bakes aileron-mcp (issue #957), so a change to
-      # the binary's source must rebuild the image on PR. internal/** is broad
-      # but correct: aileron-mcp links the internal module.
+      # The published image now bakes aileron-mcp (issue #957) and the aileron
+      # CLI (issue #1807, ADR-0027 image-boot), so a change to either binary's
+      # source must rebuild the image on PR. internal/** is broad but correct:
+      # both binaries link the internal module.
       - "cmd/aileron-mcp/**"
+      - "cmd/aileron/**"
       - "internal/**"
       - "sdk/go/**"
       - "go.work"
@@ -27,6 +29,7 @@ on:
       - ".github/workflows/sandbox-base.yml"
       - "images/sandbox-base/**"
       - "cmd/aileron-mcp/**"
+      - "cmd/aileron/**"
       - "internal/**"
       - "sdk/go/**"
       - "go.work"
@@ -308,6 +311,23 @@ jobs:
             exit 1
           fi
           echo "ai.aileron.mcp.version label: $label"
+
+          # Baked aileron CLI runs and reports a non-empty version (#1807,
+          # ADR-0027 image-boot re-entry contract: aileron on PATH).
+          cli_version=$(docker run --rm "$IMG" aileron --version)
+          if [ -z "$cli_version" ]; then
+            echo "baked aileron --version returned empty"
+            exit 1
+          fi
+          echo "baked aileron --version: $cli_version"
+
+          # The ai.aileron.cli.version label is present.
+          cli_label=$(docker inspect --format '{{ index .Config.Labels "ai.aileron.cli.version" }}' "$IMG")
+          if [ -z "$cli_label" ]; then
+            echo "ai.aileron.cli.version label missing on smoke image"
+            exit 1
+          fi
+          echo "ai.aileron.cli.version label: $cli_label"
 
           # #959: the tools.txt manifest and its profile banner are gone.
           docker run --rm "$IMG" sh -c '[ ! -e /etc/aileron/tools.txt ]'

--- a/images/sandbox-base/Containerfile.published
+++ b/images/sandbox-base/Containerfile.published
@@ -1,11 +1,18 @@
 # Published sandbox-base (ghcr.io/alrubinger/aileron-sandbox-base).
 #
-# Unlike the local Tier 0 Containerfile, this recipe BAKES aileron-mcp into the
-# image and stamps an `ai.aileron.mcp.version` label. A sealed customer-operated
-# runtime ships only this image with no host-side aileron-mcp to bind-mount, so
-# the binary has to travel inside the image (issue #957, the ADR-0024 image-bake
-# flip). The launcher detects the label and skips the host-mount; unlabeled
-# images (local Tier 0, devcontainers, BYO) keep the host-mount fallback.
+# Unlike the local Tier 0 Containerfile, this recipe BAKES two Go binaries into
+# the image and stamps a version label for each:
+#   - aileron-mcp (issue #957, ADR-0024 image-bake flip) with
+#     `ai.aileron.mcp.version`. A sealed customer-operated runtime ships only
+#     this image with no host-side aileron-mcp to bind-mount, so the binary has
+#     to travel inside the image. The launcher detects the mcp label and skips
+#     the host-mount; unlabeled images (local Tier 0, devcontainers, BYO) keep
+#     the host-mount fallback.
+#   - the aileron CLI (issue #1807, ADR-0027 image-boot re-entry) with
+#     `ai.aileron.cli.version`. The image-boot contract requires `aileron` on
+#     PATH inside the sandbox so the sealed runtime can re-enter the CLI without
+#     a host binary; the version-stamped label lets consumers (#1808/#1809)
+#     detect the baked CLI the same way they detect the baked MCP.
 #
 # Build context is the REPO ROOT (`.github/workflows/sandbox-base.yml` passes
 # `context: .`), because the builder stage needs go.work and the Go source. A
@@ -52,6 +59,45 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -X github.com/ALRubinger/aileron/internal/version.Commit=${AILERON_COMMIT}" \
     -o /out/aileron-mcp .
 
+# Builder stage: cross-compile the aileron CLI for the target platform. This
+# mirrors mcp-builder exactly (same toolchain pin, reconstructed workspace,
+# shared go.work.sum, cross-compile flags, and version -X ldflags) so the baked
+# CLI is version-aligned with the baked aileron-mcp. Satisfying the ADR-0027 /
+# issue #1731 image-boot re-entry contract requires `aileron` on PATH in the
+# sealed runtime; this stage produces that binary. BuildKit runs this stage in
+# parallel with mcp-builder since both read the same context layers.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS cli-builder
+WORKDIR /build
+
+# Like aileron-mcp, the aileron CLI resolves its module graph through the repo
+# workspace (go.work), so reconstruct a minimal workspace with the modules it
+# needs (cmd/aileron links only ./internal; ./sdk/go is kept for stage symmetry
+# with mcp-builder and the shared go.work.sum covers the superset either way),
+# reusing the committed go.work.sum for a reproducible, offline-checksummed
+# build.
+ENV CGO_ENABLED=0
+
+COPY internal/ internal/
+COPY sdk/go/ sdk/go/
+COPY cmd/aileron/ cmd/aileron/
+COPY go.work.sum go.work.sum
+RUN go work init ./internal ./sdk/go ./cmd/aileron
+
+# Version stamp injected via the same -X ldflags `task build` uses, so the
+# baked CLI's `--version` and the ai.aileron.cli.version image label report the
+# release identity.
+ARG AILERON_VERSION=dev
+ARG AILERON_COMMIT=unknown
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /build/cmd/aileron
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X github.com/ALRubinger/aileron/internal/version.Version=${AILERON_VERSION} \
+      -X github.com/ALRubinger/aileron/internal/version.Commit=${AILERON_COMMIT}" \
+    -o /out/aileron .
+
 FROM alpine:3.24
 
 LABEL org.opencontainers.image.title="Aileron sandbox base"
@@ -65,6 +111,14 @@ LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
 # sync. ARGs do not cross the FROM boundary, so AILERON_VERSION is re-declared.
 ARG AILERON_VERSION=dev
 LABEL ai.aileron.mcp.version="${AILERON_VERSION}"
+
+# ai.aileron.cli.version carries the baked aileron CLI's release identity,
+# stamped from the same ARG as the mcp label because both binaries build from
+# the same context and build-args (always version-aligned). It backs the
+# ADR-0027 image-boot re-entry contract: consumers (#1808/#1809) detect the
+# baked CLI on PATH by reading this label, the same way the launcher detects
+# the baked MCP via ai.aileron.mcp.version.
+LABEL ai.aileron.cli.version="${AILERON_VERSION}"
 
 # Base substrate packages. github-cli is NOT installed here: gh ships as a
 # composable devcontainer Feature (images/sandbox-features/gh) layered onto this
@@ -108,6 +162,13 @@ RUN chmod 0755 \
 # the RequireMCPBinary smoke check both target this path.
 COPY --from=mcp-builder /out/aileron-mcp /usr/local/bin/aileron-mcp
 RUN chmod 0755 /usr/local/bin/aileron-mcp
+
+# Baked aileron CLI from the cli-builder stage. Root-owned, world-executable
+# (matches aileron-mcp and the proxy-CA helpers). The ADR-0027 image-boot
+# re-entry contract requires `aileron` on PATH here so the sealed runtime can
+# re-enter the CLI without a host binary.
+COPY --from=cli-builder /out/aileron /usr/local/bin/aileron
+RUN chmod 0755 /usr/local/bin/aileron
 
 WORKDIR /home/agent/workspace
 USER agent


### PR DESCRIPTION
## Summary

The published `sandbox-base` image already bakes `aileron-mcp` and stamps `ai.aileron.mcp.version`. This adds the companion for the CLI: a version-stamped `aileron` binary at `/usr/local/bin/aileron` plus an `ai.aileron.cli.version` label, satisfying the ADR-0027 / #1731 image-boot re-entry contract (a sealed, customer-operated runtime needs `aileron` on PATH without a host binary to bind-mount).

- **`images/sandbox-base/Containerfile.published`**: new `cli-builder` stage that faithfully mirrors `mcp-builder` (same `golang:1.26` pin, reconstructed minimal workspace over the committed `go.work.sum`, `CGO_ENABLED=0`, cross-compile via `GOOS/GOARCH`, identical `-s -w -X internal/version.Version/.Commit` ldflags). The final stage stamps `ai.aileron.cli.version` (same `AILERON_VERSION` ARG, so the two binaries stay version-aligned) and installs the binary root-owned 0755 beside `aileron-mcp`. Header comment updated to describe both bakes.
- **`.github/workflows/sandbox-base.yml`**: `cmd/aileron/**` added to both the `pull_request` and `push` paths filters; the PR-only smoke step now also asserts a non-empty `aileron --version` and the presence of the `ai.aileron.cli.version` label.

Out of scope (per plan): local Tier 0 `Containerfile` (stays unbaked by design), `.dockerignore` (verified `cmd/` is not excluded), and any Go code (the label reader for image-boot consumers belongs to #1808/#1809).

## Test plan

- `actionlint .github/workflows/sandbox-base.yml` — clean.
- Local repo-root build: `docker build -f images/sandbox-base/Containerfile.published --build-arg AILERON_VERSION=dev --build-arg AILERON_COMMIT=$(git rev-parse HEAD) -t sandbox-base:local .` — succeeded (multi-stage, `cli-builder` compiled the CLI).
- `docker run --rm sandbox-base:local aileron --version` → `aileron dev (<sha>)`.
- `docker inspect --format '{{ index .Config.Labels "ai.aileron.cli.version" }}' sandbox-base:local` → `dev`.
- Confirmed the existing baked-MCP contract is intact (`aileron-mcp --version` and `ai.aileron.mcp.version` still report `dev`).
- The sandbox-base PR job (which touches `images/sandbox-base/**` and the workflow) runs the extended smoke and is the CI acceptance surface.

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sandbox base image now includes the `aileron` CLI alongside the existing MCP binary.
  * Both tools are version-stamped and available in the published image.

* **Bug Fixes**
  * PR and main-branch image rebuilds now trigger when either CLI source changes.
  * Smoke tests now verify the CLI is installed, reports a version, and includes the expected image version label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->