### PR TITLE
feat(flightplan): resolve a default aileron runner image when rung-1 declares no ref

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 	"github.com/ALRubinger/aileron/internal/sandbox/container"
+	cliversion "github.com/ALRubinger/aileron/internal/version"
 )
 
 // newDigestResolver and newFeatureComposer are package-level seams so CLI
@@ -47,6 +48,7 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 
 	res, err := freeze.Run(context.Background(), raw, freeze.Options{
 		Version:        *version,
+		CLIVersion:     cliversion.Version,
 		SigningKeyPath: *signingKey,
 		Resolver:       newDigestResolver(),
 		Composer:       newFeatureComposer(),

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -346,6 +346,79 @@ aileron:
 	}
 }
 
+// TestRunSkillFreeze_Rung1DefaultImage is the #1808 CLI acceptance: a skill
+// whose executionEnvironment declares rung1Image with no ref freezes to a pin
+// of the Aileron-provided default runner image for the CLI's build version.
+// Test binaries carry version.Version == "dev", so the default resolves the
+// sandbox-base :edge tag; the stored lockfile records that concrete ref plus
+// the fake digest.
+func TestRunSkillFreeze_Rung1DefaultImage(t *testing.T) {
+	storeDir := withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	const rung1DefaultMD = `---
+name: rung1-default-skill
+description: Rung-1 skill using the default Aileron runner image.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung1Image: {}
+  inputs: []
+  outputs: []
+---
+
+# Rung 1 Default
+`
+	dir := filepath.Join(storeDir, "rung1-default-skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(rung1DefaultMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "rung1-default-skill"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("a default rung-1 freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("rung1-default-skill")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("FrozenVersions = %v, %v", ids, err)
+	}
+	v, err := s.ReadFrozen("rung1-default-skill", ids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRef := composition.BaseImage("dev")
+	if !strings.Contains(string(v.Lockfile), wantRef) {
+		t.Errorf("a default rung-1 freeze must pin the default runner image %q, lockfile:\n%s", wantRef, v.Lockfile)
+	}
+	if !strings.Contains(string(v.Lockfile), fakeFreezeDigest) {
+		t.Errorf("a default rung-1 freeze must pin the resolved digest, lockfile:\n%s", v.Lockfile)
+	}
+	if len(v.Signature) == 0 {
+		t.Error("a default rung-1 freeze must still be signed")
+	}
+}
+
 func TestRunSkillFreeze_FromPath(t *testing.T) {
 	withTempStore(t)
 	stubFreezeResolvers(t, fakeFreezeDigest)

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -117,13 +117,12 @@
       "properties": {
         "rung1Image": {
           "type": "object",
-          "description": "Rung one. The skill names a whole prebuilt image and freeze resolves it to a digest. The operator owns the image.",
+          "description": "Rung one. The skill runs in a whole prebuilt image and freeze resolves it to a digest pin. Omit ref to select the Aileron-provided runner image for the freezing CLI's version; a workload names its own image only for workload-specific tooling. Write rung1Image: {} for the default (a bare rung1Image: key with no value parses as null and is rejected).",
           "additionalProperties": false,
-          "required": ["ref"],
           "properties": {
             "ref": {
               "type": "string",
-              "description": "An OCI image reference. Pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+              "description": "An optional OCI image reference. Omit it to select the Aileron-provided runner image for the freezing CLI's version. When present, pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves the selected image to an image@sha256: digest pin recorded in the lock section.",
               "minLength": 1
             }
           }

--- a/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
+++ b/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
@@ -60,7 +60,7 @@ The no-LLM-at-runtime rule seals the agent and the LLM out of the function, not 
 
 A Flight Plan runs on a composed execution image, and that image is assembled from rungs.
 
-Rung one pins a whole prebuilt image. The skill names an image, and freeze resolves it to a digest. The operator owns that image.
+Rung one pins a whole prebuilt image. The skill names an image, and freeze resolves it to a digest. The runner image is an implementation detail of the launch runtime. When a rung-one declaration names no image, freeze resolves the Aileron-provided runner image for the freezing CLI's version and records that concrete reference plus its digest pin in the lock. A workload names its own image only for workload-specific tooling.
 
 Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result. The capability-unit shape is the one defined in [ADR-0026](/adr/0026-cli-capability-units).
 

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -81,8 +81,8 @@ The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-se
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|
-| `rung1Image` | object | No | Rung one. Names a whole prebuilt operator-owned image. Freeze resolves it to a digest. |
-| `rung1Image.ref` | string | Yes within `rung1Image` | An OCI image reference. Freeze resolves a tag to an `image@sha256:` digest pin. |
+| `rung1Image` | object | No | Rung one. The skill runs in a whole prebuilt image. Freeze resolves it to a digest. Write `rung1Image: {}` to select the Aileron-provided runner image. |
+| `rung1Image.ref` | string | No | An optional OCI image reference. Omit it to resolve the Aileron-provided runner image for the freezing CLI's version. Freeze records the concrete ref plus an `image@sha256:` digest pin in the lock. A bare `rung1Image:` key with no value is null and is rejected, so authors write `rung1Image: {}` for the default. |
 | `rung2CapabilityUnits` | object | No | Rung two. Declares capability units composed onto the Aileron agent-free base image. |
 | `rung2CapabilityUnits.features` | array | Yes within `rung2CapabilityUnits` | The capability-unit devcontainer Feature references ([ADR-0026](/adr/0026-cli-capability-units)). |
 | `rung3PerStepImages` | object | No | Rung three. Per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Freeze resolves each step's sibling image to a digest pin recorded in the lock. |
@@ -267,6 +267,6 @@ The version is the content hash plus a semver label. The content hash identifies
 
 ## Execution rungs
 
-A Flight Plan runs on a composed execution image assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). Rung one pins a whole prebuilt operator-owned image, declared as `rung1Image`. Rung two declares capability units that Aileron composes onto a generic agent-free minimal base image, declared as `rung2CapabilityUnits` whose Features follow [ADR-0026](/adr/0026-cli-capability-units).
+A Flight Plan runs on a composed execution image assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). Rung one pins a whole prebuilt image, declared as `rung1Image`. The runner image is an implementation detail of the launch runtime. A workload names its own image under `rung1Image.ref` only for workload-specific tooling. When `rung1Image` declares no ref, freeze resolves the Aileron-provided runner image for the freezing CLI's version and records that concrete ref plus its digest pin in the lock. Rung two declares capability units that Aileron composes onto a generic agent-free minimal base image, declared as `rung2CapabilityUnits` whose Features follow [ADR-0026](/adr/0026-cli-capability-units).
 
 Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O carried in the `rung3PerStepImages` rung. Freeze resolves each step's sibling image to a content-addressed digest pinned in the lock. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.

--- a/internal/flightplan/freeze/freeze.go
+++ b/internal/flightplan/freeze/freeze.go
@@ -55,6 +55,13 @@ type Options struct {
 	// Version is the semver label recorded in the lock. Optional; empty
 	// records no version label.
 	Version string
+	// CLIVersion is the Aileron CLI build version that drives the default
+	// rung-1 runner image reference when a rung1Image declares no ref (#1808).
+	// It is distinct from Version (the skill's semver label): CLIVersion picks
+	// the floating sandbox-base tag the default resolves from. An empty value
+	// behaves as a dev build (resolves the :edge tag), matching the CLI's
+	// version default.
+	CLIVersion string
 	// SigningKeyPath is the path to the PEM ed25519 private key. Empty falls
 	// back to $AILERON_SIGNING_KEY (see LoadSigningKey).
 	SigningKeyPath string
@@ -93,7 +100,7 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	pins, capSet, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
+	pins, capSet, err := resolveImages(ctx, m, opts.Resolver, opts.Composer, opts.CLIVersion)
 	if err != nil {
 		return Result{}, err
 	}

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -128,6 +128,66 @@ func TestRun_Rung3PinsAndSigns(t *testing.T) {
 	}
 }
 
+// TestRun_Rung1DefaultImagePinsAndSigns is the #1808 end-to-end acceptance: a
+// full freeze over a rung-1 manifest that declares no ref pins the concrete
+// Aileron-provided default runner image for the CLI version plus its resolved
+// digest, and the produced signature verifies over the bytes that include that
+// pin. A dev CLIVersion selects the :edge tag.
+func TestRun_Rung1DefaultImagePinsAndSigns(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	res, err := Run(context.Background(), []byte(rung1DefaultMD), Options{
+		Version:        "1.0.0",
+		CLIVersion:     "dev",
+		SigningKeyPath: keyPath,
+		Resolver:       dr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantRef := "ghcr.io/alrubinger/aileron-sandbox-base:edge"
+	if gotRef != wantRef {
+		t.Errorf("resolver got ref %q, want the default runner image %q", gotRef, wantRef)
+	}
+	if len(res.Lock.ResolvedImages) != 1 {
+		t.Fatalf("a default rung-1 freeze must pin one image, got %+v", res.Lock.ResolvedImages)
+	}
+	if res.Lock.ResolvedImages[0].Ref != wantRef || res.Lock.ResolvedImages[0].Digest != fakeDigest {
+		t.Errorf("lock must record the concrete default ref + digest, got %+v", res.Lock.ResolvedImages[0])
+	}
+	if len(res.Lock.ResolvedCapabilitySet) != 0 {
+		t.Errorf("rung-1 pins no capability set, got %v", res.Lock.ResolvedCapabilitySet)
+	}
+
+	// The signature verifies over the canonical content bytes, so the default
+	// pin is covered by the plan content hash and signature.
+	lockNoHash := res.Lock.withoutContentHash()
+	mNoHash, err := injectLock([]byte(rung1DefaultMD), lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lfNoHash, err := MarshalLockfile(lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(canonicalContent(mNoHash, lfNoHash), res.Signature, res.PublicKey); err != nil {
+		t.Errorf("signature must verify over the default pin: %v", err)
+	}
+
+	// The frozen manifest re-parses with the lock present, carrying the pin.
+	fm, err := manifest.Parse(res.FrozenManifest)
+	if err != nil {
+		t.Fatalf("frozen default rung-1 manifest must re-parse: %v", err)
+	}
+	if fm.Aileron.Lock["contentHash"] != res.ContentHash {
+		t.Errorf("frozen manifest lock.contentHash = %v, want %v", fm.Aileron.Lock["contentHash"], res.ContentHash)
+	}
+}
+
 // TestRun_Rung3SealsTrustContractReach is the #1775 end-to-end acceptance: a
 // full freeze over a rung-3 manifest with a per-step trust contract records the
 // declared hosts on the step's lock pin, and the produced signature verifies

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 )
 
 // digestPattern is the schema's content-addressed digest shape. A
@@ -65,7 +66,9 @@ const rung3Name = "rung3PerStepImages"
 //
 //   - instruction-only / no executionEnvironment: empty pins, no error
 //     (the skill still gets a contentHash and signature);
-//   - rung-1 (rung1Image.ref): resolve the named image to a digest pin;
+//   - rung-1 (rung1Image): resolve the named image to a digest pin, or when
+//     rung1Image.ref is omitted, resolve the Aileron-provided runner image for
+//     cliVersion (composition.BaseImage) to a digest pin (#1808);
 //   - rung-2 (rung2CapabilityUnits.features): compose the Features and pin
 //     the built image's digest plus the resolved capability set;
 //   - rung-3 (rung3PerStepImages.steps[].image): resolve each per-step
@@ -76,7 +79,12 @@ const rung3Name = "rung3PerStepImages"
 //
 // Every resolved digest is checked against digestPattern: a resolver that
 // yields a tag rather than a digest is rejected (pin by digest, never tag).
-func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, err error) {
+// cliVersion is the Aileron CLI build version used to resolve the default
+// rung-1 runner image when a rung1Image declares no ref. It selects the
+// floating sandbox-base tag (dev/empty maps to :edge, a release maps to
+// :latest) through composition.BaseImage. It is distinct from the skill's
+// semver label recorded in the lock (Options.Version).
+func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer, cliVersion string) (pins []ImagePin, capSet []string, err error) {
 	if m == nil || m.InstructionOnly {
 		return nil, nil, nil
 	}
@@ -97,6 +105,14 @@ func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver,
 		ref, err := rung1ImageRef(rung1)
 		if err != nil {
 			return nil, nil, err
+		}
+		if ref == "" {
+			// No ref declared: resolve the Aileron-provided runner image for the
+			// freezing CLI's version (#1808). The default flows through the same
+			// named-ref resolution below (resolver, requireDigest, digest pin), so
+			// the lock records the concrete resolved ref plus digest exactly as a
+			// named ref does.
+			ref = composition.BaseImage(cliVersion)
 		}
 		if dr == nil {
 			return nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
@@ -185,17 +201,26 @@ func requireDigest(ref, digest string) error {
 }
 
 // rung1ImageRef extracts rung1Image.ref from the untyped execution
-// environment block. The ref MUST be a real string: a non-string scalar
-// coerced into an image reference would silently produce a bad pin, so a
-// non-string ref is rejected here rather than stringified.
+// environment block. An absent ref key is the default-runner contract
+// (#1808): it returns ("", nil), meaning "resolve the Aileron-provided
+// runner image for this CLI version". A ref key that IS present but is not a
+// real, non-empty string (non-string scalar, null, empty, or whitespace-only)
+// is a hard error, not a default: coercing it into an image reference would
+// silently produce a bad pin, and an explicit empty-string ref stays rejected
+// exactly as the schema rejects it.
 func rung1ImageRef(v any) (string, error) {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("freeze: rung1Image is not a mapping")
 	}
-	ref, ok := m["ref"].(string)
+	raw, present := m["ref"]
+	if !present {
+		// No ref declared: use the default Aileron runner image (#1808).
+		return "", nil
+	}
+	ref, ok := raw.(string)
 	if !ok || strings.TrimSpace(ref) == "" {
-		return "", fmt.Errorf("freeze: rung1Image.ref is missing, empty, or not a string")
+		return "", fmt.Errorf("freeze: rung1Image.ref is present but empty or not a string")
 	}
 	return strings.TrimSpace(ref), nil
 }

--- a/internal/flightplan/freeze/images_malformed_test.go
+++ b/internal/flightplan/freeze/images_malformed_test.go
@@ -33,7 +33,7 @@ func TestResolveImages_BothRungsRejected(t *testing.T) {
 		"rung1Image":           map[string]any{"ref": "a:1"},
 		"rung2CapabilityUnits": map[string]any{"features": []any{"f"}},
 	})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("declaring both rungs must error")
 	}
 }
@@ -43,84 +43,98 @@ func TestResolveImages_Rung3AlongsideRung1Rejected(t *testing.T) {
 		"rung1Image":         map[string]any{"ref": "a:1"},
 		"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": "b:1"}}},
 	})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("declaring rung-3 alongside rung-1 must error (exactly one image rung)")
 	}
 }
 
-func TestResolveImages_Rung1MissingRef(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
-		t.Error("rung1Image with no ref must error")
+// TestResolveImages_Rung1InvalidRef proves that a rung1Image whose ref key is
+// present but not a real, non-empty string stays rejected at the freeze
+// backstop (an absent key is the default and is covered separately). An empty
+// string, a non-string scalar, and a null are each a hard error, never coerced
+// into a default or a bad pin.
+func TestResolveImages_Rung1InvalidRef(t *testing.T) {
+	cases := map[string]any{
+		"empty string": "",
+		"non-string":   7,
+		"null":         nil,
+	}
+	for name, ref := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{"ref": ref}})
+			if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
+				t.Errorf("rung1Image with a %s ref must error", name)
+			}
+		})
 	}
 }
 
 func TestResolveImages_Rung1NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung1Image": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("rung1Image that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatures(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
 		t.Error("rung2 with empty features must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatureEntry(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{""}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
 		t.Error("rung2 with an empty feature entry must error")
 	}
 }
 
 func TestResolveImages_Rung2NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
 		t.Error("rung2CapabilityUnits that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung3NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("rung3PerStepImages that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung3MissingSteps(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("rung3PerStepImages with no steps must error")
 	}
 }
 
 func TestResolveImages_Rung3EmptySteps(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("rung3PerStepImages with an empty steps list must error")
 	}
 }
 
 func TestResolveImages_Rung3StepNotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{"scalar"}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 step that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung3StepEmptyImage(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": ""}}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 step with an empty image must error")
 	}
 }
 
 func TestResolveImages_Rung3StepNonStringImage(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": 42}}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 step with a non-string image must error")
 	}
 }
@@ -129,7 +143,7 @@ func TestResolveImages_Rung3TrustContractNotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
 		map[string]any{"image": "b:1", "trustContract": "scalar"},
 	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 step whose trustContract is not a mapping must error")
 	}
 }
@@ -138,7 +152,7 @@ func TestResolveImages_Rung3TrustContractNoHosts(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
 		map[string]any{"image": "b:1", "trustContract": map[string]any{"effect": "read"}},
 	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 trustContract with no hosts must error")
 	}
 }
@@ -147,7 +161,7 @@ func TestResolveImages_Rung3TrustContractNonStringHost(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
 		map[string]any{"image": "b:1", "trustContract": map[string]any{"hosts": []any{42}}},
 	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 trustContract with a non-string host must error")
 	}
 }
@@ -156,14 +170,14 @@ func TestResolveImages_Rung3TrustContractEmptyHosts(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
 		map[string]any{"image": "b:1", "trustContract": map[string]any{"hosts": []any{}}},
 	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
 		t.Error("a rung-3 trustContract with an empty hosts list must error")
 	}
 }
 
 func TestResolveImages_NeitherRung(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"somethingElse": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("an executionEnvironment with neither rung must error")
 	}
 }

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -25,7 +25,7 @@ func TestResolveImages_Rung1ResolvesToDigest(t *testing.T) {
 		gotRef = ref
 		return fakeDigest, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -40,6 +40,97 @@ func TestResolveImages_Rung1ResolvesToDigest(t *testing.T) {
 	}
 }
 
+// TestResolveImages_Rung1DefaultResolvesBaseImage is the #1808 acceptance
+// proof: a rung-1 manifest that declares no ref resolves the Aileron-provided
+// runner image for the CLI version. A dev CLI version selects the :edge tag;
+// the resolver receives that concrete ref and the pin records it plus the
+// resolved digest, exactly as a named ref would.
+func TestResolveImages_Rung1DefaultResolvesBaseImage(t *testing.T) {
+	m := parseM(t, []byte(rung1DefaultMD))
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "dev")
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	wantRef := "ghcr.io/alrubinger/aileron-sandbox-base:edge"
+	if gotRef != wantRef {
+		t.Errorf("resolver got ref %q, want the default runner image %q", gotRef, wantRef)
+	}
+	if len(pins) != 1 || pins[0].Ref != wantRef || pins[0].Digest != fakeDigest {
+		t.Errorf("default rung-1 must pin the concrete default ref + digest, got %+v", pins)
+	}
+	if capSet != nil {
+		t.Errorf("rung-1 must have no capability set, got %v", capSet)
+	}
+}
+
+// TestResolveImages_Rung1DefaultReleaseUsesLatest proves the CLI-version tag
+// split at the freeze contract: a real release version resolves the default
+// runner image at :latest (not :edge), matching composition.imageTag.
+func TestResolveImages_Rung1DefaultReleaseUsesLatest(t *testing.T) {
+	m := parseM(t, []byte(rung1DefaultMD))
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, nil, "0.0.3"); err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if want := "ghcr.io/alrubinger/aileron-sandbox-base:latest"; gotRef != want {
+		t.Errorf("a release CLI version must resolve the default at %q, got %q", want, gotRef)
+	}
+}
+
+// TestResolveImages_Rung1DefaultEmptyCLIVersionIsEdge proves an empty
+// CLIVersion behaves as a dev build (resolves :edge), matching the CLI's
+// version default.
+func TestResolveImages_Rung1DefaultEmptyCLIVersionIsEdge(t *testing.T) {
+	m := parseM(t, []byte(rung1DefaultMD))
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, nil, ""); err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if want := "ghcr.io/alrubinger/aileron-sandbox-base:edge"; gotRef != want {
+		t.Errorf("an empty CLI version must resolve the default at %q, got %q", want, gotRef)
+	}
+}
+
+// TestResolveImages_Rung1DefaultNeedsResolver proves the defaulted rung-1 path
+// shares the nil-resolver guard: a default-runner manifest with no resolver
+// errors rather than silently pinning nothing.
+func TestResolveImages_Rung1DefaultNeedsResolver(t *testing.T) {
+	m := parseM(t, []byte(rung1DefaultMD))
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, "dev"); err == nil {
+		t.Error("a defaulted rung-1 manifest with no resolver must error")
+	}
+}
+
+// TestResolveImages_Rung1DefaultRejectsTagNotDigest proves the defaulted
+// rung-1 path shares the pin-by-digest guard: a resolver that yields a tag
+// rather than a digest is rejected.
+func TestResolveImages_Rung1DefaultRejectsTagNotDigest(t *testing.T) {
+	m := parseM(t, []byte(rung1DefaultMD))
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		return ref, nil // echo the tag, not a digest
+	})
+	_, _, err := resolveImages(context.Background(), m, dr, nil, "dev")
+	if err == nil {
+		t.Fatal("a defaulted rung-1 resolver returning a tag must be rejected")
+	}
+	if !strings.Contains(err.Error(), "digest") {
+		t.Errorf("error should explain the pin-by-digest rule, got: %v", err)
+	}
+}
+
 func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
 	var gotFeatures []string
@@ -47,7 +138,7 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 		gotFeatures = features
 		return fakeDigest, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, nil, fc)
+	pins, capSet, err := resolveImages(context.Background(), m, nil, fc, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -68,7 +159,7 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 
 func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 	m := parseM(t, []byte(instructionOnlyMD))
-	pins, capSet, err := resolveImages(context.Background(), m, nil, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, nil, nil, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -79,7 +170,7 @@ func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 
 func TestResolveImages_NoExecEnvEmpty(t *testing.T) {
 	m := parseM(t, []byte(noExecEnvMD))
-	pins, _, err := resolveImages(context.Background(), m, nil, nil)
+	pins, _, err := resolveImages(context.Background(), m, nil, nil, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -93,7 +184,7 @@ func TestResolveImages_RejectsTagNotDigest(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "registry.example.com/runner:1.4", nil // a tag, not a digest
 	})
-	_, _, err := resolveImages(context.Background(), m, dr, nil)
+	_, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err == nil {
 		t.Fatal("a resolver returning a tag must be rejected")
 	}
@@ -107,21 +198,21 @@ func TestResolveImages_ResolverError(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "", errors.New("image not found")
 	})
-	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dr, nil, ""); err == nil {
 		t.Error("an unresolvable image must error")
 	}
 }
 
 func TestResolveImages_Rung1NeedsResolver(t *testing.T) {
 	m := parseM(t, []byte(rung1MD))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("a rung-1 manifest with no resolver must error")
 	}
 }
 
 func TestResolveImages_Rung2NeedsComposer(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("a rung-2 manifest with no composer must error")
 	}
 }
@@ -153,7 +244,7 @@ func TestResolveImages_Rung3ResolvesPerStepDigests(t *testing.T) {
 		gotRefs = append(gotRefs, ref)
 		return digestFor[ref], nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("rung-3 resolution must succeed: %v", err)
 	}
@@ -184,7 +275,7 @@ func TestResolveImages_Rung3SharedTagPinsDistinctlyByID(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return fakeDigest, nil
 	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil)
+	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("shared-tag rung-3 resolution must succeed: %v", err)
 	}
@@ -216,7 +307,7 @@ func TestResolveImages_Rung3PositionalIDFallback(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
 		return digestFor[ref], nil
 	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil)
+	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("no-id rung-3 resolution must succeed: %v", err)
 	}
@@ -241,7 +332,7 @@ func TestResolveImages_Rung3SealsTrustContractHosts(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
 		return digestFor[ref], nil
 	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil)
+	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -276,7 +367,7 @@ func TestResolveImages_Rung1PinCarriesNoStepID(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return fakeDigest, nil
 	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil)
+	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -293,7 +384,7 @@ func TestResolveImages_Rung3RejectsTagNotDigest(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "registry.example.com/per-step-tool:1", nil // a tag, not a digest
 	})
-	_, _, err := resolveImages(context.Background(), m, dr, nil)
+	_, _, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err == nil {
 		t.Fatal("a rung-3 resolver returning a tag must be rejected")
 	}
@@ -309,7 +400,7 @@ func TestResolveImages_Rung3ResolverError(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "", errors.New("image not found")
 	})
-	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dr, nil, ""); err == nil {
 		t.Error("an unresolvable rung-3 image must error")
 	}
 }
@@ -319,7 +410,7 @@ func TestResolveImages_Rung3ResolverError(t *testing.T) {
 // pinning nothing (mirrors the rung-1 nil-resolver contract).
 func TestResolveImages_Rung3NeedsResolver(t *testing.T) {
 	m := parseM(t, []byte(rung3MD))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
 		t.Error("a rung-3 manifest with no resolver must error")
 	}
 }
@@ -357,11 +448,11 @@ func TestResolveImages_DistinctFeatureSetsDistinctPins(t *testing.T) {
 		}
 	}
 
-	pinsA, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	pinsA, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc, "")
 	if err != nil {
 		t.Fatalf("compose feature set A: %v", err)
 	}
-	pinsB, _, err := resolveImages(context.Background(), mWithFeatures("b"), nil, fc)
+	pinsB, _, err := resolveImages(context.Background(), mWithFeatures("b"), nil, fc, "")
 	if err != nil {
 		t.Fatalf("compose feature set B: %v", err)
 	}
@@ -372,7 +463,7 @@ func TestResolveImages_DistinctFeatureSetsDistinctPins(t *testing.T) {
 		t.Errorf("distinct Feature sets must produce distinct pinned digests, both pinned %q", pinsA[0].Digest)
 	}
 	// Same feature set must reproduce the same pin (determinism).
-	pinsA2, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	pinsA2, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc, "")
 	if err != nil {
 		t.Fatalf("recompose feature set A: %v", err)
 	}
@@ -393,7 +484,7 @@ func TestFreeze_Rung1WorkedExample(t *testing.T) {
 		gotRef = ref
 		return fakeDigest, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "")
 	if err != nil {
 		t.Fatalf("freeze rung-1 worked example: %v", err)
 	}

--- a/internal/flightplan/freeze/testdata_test.go
+++ b/internal/flightplan/freeze/testdata_test.go
@@ -95,6 +95,38 @@ aileron:
 # Rung 1 Skill
 `
 
+// rung1DefaultMD is a minimal valid rung-1 manifest that declares no ref
+// under rung1Image, so freeze resolves the Aileron-provided default runner
+// image for the CLI version (#1808). It exercises the Unit-1 schema through
+// manifest.Parse (rung1Image: {} is valid).
+const rung1DefaultMD = `---
+name: rung1-default-skill
+description: A rung-1 skill using the default Aileron runner image.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung1Image: {}
+  inputs: []
+  outputs: []
+---
+
+# Rung 1 Default Skill
+`
+
 // noExecEnvMD is a valid manifest with an aileron block but no
 // executionEnvironment (composition-only, no images to resolve).
 const noExecEnvMD = `---

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -117,13 +117,12 @@
       "properties": {
         "rung1Image": {
           "type": "object",
-          "description": "Rung one. The skill names a whole prebuilt image and freeze resolves it to a digest. The operator owns the image.",
+          "description": "Rung one. The skill runs in a whole prebuilt image and freeze resolves it to a digest pin. Omit ref to select the Aileron-provided runner image for the freezing CLI's version; a workload names its own image only for workload-specific tooling. Write rung1Image: {} for the default (a bare rung1Image: key with no value parses as null and is rejected).",
           "additionalProperties": false,
-          "required": ["ref"],
           "properties": {
             "ref": {
               "type": "string",
-              "description": "An OCI image reference. Pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+              "description": "An optional OCI image reference. Omit it to select the Aileron-provided runner image for the freezing CLI's version. When present, pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves the selected image to an image@sha256: digest pin recorded in the lock section.",
               "minLength": 1
             }
           }

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -343,6 +343,7 @@ func TestExecutionEnvironmentRungValidity(t *testing.T) {
 	valid := map[string]string{
 		"rung1 only": `      rung1Image:
         ref: registry.example.com/runner:1.4`,
+		"rung1 with no ref": `      rung1Image: {}`,
 		"rung2 only": `      rung2CapabilityUnits:
         features:
           - ghcr.io/example/aileron-feature-metrics-cli:1`,
@@ -380,6 +381,10 @@ func TestExecutionEnvironmentRungValidity(t *testing.T) {
 		"rung3 with empty steps rejected": `      rung3PerStepImages:
         steps: []`,
 		"empty executionEnvironment rejected": `      {}`,
+		"rung1 empty-string ref rejected": `      rung1Image:
+        ref: ""`,
+		"rung1 non-string ref rejected": `      rung1Image:
+        ref: 7`,
 	}
 	for name, env := range invalid {
 		t.Run("invalid/"+name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

A rung-1 execution environment may now declare `rung1Image` with no `ref`, and freeze resolves the Aileron-provided runner image for the freezing CLI's version rather than hard-erroring. The default flows through the existing named-ref path unchanged: same resolver seam, same pin-by-digest enforcement, so the lock records the concrete resolved ref plus its `sha256:` digest exactly as a named ref does.

- **Schema** (`docs/` + embedded mirror, kept byte-identical): `rung1Image.ref` is now optional. `rung1Image: {}` is valid and means "the Aileron-provided runner image for this CLI version". An explicit `ref: ""` and non-string refs stay rejected (`minLength: 1`, `type: string`). A bare `rung1Image:` key with no value parses as null and stays rejected.
- **Freeze core**: `rung1ImageRef` now distinguishes an absent ref key (returns `("", nil)`, the default contract) from a present-but-invalid ref (empty, non-string, null; still a hard error). `resolveImages` gains a `cliVersion` parameter and, in the defaulted branch, resolves `composition.BaseImage(cliVersion)` before the existing resolver + `requireDigest` guards. `freeze.Options` gains `CLIVersion` (the CLI build version, distinct from `Version`, the skill's semver label). Empty `CLIVersion` maps to `:edge` (dev semantics).
- **CLI**: `runSkillFreeze` wires `CLIVersion: version.Version`.
- **Docs**: manifest spec field table + rung-one prose and ADR-0027 rung-one paragraph updated (amended in place, pre-MVP convention).

Named-ref, rung-2, and rung-3 behavior is byte-for-byte unchanged. No launch/runtime/boot changes (that is #1807's territory); this ends at the lock recording the pinned default.

## Test plan

- `go test ./internal/flightplan/... ./cmd/aileron/... ./internal/sandbox/composition/...` all green.
- Schema: `TestExecutionEnvironmentRungValidity` extended with a valid `rung1 with no ref` case and invalid empty-string / non-string ref cases; `TestEmbeddedSchemaMatchesDoc` (drift guard) passes.
- Freeze: new default-path tests assert the fake resolver receives `ghcr.io/alrubinger/aileron-sandbox-base:edge` for a dev version and `:latest` for a release, that the pin records the concrete ref + digest, and that the defaulted path still errors on a nil resolver and rejects a tag. `TestResolveImages_Rung1MissingRef` reworked into `TestResolveImages_Rung1InvalidRef` (empty / non-string / null). A `Run`-level test asserts the lockfile carries the concrete default ref + digest and signs normally.
- CLI: `TestRunSkillFreeze_Rung1DefaultImage` freezes a `rung1Image: {}` skill and asserts the stored lockfile pins the `:edge` default with the fake digest.
- Coverage: `rung1ImageRef` 100%, `resolveImages` 95.9%; new branches covered.
- `gofmt`, `go vet`, and CodeRabbit review (0 findings) clean.

Closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
