### PR TITLE
test(cli): assert newLaunchImageRunner wires nil diag

### DIFF
--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -240,6 +240,9 @@ func TestNewLaunchImageRunner_WiresDaemonEnvResolver(t *testing.T) {
 	if _, ok := runner.daemonEnv.(daemonImageEnv); !ok {
 		t.Errorf("daemonEnv = %T, want daemonImageEnv (the production resolver)", runner.daemonEnv)
 	}
+	if runner.diag != nil {
+		t.Errorf("newLaunchImageRunner diag = %v, want nil (os.Stderr in production)", runner.diag)
+	}
 }
 
 // --- CLI-version skew preflight (#1809) ---


### PR DESCRIPTION
## Summary

Adds the operator-authorized production-wiring assertion (cw-review-residual #1812, sub-issue #1809, Decision 2): `TestNewLaunchImageRunner_WiresDaemonEnvResolver` now asserts that the runner returned by `newLaunchImageRunner()` has `diag == nil`, proving production wiring routes diagnostics to `os.Stderr` via the zero-value `diagWriter()` path.

The existing `TestContainerImageRunner_DiagDefaultsToStderr` accessor test is left unchanged, so both the production seam and the accessor default remain covered.

## Test plan

- `go test ./cmd/aileron/ -run 'TestNewLaunchImageRunner_WiresDaemonEnvResolver|TestContainerImageRunner_DiagDefaultsToStderr' -v` — both pass
- `go build ./cmd/aileron/` — OK
- `go test ./cmd/aileron/` — package green

Closes #1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
