### PR TITLE
docs(flightplan): note defaulted rung-1 runner image in guides

### DIFF
--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -107,7 +107,7 @@ Declare the minimum each action needs. The contract is verbose by design. A plan
 
 `requires.executionEnvironment` declares the image the Flight Plan runs in, as one rung. The three rungs are mutually exclusive, so exactly one is declared.
 
-- `rung1Image.ref` names a whole prebuilt operator-owned image. Freeze resolves a tag to an `image@sha256:` digest pin.
+- `rung1Image.ref` names a whole prebuilt operator-owned image. Freeze resolves a tag to an `image@sha256:` digest pin. `rung1Image.ref` is optional. When `rung1Image` declares no ref (write `rung1Image: {}`), freeze resolves the Aileron-provided runner image for the freezing CLI's version and records that concrete ref plus its digest pin in the lock.
 - `rung2CapabilityUnits.features` declares the capability-unit devcontainer Features composed onto the Aileron agent-free base image. Freeze composes them and pins the built image by digest.
 - `rung3PerStepImages.steps` declares one sibling image per step, each with an optional `id`, `mount`, and `collect`. Freeze resolves each step's image to an `image@sha256:` digest pin recorded in the lock.
 

--- a/docs/src/content/docs/guides/freezing-a-flight-plan.md
+++ b/docs/src/content/docs/guides/freezing-a-flight-plan.md
@@ -10,7 +10,7 @@ Freeze is the author-time step that seals an installed Aileron skill into a Flig
 Freeze runs a fixed sequence over one `SKILL.md` document.
 
 1. It parses and lints the manifest. The lint rejects any step that could reach an LLM outside the marked `llm-seam` (see [the manifest spec](/development/flight-plan-manifest-spec)).
-2. It resolves the execution environment to image digests. A rung-1 `rung1Image.ref` is resolved to its `sha256:` digest. A rung-2 `rung2CapabilityUnits.features` set is composed and the built image is pinned by digest.
+2. It resolves the execution environment to image digests. A rung-1 `rung1Image.ref` is resolved to its `sha256:` digest. When a rung-1 `rung1Image` declares no ref, freeze resolves the Aileron-provided runner image for the freezing CLI's version and records that concrete ref plus its digest pin in the lock. A rung-2 `rung2CapabilityUnits.features` set is composed and the built image is pinned by digest.
 3. It builds the lockfile. The lockfile records the resolved image pins, the resolved capability set, the content hash, and the semver label.
 4. It content-addresses the unit. The content hash is a `sha256` over the canonical frozen manifest bytes plus the lockfile bytes.
 5. It signs the content with a detached ed25519 signature.


### PR DESCRIPTION
## Summary

PR #1815 made `rung1Image.ref` optional: when a rung-1 `rung1Image` declares no ref (written `rung1Image: {}`), freeze resolves the Aileron-provided runner image for the freezing CLI's version and records that concrete ref plus its digest pin in the lock. That PR updated the manifest spec field table and ADR-0027, but left two guides describing `ref` as always-present:

- `docs/src/content/docs/guides/authoring-a-flight-plan.md` (rung-1 bullet) — added the optional/defaulted-runner sentence.
- `docs/src/content/docs/guides/freezing-a-flight-plan.md` (freeze-sequence step 2) — added the defaulted-runner sentence to the resolve step.

Both use wording consistent with the already-landed spec and ADR-0027 text.

## Test plan

Doc-only change (prose in two Starlight `.md` guides). No code, tests, generated files, or schema touched. Verified the two guides were the only remaining docs describing `rung1Image.ref` as always-present after #1815; the manifest spec and ADR-0027 already carry the defaulted-runner wording.

Closes #1813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
