### PR TITLE
feat(cli): warn on CLI version skew between the pinned image and the booting host

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/version"
 )
 
 // containerImageRunner is the production runtime.ImageRunner: it boots the
@@ -46,6 +47,19 @@ type containerImageRunner struct {
 	// the in-container launch reaches the host daemon. nil (the zero value) is
 	// passthrough (no injected env).
 	daemonEnv imageDaemonEnv
+	// diag is where the pre-boot CLI-version-skew warning is written. nil (the
+	// zero value) means os.Stderr in production; tests set a buffer to assert the
+	// warning end-to-end through Run.
+	diag io.Writer
+}
+
+// diagWriter returns the destination for the skew warning: the injected diag
+// writer, or os.Stderr when unset (production wiring leaves diag nil).
+func (r containerImageRunner) diagWriter() io.Writer {
+	if r.diag != nil {
+		return r.diag
+	}
+	return os.Stderr
 }
 
 // envSkillImageBooted marks the image-boot re-entry (#1731). The image runner
@@ -68,6 +82,30 @@ var containerRunFlightPlan = func(ctx context.Context, runtimeName string, stdou
 	}.Run(ctx, opts)
 }
 
+// containerBakedCLIVersion reads the aileron CLI version baked into the pinned
+// image (empty when unlabeled or uninspectable). It is a package variable so the
+// CLI tests swap it for a fake and never shell out to `docker image inspect`,
+// mirroring the containerRunFlightPlan and sandboxCheckBakedVersionFn seams.
+var containerBakedCLIVersion = func(ctx context.Context, runtimeName, image string) string {
+	return sandboxcontainer.BakedCLIVersion(ctx, sandboxcontainer.DefaultRunner(), runtimeName, image)
+}
+
+// reportBakedCLIVersion surfaces version skew between the pinned rung-1/rung-2
+// image's baked aileron CLI and the host CLI that is booting it (#1809). The
+// image-boot re-entry runs the baked binary against this host's launch
+// (ADR-0027 / #1731), so a mismatch is worth a heads-up but is never fatal: the
+// launch always proceeds. A baked value of "" (unlabeled or uninspectable
+// image) is silent because a custom image's contract is the operator's
+// responsibility under ADR-0027; a match is silent so the stdout of
+// `aileron skill launch` stays byte-identical (unlike the sandbox-check
+// precedent, this emits no OK line).
+func reportBakedCLIVersion(stderr io.Writer, image, baked, host string) {
+	if baked == "" || baked == host {
+		return
+	}
+	fmt.Fprintf(stderr, "warning: pinned image %q bakes aileron CLI version %s but the host CLI booting it is version %s. The image-boot re-entry (ADR-0027 / #1731) runs the baked binary against this host's launch; keep both sides on the same release. The launch proceeds.\n", image, baked, host)
+}
+
 func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
 	if spec.Image == "" {
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: image runner requires a pinned image")
@@ -76,6 +114,14 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 	if err != nil {
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: resolve container runtime: %w", err)
 	}
+
+	// Preflight the CLI-version skew (#1809). The image-boot re-entry runs the
+	// image's baked aileron binary against THIS host's launch (ADR-0027 / #1731),
+	// so mismatched releases on the two sides are worth a heads-up. This warns on
+	// stderr and never fails the launch: an unlabeled/uninspectable image reads as
+	// "" and stays silent (custom-image contract is the operator's under ADR-0027),
+	// a matching version stays silent (stdout unchanged), and any other value warns.
+	reportBakedCLIVersion(r.diagWriter(), spec.Image, containerBakedCLIVersion(ctx, runtimeName, spec.Image), version.Version)
 
 	// Mount the frozen store read-only so the in-container run reads the exact
 	// bytes verified on the host, and the out-dir writable so materialized

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -11,18 +12,40 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/version"
 )
 
 // stubContainerBoot swaps the single real-Docker call site for a recorder so the
 // container image runner's spec-construction is testable with no live runtime.
+// It also stubs the CLI-version-skew preflight to "" so every Run test stays
+// Docker-free and warning-silent by default; skew tests override it via
+// stubBakedCLIVersion.
 func stubContainerBoot(t *testing.T, capture *sandboxcontainer.RunOptions, err error) {
 	t.Helper()
+	stubBakedCLIVersion(t, "")
 	orig := containerRunFlightPlan
 	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
 		*capture = opts
 		return sandboxcontainer.RunResult{}, err
 	}
 	t.Cleanup(func() { containerRunFlightPlan = orig })
+}
+
+// stubBakedCLIVersion swaps the CLI-version inspect seam for a fake returning
+// value, recording the image it was asked to inspect. This keeps the preflight
+// off `docker image inspect` in unit tests and lets skew tests assert the
+// three cases (match, mismatch, missing label) through Run. It returns a pointer
+// to the recorded image so tests can assert the pin was passed, never re-resolved.
+func stubBakedCLIVersion(t *testing.T, value string) *string {
+	t.Helper()
+	var inspected string
+	orig := containerBakedCLIVersion
+	containerBakedCLIVersion = func(_ context.Context, _ string, image string) string {
+		inspected = image
+		return value
+	}
+	t.Cleanup(func() { containerBakedCLIVersion = orig })
+	return &inspected
 }
 
 func TestContainerImageRunner_BootsExactImageWithMounts(t *testing.T) {
@@ -216,6 +239,136 @@ func TestNewLaunchImageRunner_WiresDaemonEnvResolver(t *testing.T) {
 	}
 	if _, ok := runner.daemonEnv.(daemonImageEnv); !ok {
 		t.Errorf("daemonEnv = %T, want daemonImageEnv (the production resolver)", runner.daemonEnv)
+	}
+}
+
+// --- CLI-version skew preflight (#1809) ---
+
+// newSkewTestSpec returns a minimal spec with the store dir pointed at a temp
+// dir so Run reaches the boot without touching the real store.
+func newSkewTestSpec(t *testing.T) runtime.ImageRunSpec {
+	t.Helper()
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+	return runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+	}
+}
+
+// TestContainerImageRunner_SkewWarnsOnMismatch proves a baked CLI version that
+// differs from the host version prints one stderr warning naming both versions
+// and the image, still boots the exact pin, and returns no error.
+func TestContainerImageRunner_SkewWarnsOnMismatch(t *testing.T) {
+	spec := newSkewTestSpec(t)
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	inspected := stubBakedCLIVersion(t, "9.9.9")
+
+	var buf bytes.Buffer
+	if _, err := (containerImageRunner{diag: &buf}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "warning:") {
+		t.Errorf("expected a stderr warning, got %q", out)
+	}
+	if !strings.Contains(out, "9.9.9") {
+		t.Errorf("warning must name the baked version 9.9.9: %q", out)
+	}
+	if !strings.Contains(out, version.Version) {
+		t.Errorf("warning must name the host version %q: %q", version.Version, out)
+	}
+	if !strings.Contains(out, spec.Image) {
+		t.Errorf("warning must name the image %q: %q", spec.Image, out)
+	}
+	// The launch proceeds with the exact pin regardless of skew.
+	if got.Image != spec.Image {
+		t.Errorf("booted image = %q, want the exact pin %q", got.Image, spec.Image)
+	}
+	// The preflight inspects the pin, never a re-resolved image.
+	if *inspected != spec.Image {
+		t.Errorf("preflight inspected %q, want the pin %q", *inspected, spec.Image)
+	}
+}
+
+// TestContainerImageRunner_SkewSilentOnMatch proves a baked CLI version equal to
+// the host version emits nothing (stdout stays byte-identical, no OK line) and
+// still boots the pin.
+func TestContainerImageRunner_SkewSilentOnMatch(t *testing.T) {
+	spec := newSkewTestSpec(t)
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	stubBakedCLIVersion(t, version.Version)
+
+	var buf bytes.Buffer
+	if _, err := (containerImageRunner{diag: &buf}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("matching version must be silent, got %q", buf.String())
+	}
+	if got.Image != spec.Image {
+		t.Errorf("booted image = %q, want the exact pin %q", got.Image, spec.Image)
+	}
+}
+
+// TestContainerImageRunner_SkewSilentOnMissingLabel proves an unlabeled or
+// uninspectable image (baked == "") stays silent because a custom image's
+// contract is the operator's under ADR-0027, and still boots.
+func TestContainerImageRunner_SkewSilentOnMissingLabel(t *testing.T) {
+	spec := newSkewTestSpec(t)
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	stubBakedCLIVersion(t, "")
+
+	var buf bytes.Buffer
+	if _, err := (containerImageRunner{diag: &buf}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("missing label must be silent, got %q", buf.String())
+	}
+	if got.Image != spec.Image {
+		t.Errorf("booted image = %q, want the exact pin %q", got.Image, spec.Image)
+	}
+}
+
+// TestContainerImageRunner_DiagDefaultsToStderr proves the zero-value diag field
+// resolves to os.Stderr in production wiring, so a nil diag never routes the
+// warning to a discarded writer.
+func TestContainerImageRunner_DiagDefaultsToStderr(t *testing.T) {
+	if got := (containerImageRunner{}).diagWriter(); got != os.Stderr {
+		t.Errorf("zero-value diag writer = %v, want os.Stderr", got)
+	}
+	var buf bytes.Buffer
+	if got := (containerImageRunner{diag: &buf}).diagWriter(); got != &buf {
+		t.Errorf("injected diag writer = %v, want the injected buffer", got)
+	}
+}
+
+// TestReportBakedCLIVersion covers the skew helper's three-way contract directly.
+func TestReportBakedCLIVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		baked      string
+		host       string
+		wantOutput bool
+	}{
+		{name: "empty is silent", baked: "", host: "0.0.5", wantOutput: false},
+		{name: "match is silent", baked: "0.0.5", host: "0.0.5", wantOutput: false},
+		{name: "mismatch warns", baked: "9.9.9", host: "0.0.5", wantOutput: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			reportBakedCLIVersion(&buf, "img:test", tc.baked, tc.host)
+			if got := buf.Len() > 0; got != tc.wantOutput {
+				t.Fatalf("output presence = %v, want %v (got %q)", got, tc.wantOutput, buf.String())
+			}
+		})
 	}
 }
 

--- a/docs/src/content/docs/development/launch-surfaces-spec.md
+++ b/docs/src/content/docs/development/launch-surfaces-spec.md
@@ -24,6 +24,8 @@ Every surface shares one Launch contract. The per-surface dimensions specialize 
 
 Every Launch binds a frozen Flight Plan version. The version is the content hash plus the semver label from the manifest `lock` section ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) freeze and lock section). A surface invokes the deterministic Launch runtime against a digest-pinned, signed version. A surface never invokes an unfrozen skill.
 
+Booting a pinned rung-1 or rung-2 image runs the aileron binary baked into that image against the host CLI that started the Launch ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill)). The launcher reads the image's `ai.aileron.cli.version` label and compares it to the host CLI version. A mismatch prints a stderr warning naming both versions. The Launch never fails on version skew. An image that carries no such label boots silently, because a custom image's contract is the operator's responsibility under ADR-0027.
+
 Every Launch resolves its declared inputs once, at the launch boundary ([#1523](https://github.com/ALRubinger/aileron/issues/1523)). A surface passes literal-input overrides into that single resolution step. A surface never resolves inputs itself and never resolves them more than once.
 
 Every Launch carries an idempotency key. The key identifies one Launch attempt so a retried submission from the same surface does not double-run a Flight. The key is supplied by the surface and recorded with the run.

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -652,18 +652,19 @@ func (b Builder) imageExists(ctx context.Context, runner Runner, runtimeName, im
 // keep this string in sync with that file (the Containerfile cannot import it).
 const MCPVersionLabel = "ai.aileron.mcp.version"
 
-// BakedMCPVersion reports the aileron-mcp version baked into image, read from
-// the MCPVersionLabel OCI label via `<runtime> image inspect`. It returns the
-// trimmed label value, or "" when the image is unlabeled, not present locally,
-// or the inspect fails. Callers treat "" as "not baked" and fall back to the
-// host-mount path, so an inspect error is deliberately not propagated as fatal:
-// "cannot determine" degrades to "host-mount", never a broken launch.
-func BakedMCPVersion(ctx context.Context, runner Runner, runtimeName, image string) string {
+// imageLabel reports the trimmed value of a single OCI label on image, read via
+// `<runtime> image inspect --format`. It returns "" when the image carries no
+// such label, is not present locally, or the inspect fails, and it maps the Go
+// template "<no value>" sentinel (rendered for a missing key) to "". A nil
+// runner defaults to the production execRunner. This is the shared fail-soft
+// inspect plumbing behind BakedMCPVersion, ImageMetadataLabel, and
+// BakedCLIVersion: "cannot determine" always degrades to "", never a fatal.
+func imageLabel(ctx context.Context, runner Runner, runtimeName, image, label string) string {
 	if runner == nil {
 		runner = execRunner{}
 	}
 	var stdout bytes.Buffer
-	format := "{{ index .Config.Labels \"" + MCPVersionLabel + "\" }}"
+	format := "{{ index .Config.Labels \"" + label + "\" }}"
 	args := []string{"image", "inspect", "--format", format, image}
 	if err := runner.Run(ctx, runtimeName, args, &stdout, io.Discard); err != nil {
 		return ""
@@ -671,11 +672,41 @@ func BakedMCPVersion(ctx context.Context, runner Runner, runtimeName, image stri
 	out := strings.TrimSpace(stdout.String())
 	// An image with no labels at all renders the missing key as the Go
 	// template "<no value>" sentinel rather than an empty string; treat it
-	// as "not baked".
+	// as absent.
 	if out == "<no value>" {
 		return ""
 	}
 	return out
+}
+
+// BakedMCPVersion reports the aileron-mcp version baked into image, read from
+// the MCPVersionLabel OCI label via `<runtime> image inspect`. It returns the
+// trimmed label value, or "" when the image is unlabeled, not present locally,
+// or the inspect fails. Callers treat "" as "not baked" and fall back to the
+// host-mount path, so an inspect error is deliberately not propagated as fatal:
+// "cannot determine" degrades to "host-mount", never a broken launch.
+func BakedMCPVersion(ctx context.Context, runner Runner, runtimeName, image string) string {
+	return imageLabel(ctx, runner, runtimeName, image, MCPVersionLabel)
+}
+
+// CLIVersionLabel is the OCI image label the published sandbox-base image
+// carries to advertise the aileron CLI version baked into it (issue #1807).
+// The image-boot re-entry runs that baked binary against the host's launch
+// (ADR-0027 / #1731), so the launcher reads this label to detect version skew
+// between the pinned image and the booting host and warn the operator. The
+// label is stamped by images/sandbox-base/Containerfile.published; keep this
+// string in sync with that file (the Containerfile cannot import it).
+const CLIVersionLabel = "ai.aileron.cli.version"
+
+// BakedCLIVersion reports the aileron CLI version baked into image, read from
+// the CLIVersionLabel OCI label via `<runtime> image inspect`. It returns the
+// trimmed label value, or "" when the image is unlabeled, not present locally,
+// or the inspect fails. Callers treat "" as "cannot determine" and stay silent
+// (an unlabeled custom image is the operator's contract under ADR-0027), so an
+// inspect error is deliberately not propagated as fatal: skew detection degrades
+// to "no warning", never a broken launch.
+func BakedCLIVersion(ctx context.Context, runner Runner, runtimeName, image string) string {
+	return imageLabel(ctx, runner, runtimeName, image, CLIVersionLabel)
 }
 
 // DevcontainerMetadataLabel is the OCI image label the devcontainer CLI
@@ -697,23 +728,7 @@ const DevcontainerMetadataLabel = "devcontainer.metadata"
 // layer", never a broken startup. This mirrors BakedMCPVersion's fail-soft
 // posture and inspect plumbing.
 func ImageMetadataLabel(ctx context.Context, runner Runner, runtimeName, image string) string {
-	if runner == nil {
-		runner = execRunner{}
-	}
-	var stdout bytes.Buffer
-	format := "{{ index .Config.Labels \"" + DevcontainerMetadataLabel + "\" }}"
-	args := []string{"image", "inspect", "--format", format, image}
-	if err := runner.Run(ctx, runtimeName, args, &stdout, io.Discard); err != nil {
-		return ""
-	}
-	out := strings.TrimSpace(stdout.String())
-	// An image with no labels at all renders the missing key as the Go
-	// template "<no value>" sentinel rather than an empty string; treat it
-	// as "no metadata".
-	if out == "<no value>" {
-		return ""
-	}
-	return out
+	return imageLabel(ctx, runner, runtimeName, image, DevcontainerMetadataLabel)
 }
 
 // Run starts a one-shot sandbox container for an agent command.

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -2035,6 +2035,73 @@ func TestBakedMCPVersion_InspectArgs(t *testing.T) {
 	}
 }
 
+// --- BakedCLIVersion ai.aileron.cli.version detection (#1809) ---
+
+func TestBakedCLIVersion(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		runErr error
+		want   string
+	}{
+		{name: "baked", stdout: "0.0.42\n", want: "0.0.42"},
+		{name: "trailing and leading whitespace", stdout: "  0.0.42  \n", want: "0.0.42"},
+		{name: "unlabeled empty", stdout: "\n", want: ""},
+		{name: "no labels sentinel", stdout: "<no value>\n", want: ""},
+		{name: "inspect error not baked", stdout: "", runErr: errors.New("no such image"), want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := runnerFunc(func(_ context.Context, _ string, _ []string, stdout, _ io.Writer) error {
+				if tc.runErr != nil {
+					return tc.runErr
+				}
+				_, _ = io.WriteString(stdout, tc.stdout)
+				return nil
+			})
+			got := BakedCLIVersion(context.Background(), runner, "docker", "img:test")
+			if got != tc.want {
+				t.Fatalf("BakedCLIVersion = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBakedCLIVersion_InspectArgs(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := runnerFunc(func(_ context.Context, name string, args []string, stdout, _ io.Writer) error {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		_, _ = io.WriteString(stdout, "0.0.1\n")
+		return nil
+	})
+	BakedCLIVersion(context.Background(), runner, "docker", "ghcr.io/acme/base:latest")
+	if gotName != "docker" {
+		t.Fatalf("runtime name = %q, want docker", gotName)
+	}
+	want := []string{
+		"image", "inspect",
+		"--format", `{{ index .Config.Labels "ai.aileron.cli.version" }}`,
+		"ghcr.io/acme/base:latest",
+	}
+	if !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("inspect args = %v, want %v", gotArgs, want)
+	}
+}
+
+// TestBakedCLIVersion_NilRunnerDefaults proves a nil Runner degrades to the
+// production exec runner rather than panicking. The inspect targets a
+// guaranteed-absent image so the exec path returns an error and the function
+// fail-softs to "".
+func TestBakedCLIVersion_NilRunnerDefaults(t *testing.T) {
+	got := BakedCLIVersion(context.Background(), nil, DefaultRuntime,
+		"aileron-nonexistent-image-for-test:doesnotexist")
+	if got != "" {
+		t.Fatalf("BakedCLIVersion(nil runner, absent image) = %q, want \"\"", got)
+	}
+}
+
 // --- ImageMetadataLabel devcontainer.metadata detection (#1322) ---
 
 func TestImageMetadataLabel(t *testing.T) {


### PR DESCRIPTION
## Summary

Booting a pinned rung-1/rung-2 image re-enters the aileron binary baked into that image against the host CLI that started the launch (ADR-0027 / #1731). When the two sides are on different releases the baked binary runs against a mismatched host launch, which is worth a heads-up but should never fail the launch.

This adds a fail-soft preflight in `containerImageRunner.Run` that reads the image's `ai.aileron.cli.version` label (stamped in #1811) and compares it to the host CLI version (`internal/version.Version`):

- **mismatch** prints one stderr warning naming both versions and the image, then boots the exact pin anyway;
- **match** stays silent (stdout of `aileron skill launch` stays byte-identical, no OK line);
- **unlabeled / uninspectable image** stays silent, because a custom image's contract is the operator's responsibility under ADR-0027;
- an inspect failure degrades to `""` and stays silent. The launch never fails on skew.

### Changes
- `internal/sandbox/container/runtime.go`: add `CLIVersionLabel` + `BakedCLIVersion` mirroring `BakedMCPVersion`, and factor the triplicated inspect plumbing (`BakedMCPVersion`, `ImageMetadataLabel`, `BakedCLIVersion`) into one shared `imageLabel` helper. Behavior-preserving for the existing two readers.
- `cmd/aileron/skill_launch_container.go`: add the `containerBakedCLIVersion` package-var seam (keeps unit tests Docker-free), an injectable `diag io.Writer` on the runner (nil means `os.Stderr`), and the `reportBakedCLIVersion` skew helper. Preflight runs after `ResolveRuntime` and before the boot.
- `docs/src/content/docs/development/launch-surfaces-spec.md`: document the check under the common Launch contract.

Out of scope (per plan): the rung-3 tool-image path, `aileron sandbox check`, hard-fail/`--strict` modes, ADR/manifest-spec doc updates, Containerfile changes (done in #1811). No OpenAPI surface touched.

## Test plan
- `go test ./cmd/aileron/ ./internal/sandbox/container/` green; coverage 86.3% / 92.2%.
- New container-package tests mirror the MCP reader: table (baked, whitespace, unlabeled-empty, `<no value>` sentinel, inspect error), exact inspect argv, nil-runner fail-soft.
- New CLI tests assert the three cases end-to-end through `Run` (mismatch warns naming both versions + image and still boots the exact pin; match silent; missing label silent), the preflight consults the pin (never re-resolved), the zero-value `diag` defaults to `os.Stderr`, and the helper's three-way contract directly.
- `stubContainerBoot` now stubs the CLI-version seam to `""` so every pre-existing `Run` test stays Docker-free and warning-silent.

Closes #1809
Refs #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
