### PR TITLE
fix(sandbox,flightplan): let a rung-3 tool dispatch run its baked entrypoint without the agent-sandbox contract

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -306,6 +306,11 @@ func (r containerToolImageRunner) Run(ctx context.Context, spec runtime.ToolRunS
 		Image:   spec.Image,
 		Volumes: volumes,
 		Name:    toolContainerName(spec),
+		// ToolDispatch selects the rung-3 sealed-tool contract in the shared
+		// container builder: the image's baked entrypoint runs with no command,
+		// and no implicit operator-CWD workspace mount is emitted — the tool
+		// sees exactly the declared mounts above and nothing else.
+		ToolDispatch: true,
 	}
 
 	// Credential-injection enrichment (#1769): when a proxy bootstrapper is

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -451,6 +451,15 @@ func TestContainerToolImageRunner_MountsRunsCollects(t *testing.T) {
 	if !strings.HasPrefix(got.Name, "aileron-flightplan-tool-extract-") {
 		t.Errorf("container name = %q, want the stable tool prefix plus a suffix", got.Name)
 	}
+	// The dispatch selects the sealed-tool contract in the shared builder:
+	// entrypoint-only (no command) and no implicit workspace mount. Without it,
+	// Builder.Run refuses the boot with "sandbox command is required".
+	if !got.ToolDispatch {
+		t.Error("RunOptions.ToolDispatch must be set on a rung-3 tool dispatch")
+	}
+	if len(got.Command) != 0 {
+		t.Errorf("Command = %v, want empty (the tool image's baked entrypoint runs)", got.Command)
+	}
 }
 
 // TestContainerToolImageRunner_NoMountNoCollect proves a minimal rung-3 step

--- a/internal/app/sandbox_forward_proxy_sigv4_live_test.go
+++ b/internal/app/sandbox_forward_proxy_sigv4_live_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+)
+
+// TestSandboxForwardProxy_SigV4ResignAgainstRealAWS drives the daemon's real
+// upstream leg (default http.Client — real Transport, real ALPN/h2 negotiation
+// with AWS) end to end against the real Athena endpoint, with the request
+// entering through the same CONNECT/MITM proxy path a rung-3 tool uses. It is
+// the one test that lets AWS itself judge the re-signed signature — the
+// local wire test can't exercise HTTP/2 header serialization to AWS.
+//
+// Gated on env so CI never needs credentials:
+//
+//	AILERON_SIGV4_LIVE_AKID / AILERON_SIGV4_LIVE_SECRET  — a real (throwaway,
+//	read-only) key pair; AILERON_SIGV4_LIVE_REGION defaults us-east-1.
+func TestSandboxForwardProxy_SigV4ResignAgainstRealAWS(t *testing.T) {
+	akid := os.Getenv("AILERON_SIGV4_LIVE_AKID")
+	secret := os.Getenv("AILERON_SIGV4_LIVE_SECRET")
+	if akid == "" || secret == "" {
+		t.Skip("AILERON_SIGV4_LIVE_AKID/SECRET not set; skipping live AWS signature test")
+	}
+	region := os.Getenv("AILERON_SIGV4_LIVE_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	host := "athena." + region + ".amazonaws.com"
+
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-sigv4-live" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte(secret)),
+		hostBindings: mustHostBindingTableOpts(t, host, "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign(akid, region, "athena")),
+		// The REAL upstream leg: default client, real Transport, real AWS.
+		sandboxProxyClient: &http.Client{},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	body := `{}`
+	req, err := http.NewRequest(http.MethodPost, "https://"+host+"/", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AmazonAthena.ListWorkGroups")
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("User-Agent", "aws-cli/2.35.15 md/awscrt#0.35.0 ua/2.1 os/linux#6.12.76-linuxkit md/arch#aarch64 lang/python#3.14.5")
+	req.Header.Set("Amz-Sdk-Invocation-Id", "45b9a48b-67da-4d67-b1b3-a0347fe6f6a7")
+	req.Header.Set("Amz-Sdk-Request", "attempt=1")
+	req.Header.Set("X-Amz-Date", "20260703T000000Z")
+	req.Header.Set("X-Amz-Content-Sha256", "placeholder")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7PLACEHLDR/20260703/"+region+"/athena/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef")
+
+	resp, err := setup.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST through proxy to real AWS: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("real AWS returned %d:\n%s", resp.StatusCode, respBody)
+	}
+	if !strings.Contains(string(respBody), "WorkGroups") {
+		t.Fatalf("unexpected ListWorkGroups body: %s", respBody)
+	}
+	t.Logf("real AWS accepted the re-signed request: %d, %d bytes", resp.StatusCode, len(respBody))
+}

--- a/internal/app/sandbox_forward_proxy_sigv4_realcli_test.go
+++ b/internal/app/sandbox_forward_proxy_sigv4_realcli_test.go
@@ -1,0 +1,216 @@
+package app
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+)
+
+// verifySigV4Upstream is an AWS-faithful upstream: it reconstructs the SigV4
+// canonical request from the RECEIVED wire values named in the request's
+// SignedHeaders and compares signatures derived from the known secret. On
+// mismatch it records the canonical it computed so the caller can diff.
+type verifySigV4Upstream struct {
+	secret  string
+	region  string
+	service string
+
+	ok       bool
+	received bool
+	detail   string
+}
+
+func (v *verifySigV4Upstream) handler(okBody string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		v.received = true
+		body, _ := io.ReadAll(r.Body)
+		auth := r.Header.Get("Authorization")
+
+		var signedList, gotSig, credScope string
+		for _, part := range strings.Split(auth, ", ") {
+			part = strings.TrimPrefix(part, "AWS4-HMAC-SHA256 ")
+			switch {
+			case strings.HasPrefix(part, "SignedHeaders="):
+				signedList = strings.TrimPrefix(part, "SignedHeaders=")
+			case strings.HasPrefix(part, "Signature="):
+				gotSig = strings.TrimPrefix(part, "Signature=")
+			case strings.HasPrefix(part, "Credential="):
+				credScope = strings.TrimPrefix(part, "Credential=")
+			}
+		}
+		if signedList == "" || gotSig == "" || credScope == "" {
+			v.detail = fmt.Sprintf("malformed Authorization: %q", auth)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		names := strings.Split(signedList, ";")
+		sort.Strings(names)
+		var ch strings.Builder
+		for _, n := range names {
+			var val string
+			if n == "host" {
+				val = r.Host
+			} else {
+				val = strings.Join(strings.Fields(strings.TrimSpace(r.Header.Get(n))), " ")
+			}
+			ch.WriteString(n + ":" + val + "\n")
+		}
+		payloadHash := sha256.Sum256(body)
+		canonical := strings.Join([]string{
+			r.Method,
+			r.URL.EscapedPath(),
+			r.URL.RawQuery,
+			ch.String(),
+			signedList,
+			hex.EncodeToString(payloadHash[:]),
+		}, "\n")
+
+		scopeParts := strings.Split(credScope, "/")
+		if len(scopeParts) != 5 {
+			v.detail = fmt.Sprintf("malformed Credential scope: %q", credScope)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		canonicalHash := sha256.Sum256([]byte(canonical))
+		stringToSign := strings.Join([]string{
+			"AWS4-HMAC-SHA256",
+			r.Header.Get("X-Amz-Date"),
+			strings.Join(scopeParts[1:], "/"),
+			hex.EncodeToString(canonicalHash[:]),
+		}, "\n")
+
+		hm := func(key []byte, msg string) []byte {
+			m := hmac.New(sha256.New, key)
+			m.Write([]byte(msg))
+			return m.Sum(nil)
+		}
+		kSigning := hm(hm(hm(hm([]byte("AWS4"+v.secret), scopeParts[1]), v.region), v.service), "aws4_request")
+		wantSig := hex.EncodeToString(hm(kSigning, stringToSign))
+
+		if wantSig == gotSig {
+			v.ok = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, okBody)
+			return
+		}
+		v.detail = fmt.Sprintf(
+			"SignatureDoesNotMatch\ncanonical (from received wire values):\n%s\nwant sig %s\ngot sig  %s",
+			canonical, wantSig, gotSig)
+		w.WriteHeader(http.StatusForbidden)
+	}
+}
+
+// TestSandboxForwardProxy_SigV4RealCLIThroughProxy reproduces the production
+// rung-3 signing path with the REAL AWS CLI as the in-container client: the
+// pinned tool image sends a request through HTTPS_PROXY into the real proxy
+// middleware (CONNECT + MITM with the session CA), the daemon leg re-signs and
+// forwards over a real Transport, and an AWS-faithful upstream verifies the
+// signature from received wire values. Gated on docker + the tool image ref in
+// AILERON_SIGV4_CLI_IMAGE so CI without the image skips.
+func TestSandboxForwardProxy_SigV4RealCLIThroughProxy(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH")
+	}
+	image := os.Getenv("AILERON_SIGV4_CLI_IMAGE")
+	if image == "" {
+		t.Skip("AILERON_SIGV4_CLI_IMAGE not set (an image with the aws CLI)")
+	}
+
+	const secretAccessKey = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+	const accessKeyID = "AKIDEXAMPLE"
+	const targetHost = "athena.us-east-1.amazonaws.com"
+
+	verifier := &verifySigV4Upstream{secret: secretAccessKey, region: "us-east-1", service: "athena"}
+	upstream := httptest.NewTLSServer(verifier.handler(`{"WorkGroups":[]}`))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	realLeg := &http.Client{Transport: &http.Transport{
+		// Pin every dial to the local verifier; TLS against its self-signed cert.
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return tls.Dial("tcp", upstreamURL.Host, &tls.Config{InsecureSkipVerify: true})
+		},
+	}}
+
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-sigv4-realcli" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte(secretAccessKey)),
+		hostBindings: mustHostBindingTableOpts(t, targetHost, "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign(accessKeyID, "us-east-1", "athena")),
+		sandboxProxyClient: realLeg,
+	}
+	// Inline the proxy setup (mirrors newHostBindingProxySetup) so the proxy
+	// URL is in hand for the container's HTTPS_PROXY.
+	stateDir := t.TempDir()
+	writeSandboxProxyTestCA(t, stateDir, "session-123")
+	srv.localDaemonToken = "daemon-token"
+	srv.sandboxProxyStateDir = stateDir
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	t.Cleanup(proxy.Close)
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(stateDir, "sessions", "session-123", "sandbox-proxy", "ca.pem")
+
+	// The real CLI, exactly as the rung-3 runner launches it: HTTPS_PROXY with
+	// the session credentials, the session CA as the trust bundle, placeholder
+	// static creds. list-work-groups first; start-query-execution exercises a
+	// larger body.
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"list-work-groups", []string{"athena", "list-work-groups", "--region", "us-east-1"}},
+		{"start-query-execution", []string{"athena", "start-query-execution", "--region", "us-east-1",
+			"--work-group", "wg-x", "--query-string", strings.Repeat("SELECT 'padding' AS c UNION ALL ", 300) + "SELECT 'end'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			verifier.ok, verifier.received, verifier.detail = false, false, ""
+			args := []string{"run", "--rm",
+				"--add-host", "host.docker.internal:host-gateway",
+				"-v", caPath + ":/proxyca/ca.pem:ro",
+				"-e", "HTTPS_PROXY=http://session-123:daemon-token@host.docker.internal:" + proxyURL.Port(),
+				"-e", "AWS_CA_BUNDLE=/proxyca/ca.pem",
+				"-e", "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7PLACEHLDR",
+				"-e", "AWS_SECRET_ACCESS_KEY=placeholder-secret",
+				"-e", "AWS_MAX_ATTEMPTS=1",
+				"--entrypoint", "aws", image,
+			}
+			args = append(args, tc.args...)
+			cmd := exec.Command("docker", args...)
+			out, err := cmd.CombinedOutput()
+			if !verifier.received {
+				t.Fatalf("upstream never received the request; docker err=%v out:\n%s", err, out)
+			}
+			if !verifier.ok {
+				t.Fatalf("signature verification failed for the real CLI request:\n%s\n\nCLI output:\n%s", verifier.detail, out)
+			}
+			if err != nil {
+				t.Logf("CLI exited non-zero (fake upstream body may not satisfy it): %v\n%s", err, out)
+			}
+		})
+	}
+}

--- a/internal/app/sandbox_forward_proxy_sigv4_wire_test.go
+++ b/internal/app/sandbox_forward_proxy_sigv4_wire_test.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+)
+
+// TestSandboxForwardProxy_SigV4ResignSignatureVerifiesOnTheWire is the
+// AWS-side truth test the shape-only assertions above don't provide: the
+// re-signed request travels the REAL upstream leg (a real http.Transport
+// serializing to a real TLS server), and the upstream verifies the SigV4
+// signature the way AWS does — reconstruct the canonical request from the
+// RECEIVED headers named in SignedHeaders, derive the signing key from the
+// known secret, and compare signatures. A proxy that mutates any signed
+// header between signing and the wire (or signs a value the upstream never
+// receives) fails here with the exact SignatureDoesNotMatch AWS returns in
+// production. The request is botocore-shaped (POST body, content-length,
+// accept-encoding, long user-agent, amz-sdk-* headers, a stale client
+// Authorization) because that is what the rung-3 AWS-CLI tool sends.
+func TestSandboxForwardProxy_SigV4ResignSignatureVerifiesOnTheWire(t *testing.T) {
+	const secretAccessKey = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+	const accessKeyID = "AKIDEXAMPLE"
+
+	type verdict struct {
+		ok       bool
+		detail   string
+		received bool
+	}
+	var got verdict
+
+	// The wire-truth upstream: a real TLS server that verifies the signature
+	// from what it actually received, exactly as AWS does.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.received = true
+		body, _ := io.ReadAll(r.Body)
+		auth := r.Header.Get("Authorization")
+
+		// Parse SignedHeaders and Signature out of the Authorization.
+		var signedList, gotSig, credScope string
+		for _, part := range strings.Split(auth, ", ") {
+			part = strings.TrimPrefix(part, "AWS4-HMAC-SHA256 ")
+			switch {
+			case strings.HasPrefix(part, "SignedHeaders="):
+				signedList = strings.TrimPrefix(part, "SignedHeaders=")
+			case strings.HasPrefix(part, "Signature="):
+				gotSig = strings.TrimPrefix(part, "Signature=")
+			case strings.HasPrefix(part, "Credential="):
+				credScope = strings.TrimPrefix(part, "Credential=")
+			}
+		}
+		if signedList == "" || gotSig == "" {
+			got.detail = fmt.Sprintf("malformed Authorization: %q", auth)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		// Canonicalize from RECEIVED values, per the SigV4 server-side rules.
+		names := strings.Split(signedList, ";")
+		sort.Strings(names)
+		var ch strings.Builder
+		for _, n := range names {
+			var v string
+			if n == "host" {
+				v = r.Host
+			} else {
+				v = strings.TrimSpace(r.Header.Get(n))
+			}
+			ch.WriteString(n + ":" + v + "\n")
+		}
+		payloadHash := sha256.Sum256(body)
+		canonical := strings.Join([]string{
+			r.Method,
+			r.URL.EscapedPath(),
+			r.URL.RawQuery,
+			ch.String(),
+			signedList,
+			hex.EncodeToString(payloadHash[:]),
+		}, "\n")
+
+		// Scope: AKIDEXAMPLE/<date>/us-east-1/athena/aws4_request
+		scopeParts := strings.Split(credScope, "/")
+		if len(scopeParts) != 5 {
+			got.detail = fmt.Sprintf("malformed Credential scope: %q", credScope)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		scopeDate := scopeParts[1]
+		canonicalHash := sha256.Sum256([]byte(canonical))
+		stringToSign := strings.Join([]string{
+			"AWS4-HMAC-SHA256",
+			r.Header.Get("X-Amz-Date"),
+			strings.Join(scopeParts[1:], "/"),
+			hex.EncodeToString(canonicalHash[:]),
+		}, "\n")
+
+		hm := func(key []byte, msg string) []byte {
+			m := hmac.New(sha256.New, key)
+			m.Write([]byte(msg))
+			return m.Sum(nil)
+		}
+		kSigning := hm(hm(hm(hm([]byte("AWS4"+secretAccessKey), scopeDate), "us-east-1"), "athena"), "aws4_request")
+		wantSig := hex.EncodeToString(hm(kSigning, stringToSign))
+
+		if wantSig == gotSig {
+			got.ok = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ok":true}`)
+			return
+		}
+		got.detail = fmt.Sprintf(
+			"SignatureDoesNotMatch:\ncanonical (from received wire values):\n%s\nwant sig %s\ngot sig  %s\nauth %q",
+			canonical, wantSig, gotSig, auth)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Real upstream leg: a REAL http.Transport (real request serialization)
+	// whose dial is pinned to the local TLS upstream regardless of the
+	// target host, mirroring "the daemon dials AWS".
+	upstreamAddr := upstream.Listener.Addr().String()
+	realLeg := &http.Client{Transport: &http.Transport{
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return tls.Dial("tcp", upstreamAddr, &tls.Config{InsecureSkipVerify: true})
+		},
+	}}
+
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-sigv4-wire" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte(secretAccessKey)),
+		hostBindings: mustHostBindingTableOpts(t, "athena.us-east-1.amazonaws.test", "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign(accessKeyID, "us-east-1", "athena")),
+		sandboxProxyClient: realLeg,
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	// A botocore-shaped request: POST body, stale placeholder signature, the
+	// full header set the AWS CLI sends.
+	body := `{"QueryString":"SELECT 1","WorkGroup":"wg-x","QueryExecutionContext":{"Database":"db"}}`
+	req, err := http.NewRequest(http.MethodPost, "https://athena.us-east-1.amazonaws.test/", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AmazonAthena.StartQueryExecution")
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("User-Agent", "aws-cli/2.35.15 md/awscrt#0.35.0 ua/2.1 os/linux#6.12.76-linuxkit md/arch#aarch64 lang/python#3.14.5")
+	req.Header.Set("Amz-Sdk-Invocation-Id", "45b9a48b-67da-4d67-b1b3-a0347fe6f6a7")
+	req.Header.Set("Amz-Sdk-Request", "attempt=1")
+	req.Header.Set("X-Amz-Date", "20260703T000000Z")
+	req.Header.Set("X-Amz-Content-Sha256", "placeholder")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7PLACEHLDR/20260703/us-east-1/athena/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef")
+
+	resp, err := setup.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if !got.received {
+		t.Fatalf("upstream never received the request; proxy status=%d body=%s", resp.StatusCode, respBody)
+	}
+	if !got.ok {
+		t.Fatalf("upstream signature verification failed:\n%s", got.detail)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, respBody)
+	}
+}

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -302,6 +302,16 @@ type RunOptions struct {
 	// container cannot be stopped by name, so the launcher generates a
 	// deterministic per-session name and reuses it for StopContainer.
 	Name string
+	// ToolDispatch marks a rung-3 sealed-tool dispatch (#1733): the image's
+	// baked entrypoint runs with NO command (a non-empty Command is an error —
+	// the tool contract forbids overriding the entrypoint), and the implicit
+	// operator-CWD workspace mount is NOT emitted. A sealed tool sees only its
+	// declared Volumes (the read-only input mount and the writable collect
+	// mount); bind-mounting the launch directory read-write into it would hand
+	// the tool the operator's project, which the mount → run → collect contract
+	// exists to prevent. The default (false) keeps the agent-sandbox behavior:
+	// command required, workspace mounted at WorkspacePath.
+	ToolDispatch bool
 }
 
 // Volume describes an additional mount for a sandbox container. By default
@@ -731,12 +741,18 @@ func ImageMetadataLabel(ctx context.Context, runner Runner, runtimeName, image s
 	return imageLabel(ctx, runner, runtimeName, image, DevcontainerMetadataLabel)
 }
 
-// Run starts a one-shot sandbox container for an agent command.
+// Run starts a one-shot sandbox container for an agent command, or — when
+// opts.ToolDispatch is set — a rung-3 sealed-tool dispatch that runs the
+// image's baked entrypoint with no command and no implicit workspace mount.
 func (b Builder) Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	if opts.Image == "" {
 		return RunResult{}, fmt.Errorf("sandbox image is required")
 	}
-	if len(opts.Command) == 0 || strings.TrimSpace(opts.Command[0]) == "" {
+	if opts.ToolDispatch {
+		if len(opts.Command) != 0 {
+			return RunResult{}, fmt.Errorf("tool dispatch runs the image's baked entrypoint; command must be empty")
+		}
+	} else if len(opts.Command) == 0 || strings.TrimSpace(opts.Command[0]) == "" {
 		return RunResult{}, fmt.Errorf("sandbox command is required")
 	}
 	runner := b.Runner
@@ -1045,14 +1061,20 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 	// no-op). Named volumes are managed by the runtime and already carry a
 	// container-accessible label, so they are not relabeled.
 	relabel := WorkspaceRelabelActive(runtimeName)
-	workspaceSpec := absWorkDir + ":" + WorkspacePath
-	if relabel {
-		workspaceSpec += ":z"
+	// A rung-3 tool dispatch never mounts the operator's CWD: the sealed tool
+	// sees only its declared Volumes (input mount + collect mount), and the
+	// image's own WORKDIR applies. The workspace mount is the agent-sandbox
+	// contract, not the tool contract.
+	if !opts.ToolDispatch {
+		workspaceSpec := absWorkDir + ":" + WorkspacePath
+		if relabel {
+			workspaceSpec += ":z"
+		}
+		args = append(args,
+			"--workdir", WorkspacePath,
+			"--volume", workspaceSpec,
+		)
 	}
-	args = append(args,
-		"--workdir", WorkspacePath,
-		"--volume", workspaceSpec,
-	)
 	for _, volume := range opts.Volumes {
 		if strings.TrimSpace(volume.Source) == "" || strings.TrimSpace(volume.Target) == "" {
 			return nil, fmt.Errorf("sandbox volume source and target are required")

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1116,6 +1116,62 @@ func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
 	}
 }
 
+// TestRunToolDispatchRunsEntrypointOnly proves the rung-3 sealed-tool contract
+// (#1733) in the shared builder: no command (the image's baked entrypoint
+// runs), and no implicit operator-CWD workspace mount — the container sees
+// exactly the declared volumes. Without this, every real tool dispatch died
+// with "sandbox command is required" (the CLI's tool runner never sets a
+// command by design, and the integration e2e bypasses Builder.Run).
+func TestRunToolDispatchRunsEntrypointOnly(t *testing.T) {
+	pinHostOSDarwin(t)
+	in := t.TempDir()
+	out := t.TempDir()
+	runner := &recordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image: "octane-tool:test",
+		Volumes: []Volume{
+			{Source: in, Target: "/aileron/in", ReadOnly: true},
+			{Source: out, Target: "/aileron/out"},
+		},
+		Env:          map[string]string{"HTTPS_PROXY": "http://host.docker.internal:1"},
+		ToolDispatch: true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Runtime != "docker" {
+		t.Fatalf("runtime = %q, want docker", result.Runtime)
+	}
+	want := []string{
+		"run", "--rm", "-i",
+		"--volume", in + ":/aileron/in:ro",
+		"--volume", out + ":/aileron/out",
+		"--env", "HTTPS_PROXY=http://host.docker.internal:1",
+		"octane-tool:test",
+	}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v (no --workdir, no workspace volume, no trailing command)", runner.args, want)
+	}
+}
+
+// TestRunToolDispatchRejectsCommand locks the other half of the contract: a
+// tool dispatch may never override the image's baked entrypoint, so a
+// non-empty Command is refused rather than silently appended.
+func TestRunToolDispatchRejectsCommand(t *testing.T) {
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:        "octane-tool:test",
+		Command:      []string{"sh", "-c", "evil"},
+		ToolDispatch: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "baked entrypoint") {
+		t.Fatalf("err = %v, want the baked-entrypoint refusal", err)
+	}
+	if runner.name != "" {
+		t.Fatal("the runner must not be invoked when validation refuses the dispatch")
+	}
+}
+
 func TestRunCanOverrideContainerUser(t *testing.T) {
 	pinHostOSDarwin(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- `Builder.Run` was written for the agent sandbox: it hard-requires a command and always bind-mounts the operator's CWD read-write at `/work`. The rung-3 tool dispatch (#1733) reuses it with the opposite contract — the tool image's **baked entrypoint** runs (never an override), and the sealed tool must see **only its declared input/collect mounts**. Result: every real rung-3 dispatch died with `sandbox command is required`; and had it booted, the tool container would have inherited the operator's project directory read-write — exactly what the mount → run → collect contract exists to prevent.
- The junction was never exercised with a real container: the CLI unit tests stub `containerRunToolImage`, and `TestSandboxProxyToolContainerIntegration` drives docker via `exec.Command` directly, bypassing `Builder.Run`.
- Fix: `RunOptions.ToolDispatch` — entrypoint-only (a non-empty `Command` is refused, not appended) and no implicit workspace mount. `containerToolImageRunner` sets it; the agent-sandbox default path is byte-for-byte unchanged.

## Test plan
- [x] `TestRunToolDispatchRunsEntrypointOnly`: full arg-vector assertion — declared volumes only, no `--workdir`, no workspace volume, image is the final arg. Fails before the fix (`sandbox command is required`).
- [x] `TestRunToolDispatchRejectsCommand`: entrypoint-override refusal, runner never invoked.
- [x] `TestContainerToolImageRunner_MountsRunsCollects` extended: the dispatch carries `ToolDispatch` and an empty `Command`.
- [x] `go test ./internal/sandbox/container/ ./cmd/aileron/` green.
- [x] Verified live: a rung-3 Flight Plan (two pinned AWS-CLI tool steps) launch proceeds past the boot on this binary (E2E in flight; results posted on the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sUjkxyPusyc7FivV3rQpL