### PR TITLE
fix(flightplan): re-emit launch input overrides on the image-boot re-entry

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
@@ -157,6 +158,30 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 	}
 	if spec.OutDir != "" {
 		command = append(command, "--out-dir", outDirMount)
+	}
+	// Re-emit the launch input overrides as --input name=value on the in-container
+	// re-entry (#1802). Without this the inner binary sees no overrides and every
+	// input silently resolves to its default, while the runner still echoes
+	// spec.Inputs as ResolvedInputs — falsely telling the operator the overrides
+	// applied. CLI-path values arrive as strings via inputFlag.Set, and the inner
+	// re-entry parses them with the same inputFlag, so the string round-trip is
+	// exact. Keys are appended in sorted order so the emitted command is
+	// deterministic. A non-string value in the map[string]any seam type has no
+	// exact name=value round-trip, so refuse the boot with an explicit error
+	// rather than coerce or drop it (the issue's never-silently-drop requirement).
+	if len(spec.Inputs) > 0 {
+		keys := make([]string, 0, len(spec.Inputs))
+		for k := range spec.Inputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			s, ok := spec.Inputs[k].(string)
+			if !ok {
+				return runtime.ImageRunResult{}, fmt.Errorf("skill launch: image-boot re-entry cannot pass non-string override for input %q (got %T): refusing to boot rather than drop or coerce it", k, spec.Inputs[k])
+			}
+			command = append(command, "--input", k+"="+s)
+		}
 	}
 
 	opts := sandboxcontainer.RunOptions{

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -116,6 +116,138 @@ func TestContainerImageRunner_BootsExactImageWithMounts(t *testing.T) {
 	}
 }
 
+// indexOf returns the position of want in args, or -1 if absent. It is a small
+// helper for asserting the ordered emission of --input flags on the re-entry.
+func indexOf(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestContainerImageRunner_ReEmitsInputOverrides is the #1802 regression proof:
+// launch input overrides carried in ImageRunSpec.Inputs must be re-emitted as
+// --input name=value on the in-container re-entry, in sorted-key order, so the
+// inner binary applies them rather than silently resolving defaults. Before the
+// fix the command carried no --input flags and this asserts they are present,
+// value-exact, and deterministically ordered.
+func TestContainerImageRunner_ReEmitsInputOverrides(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+		Inputs: runtime.LaunchArgs{
+			"window_days": "30",
+			"format":      "csv",
+			"account":     "acme",
+		},
+	}
+	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Every override is re-emitted as an adjacent --input name=value pair.
+	joined := strings.Join(got.Command, " ")
+	for _, want := range []string{
+		"--input account=acme",
+		"--input format=csv",
+		"--input window_days=30",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("command %v must carry %q", got.Command, want)
+		}
+	}
+
+	// The emission is deterministically ordered by sorted key: account < format <
+	// window_days, so the value flags appear in that relative order.
+	iAccount := indexOf(got.Command, "account=acme")
+	iFormat := indexOf(got.Command, "format=csv")
+	iWindow := indexOf(got.Command, "window_days=30")
+	if iAccount == -1 || iFormat == -1 || iWindow == -1 {
+		t.Fatalf("all overrides must be present in the command: %v", got.Command)
+	}
+	if !(iAccount < iFormat && iFormat < iWindow) {
+		t.Errorf("overrides must be emitted in sorted-key order, got command %v", got.Command)
+	}
+}
+
+// TestContainerImageRunner_NoOverridesLeavesCommandUnchanged proves a launch with
+// no input overrides emits no --input flags, so the boot command is unchanged for
+// the common no-override case (#1802).
+func TestContainerImageRunner_NoOverridesLeavesCommandUnchanged(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	spec := runtime.ImageRunSpec{
+		Image:   "registry.example.com/runner:1.4@sha256:abc",
+		Name:    "weekly-metrics-digest",
+		Version: "1.0.0",
+	}
+	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, a := range got.Command {
+		if a == "--input" {
+			t.Errorf("a no-override launch must emit no --input flags, got %v", got.Command)
+		}
+	}
+	if strings.Join(got.Command, " ") != "aileron skill launch weekly-metrics-digest --store-dir /aileron/skills --version 1.0.0" {
+		t.Errorf("no-override command = %v, want the base re-entry unchanged", got.Command)
+	}
+}
+
+// TestContainerImageRunner_NonStringOverrideRefusesBoot proves a non-string value
+// in the map[string]any seam type has no exact name=value round-trip, so the
+// runner refuses the boot with an explicit error rather than coercing or dropping
+// it (#1802's never-silently-drop requirement). The boot must not fire.
+func TestContainerImageRunner_NonStringOverrideRefusesBoot(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	booted := false
+	orig := containerRunFlightPlan
+	stubBakedCLIVersion(t, "")
+	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+		booted = true
+		return sandboxcontainer.RunResult{}, nil
+	}
+	t.Cleanup(func() { containerRunFlightPlan = orig })
+
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner:1.4@sha256:abc",
+		Name:  "weekly-metrics-digest",
+		Inputs: runtime.LaunchArgs{
+			"window_days": 7, // non-string: no exact CLI round-trip
+		},
+	}
+	_, err := (containerImageRunner{}).Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("a non-string override must refuse the boot with an error")
+	}
+	if !strings.Contains(err.Error(), "window_days") {
+		t.Errorf("error must name the offending input, got %v", err)
+	}
+	if booted {
+		t.Error("the image must NOT boot when an override cannot be passed exactly")
+	}
+}
+
 // fakeImageDaemonEnv is a canned imageDaemonEnv for the runner tests: it returns
 // the recorded env map and ok flag so the runner's RunOptions.Env wiring is
 // asserted with no live daemon and no Docker.


### PR DESCRIPTION
## Summary

`containerImageRunner.Run` (`cmd/aileron/skill_launch_container.go`) built the in-container re-entry command with `--store-dir`, `--version`, and `--out-dir`, but no `--input` flags. Launch input overrides carried in `ImageRunSpec.Inputs` were therefore silently dropped inside the booted pin: every declared input resolved to its default instead. Meanwhile the runner still echoed `spec.Inputs` as `ResolvedInputs`, falsely telling the operator the overrides had applied.

This PR re-emits each override as `--input name=value` on the re-entry command:

- **Sorted-key order** so the emitted command is deterministic.
- **Exact string round-trip**: CLI-path values are always strings via `inputFlag.Set`, and the inner re-entry parses them with the same `inputFlag`.
- **Never silently drop**: a non-string value in the `map[string]any` seam type has no exact `name=value` round-trip, so the runner refuses the boot with an explicit error naming the offending input rather than coercing or dropping it (the issue's requirement).

No override case is unchanged: a launch with no `Inputs` emits no `--input` flags.

## Test plan

New regression tests in `cmd/aileron/skill_launch_container_test.go`, using the existing `containerRunFlightPlan` swap pattern and asserting on `got.Command`:

- `TestContainerImageRunner_ReEmitsInputOverrides` — overrides present, value-exact, emitted in sorted-key order. Fails before the fix (command carries no `--input`), passes after.
- `TestContainerImageRunner_NoOverridesLeavesCommandUnchanged` — no-override boot command is the base re-entry unchanged.
- `TestContainerImageRunner_NonStringOverrideRefusesBoot` — a non-string override errors loudly and the image never boots. Fails before the fix, passes after.

Verified both regression tests fail on the pre-fix code and pass after. `go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and the full `go test ./cmd/aileron/` suite are green.

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)
