### PR TITLE
feat(catalog): carry credential conventions on tool catalog entries

### DIFF
--- a/.github/workflows/sandbox-features.yml
+++ b/.github/workflows/sandbox-features.yml
@@ -55,7 +55,7 @@ jobs:
       # PR runs validate the Features package without pushing; ci.yml's
       # integration-sandbox-features job is the build/compose acceptance gate, so
       # this keeps the PR path lightweight. `devcontainer features package` walks
-      # the directory, processes each sub-Feature (claude, codex, gh), and fails on a
+      # the directory, processes each sub-Feature (claude, codex, gh, aws-cli), and fails on a
       # malformed manifest. It is the same directory-walk the publish step uses,
       # minus the push.
       - name: Validate Features package
@@ -76,7 +76,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # `devcontainer features publish` walks images/sandbox-features and pushes
-      # each sub-Feature (claude, codex, gh) to ghcr.io/<namespace>/<id>. A "0.0.1"
+      # each sub-Feature (claude, codex, gh, aws-cli) to ghcr.io/<namespace>/<id>. A "0.0.1"
       # manifest publishes the tag set 0.0.1, 0.0, 0, and latest, so the
       # scaffold's ":0" reference resolves.
       #

--- a/images/sandbox-features/aws-cli/devcontainer-feature.json
+++ b/images/sandbox-features/aws-cli/devcontainer-feature.json
@@ -1,0 +1,18 @@
+{
+  "id": "aws-cli",
+  "version": "0.0.1",
+  "name": "AWS CLI",
+  "description": "Installs the AWS CLI (aws-cli) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user, and carries aws-cli's credential convention (sigv4-resign scheme + AWS placeholder pair) under customizations.aileron.credential.",
+  "documentationURL": "https://docs.withaileron.ai/development/sandbox-agent-images/",
+  "customizations": {
+    "aileron": {
+      "credential": {
+        "scheme": "sigv4-resign",
+        "placeholders": [
+          {"env": "AWS_ACCESS_KEY_ID", "value": "AKIAIOSFODNN7PLACEHLDR"},
+          {"env": "AWS_SECRET_ACCESS_KEY", "value": "placeholderAileronInjectsRealSecretXXXXXX"}
+        ]
+      }
+    }
+  }
+}

--- a/images/sandbox-features/aws-cli/install.sh
+++ b/images/sandbox-features/aws-cli/install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Aileron sandbox Feature: AWS CLI (aws-cli).
+#
+# Single source of truth for the aws-cli install recipe when aws-cli ships as a
+# composable Feature. This script runs as root during the image build on the
+# Aileron Alpine sandbox base; the resulting `aws` binary lands on PATH for the
+# non-root `agent` user.
+#
+# Unlike the agent Features (claude, codex), aws-cli is an apk-only install with
+# no npm package: it is a CLI-capability Feature, not an npm agent recipe. Its
+# parity target is Alpine's community `aws-cli` package (the AWS CLI v2 build),
+# not the npm-keyed recipe table in internal/sandbox/composition/recipes.go.
+#
+# The credential convention (which scheme seals aws-cli's outbound requests and
+# which placeholder pair the launcher plants) lives entirely in this Feature's
+# devcontainer-feature.json under customizations.aileron.credential. This script
+# never reads or bakes AWS credentials.
+set -eu
+
+# aws-cli ships only in Alpine's community repo, which alpine:3.24 does not
+# enable by default. Scope the community repo to this single apk invocation via
+# --repository (pinned to v3.24 to match the base FROM tag) so the install
+# reproduces the base Containerfile's community-repo scoping exactly. apk
+# --no-cache keeps the step idempotent and image-layer-clean.
+apk add --no-cache \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
+    aws-cli

--- a/images/sandbox-features/gh/devcontainer-feature.json
+++ b/images/sandbox-features/gh/devcontainer-feature.json
@@ -1,11 +1,17 @@
 {
   "id": "gh",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "name": "GitHub CLI",
-  "description": "Installs the GitHub CLI (github-cli) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user, and carries gh's full CLI-capability unit (acquisition + credential sealing) under customizations.aileron.cli.",
+  "description": "Installs the GitHub CLI (github-cli) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user, and carries gh's full CLI-capability unit (acquisition + credential sealing) under customizations.aileron.cli and its credential convention under customizations.aileron.credential.",
   "documentationURL": "https://docs.withaileron.ai/development/sandbox-agent-images/",
   "customizations": {
     "aileron": {
+      "credential": {
+        "scheme": "bearer",
+        "placeholders": [
+          {"env": "GH_TOKEN", "value": "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"}
+        ]
+      },
       "cli": {
         "name": "gh",
         "key": "user/github",

--- a/internal/sandbox/composition/convention.go
+++ b/internal/sandbox/composition/convention.go
@@ -1,0 +1,191 @@
+package composition
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// This file defines the credential-convention loader for tool catalog entries
+// (the devcontainer Features under images/sandbox-features/<toolID>/). A
+// credential-carrying Feature declares, under
+// customizations.aileron.credential, (1) which ADR-0019 injection scheme seals
+// its outbound requests and (2) the non-secret placeholder pair(s) the launcher
+// plants into the sandbox environment so the proxy can recognize and re-sign or
+// swap requests at the network boundary.
+//
+// The block is non-secret by construction: a placeholder carries a
+// format-mimicking value (e.g. an AWS access key ID shaped like AKIA…) and the
+// env var it is planted under, never real authority. The host injects the real
+// secret at the network boundary; the placeholder only lets the proxy match the
+// request that needs sealing. This mirrors the proxybinding.Sentinel posture,
+// where the placeholder value and its plant location are catalog data rather
+// than Go constants.
+//
+// The vocabulary (scheme, placeholders' env + value) is lifted verbatim from
+// the existing sealing/sentinel vocabulary used by internal/proxybinding and
+// gh's customizations.aileron.cli block, so a catalog entry expresses its
+// convention in one shared shape rather than a parallel invented one.
+
+// CredentialPlaceholder is a single non-secret placeholder the launcher plants
+// into the sandbox environment. Value is a format-mimicking, authority-free
+// stand-in (e.g. a well-known example access key ID) and Env is the environment
+// variable it is planted under. Both fields carry the same names and semantics
+// as the sentinel-swap vocabulary in proxybinding and gh's cli block.
+type CredentialPlaceholder struct {
+	Env   string `json:"env"`
+	Value string `json:"value"`
+}
+
+// CredentialConvention is the typed, validated credential convention a catalog
+// entry declares. Scheme is a member of the ADR-0019 closed set (routed through
+// [inject.ParseScheme]); Placeholders lists the non-secret env/value pairs the
+// launcher plants. It is the parse result freeze/launch consumers depend on.
+type CredentialConvention struct {
+	// Scheme names how the resolved secret is bound onto the outbound request
+	// at the network boundary. It is always a valid [inject.Scheme].
+	Scheme inject.Scheme
+	// Placeholders are the non-secret env/value pairs the launcher plants. At
+	// least one is present, each has a non-empty env and value, and no two
+	// share an env.
+	Placeholders []CredentialPlaceholder
+}
+
+// featureCredentialEnvelope decodes only the customizations.aileron.credential
+// path of a devcontainer-feature.json. Every level is a pointer so a missing
+// block (agent Features carry none) is distinguishable from a present-but-empty
+// one: a nil credential pointer is the clean "no convention" result, while a
+// present block is validated and any malformed shape is a loud error.
+type featureCredentialEnvelope struct {
+	Customizations *struct {
+		Aileron *struct {
+			// Credential captures the raw bytes of the credential block so the
+			// strict second pass decodes the original JSON (rejecting unknown
+			// keys) rather than a re-encoding. A nil RawMessage means the key
+			// was absent; a present key is strict-decoded and validated.
+			Credential *json.RawMessage `json:"credential"`
+		} `json:"aileron"`
+	} `json:"customizations"`
+}
+
+// credentialBlock is the raw customizations.aileron.credential sub-document.
+// Decoding of this block is strict (unknown keys rejected) so a typo inside a
+// present convention fails fast rather than silently shipping a partial
+// convention, mirroring cli.Parse's KnownFields posture.
+type credentialBlock struct {
+	Scheme       string                  `json:"scheme"`
+	Placeholders []CredentialPlaceholder `json:"placeholders"`
+}
+
+// ErrInvalidCredentialConvention is the sentinel wrapping every validation
+// failure of a present-but-malformed credential block (missing scheme, no
+// placeholders, a placeholder missing env or value, or a duplicate env).
+// Callers pattern-match with errors.Is. An unknown scheme additionally wraps
+// [inject.ErrUnknownScheme] so callers can distinguish that case.
+var ErrInvalidCredentialConvention = errors.New("composition: invalid credential convention")
+
+// ParseCredentialConvention parses a catalog entry's credential convention from
+// its raw devcontainer-feature.json bytes. It is pure and byte-driven so
+// freeze/launch consumers can feed manifest bytes from whatever source they
+// resolve (repo checkout, image metadata, published Feature manifest).
+//
+// The return contract:
+//   - No customizations.aileron.credential block: (zero, false, nil). Agent
+//     Features (claude, codex) carry no convention and take this path.
+//   - A present, valid block: (convention, true, nil).
+//   - Malformed JSON, or a present-but-invalid block: (zero, false, err). A
+//     present-but-broken convention is a loud error, never a silent no-op.
+//
+// Validation is fail-closed: scheme is required and routed through
+// [inject.ParseScheme] (an unknown scheme wraps [inject.ErrUnknownScheme]); at
+// least one placeholder is required; every placeholder needs a non-empty env
+// and value; and no two placeholders may share an env. Unknown keys inside the
+// credential block are rejected.
+func ParseCredentialConvention(manifest []byte) (CredentialConvention, bool, error) {
+	// First pass: locate the credential block with a lenient decode. Unknown
+	// keys elsewhere in the manifest (the full devcontainer schema, the cli
+	// sibling block) are irrelevant to this loader and must not fail it.
+	var env featureCredentialEnvelope
+	if err := json.Unmarshal(manifest, &env); err != nil {
+		return CredentialConvention{}, false, fmt.Errorf("composition: parse credential convention: %w", err)
+	}
+	if env.Customizations == nil ||
+		env.Customizations.Aileron == nil ||
+		env.Customizations.Aileron.Credential == nil {
+		return CredentialConvention{}, false, nil
+	}
+
+	// Second pass: strict-decode the credential block's original bytes so a typo
+	// inside a present convention (e.g. "placeholder" for "placeholders") fails
+	// fast.
+	dec := json.NewDecoder(bytes.NewReader(*env.Customizations.Aileron.Credential))
+	dec.DisallowUnknownFields()
+	var block credentialBlock
+	if err := dec.Decode(&block); err != nil {
+		return CredentialConvention{}, false, fmt.Errorf("%w: %v", ErrInvalidCredentialConvention, err)
+	}
+
+	conv, err := block.validate()
+	if err != nil {
+		return CredentialConvention{}, false, err
+	}
+	return conv, true, nil
+}
+
+// validate applies the fail-closed rules to a decoded credential block and
+// returns the typed convention. Every failure wraps
+// [ErrInvalidCredentialConvention]; an unknown scheme additionally wraps
+// [inject.ErrUnknownScheme].
+func (b credentialBlock) validate() (CredentialConvention, error) {
+	if b.Scheme == "" {
+		return CredentialConvention{}, fmt.Errorf("%w: scheme is required", ErrInvalidCredentialConvention)
+	}
+	scheme, err := inject.ParseScheme(b.Scheme)
+	if err != nil {
+		// Wrap both sentinels: callers can errors.Is either
+		// ErrInvalidCredentialConvention (any bad convention) or
+		// inject.ErrUnknownScheme (specifically an unknown scheme).
+		return CredentialConvention{}, fmt.Errorf("%w: %w", ErrInvalidCredentialConvention, err)
+	}
+	if len(b.Placeholders) == 0 {
+		return CredentialConvention{}, fmt.Errorf("%w: at least one placeholder is required", ErrInvalidCredentialConvention)
+	}
+	seen := make(map[string]struct{}, len(b.Placeholders))
+	for i, p := range b.Placeholders {
+		if p.Env == "" {
+			return CredentialConvention{}, fmt.Errorf("%w: placeholder %d missing env", ErrInvalidCredentialConvention, i)
+		}
+		if p.Value == "" {
+			return CredentialConvention{}, fmt.Errorf("%w: placeholder %q missing value", ErrInvalidCredentialConvention, p.Env)
+		}
+		if _, dup := seen[p.Env]; dup {
+			return CredentialConvention{}, fmt.Errorf("%w: duplicate placeholder env %q", ErrInvalidCredentialConvention, p.Env)
+		}
+		seen[p.Env] = struct{}{}
+	}
+
+	placeholders := make([]CredentialPlaceholder, len(b.Placeholders))
+	copy(placeholders, b.Placeholders)
+	return CredentialConvention{Scheme: scheme, Placeholders: placeholders}, nil
+}
+
+// LoadCredentialConvention reads <featuresRoot>/<toolID>/devcontainer-feature.json
+// and parses its credential convention via [ParseCredentialConvention]. It is
+// the filesystem-backed entry point for consumers that resolve catalog entries
+// from a repo checkout; consumers that already hold manifest bytes call
+// [ParseCredentialConvention] directly. The (convention, ok, err) contract is
+// identical to [ParseCredentialConvention]; a missing manifest file is an
+// error.
+func LoadCredentialConvention(featuresRoot, toolID string) (CredentialConvention, bool, error) {
+	path := filepath.Join(featuresRoot, toolID, "devcontainer-feature.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return CredentialConvention{}, false, fmt.Errorf("composition: read %s: %w", path, err)
+	}
+	return ParseCredentialConvention(raw)
+}

--- a/internal/sandbox/composition/convention_test.go
+++ b/internal/sandbox/composition/convention_test.go
@@ -1,0 +1,347 @@
+package composition
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// TestParseCredentialConvention_Valid exercises the happy paths: a single-
+// placeholder bearer convention and a two-placeholder sigv4-resign convention,
+// asserting the typed result matches the declared bytes exactly.
+func TestParseCredentialConvention_Valid(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		want     CredentialConvention
+	}{
+		{
+			name: "bearer single placeholder",
+			manifest: `{
+				"id": "gh",
+				"customizations": {"aileron": {"credential": {
+					"scheme": "bearer",
+					"placeholders": [{"env": "GH_TOKEN", "value": "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"}]
+				}}}
+			}`,
+			want: CredentialConvention{
+				Scheme: inject.SchemeBearer,
+				Placeholders: []CredentialPlaceholder{
+					{Env: "GH_TOKEN", Value: "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"},
+				},
+			},
+		},
+		{
+			name: "sigv4-resign two placeholders",
+			manifest: `{
+				"customizations": {"aileron": {"credential": {
+					"scheme": "sigv4-resign",
+					"placeholders": [
+						{"env": "AWS_ACCESS_KEY_ID", "value": "AKIAIOSFODNN7PLACEHLDR"},
+						{"env": "AWS_SECRET_ACCESS_KEY", "value": "placeholderAileronInjectsRealSecretXXXXXX"}
+					]
+				}}}
+			}`,
+			want: CredentialConvention{
+				Scheme: inject.SchemeSigV4Resign,
+				Placeholders: []CredentialPlaceholder{
+					{Env: "AWS_ACCESS_KEY_ID", Value: "AKIAIOSFODNN7PLACEHLDR"},
+					{Env: "AWS_SECRET_ACCESS_KEY", Value: "placeholderAileronInjectsRealSecretXXXXXX"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := ParseCredentialConvention([]byte(tt.manifest))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("ok = false, want true for a present valid convention")
+			}
+			assertConventionEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestParseCredentialConvention_Absent covers the manifests that carry no
+// convention: a Feature with no customizations at all, and one whose
+// customizations.aileron block omits credential (agent Features). Both yield the
+// clean (zero, false, nil) result, never an error.
+func TestParseCredentialConvention_Absent(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+	}{
+		{
+			name:     "no customizations",
+			manifest: `{"id": "claude", "version": "0.0.1"}`,
+		},
+		{
+			name:     "aileron block without credential",
+			manifest: `{"customizations": {"aileron": {"cli": {"name": "gh"}}}}`,
+		},
+		{
+			name:     "customizations without aileron",
+			manifest: `{"customizations": {"vscode": {"extensions": []}}}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := ParseCredentialConvention([]byte(tt.manifest))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok {
+				t.Fatalf("ok = true, want false for a manifest with no convention")
+			}
+			if got.Scheme != "" || len(got.Placeholders) != 0 {
+				t.Fatalf("got non-zero convention %+v, want zero value", got)
+			}
+		})
+	}
+}
+
+// TestParseCredentialConvention_Invalid covers every fail-closed rule: a
+// present-but-broken convention must be a loud error, never a silent no-op.
+func TestParseCredentialConvention_Invalid(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		// wantUnknownScheme asserts the error additionally wraps
+		// inject.ErrUnknownScheme so callers can distinguish that case.
+		wantUnknownScheme bool
+	}{
+		{
+			name:              "unknown scheme",
+			manifest:          `{"customizations":{"aileron":{"credential":{"scheme":"totp","placeholders":[{"env":"X","value":"y"}]}}}}`,
+			wantUnknownScheme: true,
+		},
+		{
+			name:     "missing scheme",
+			manifest: `{"customizations":{"aileron":{"credential":{"placeholders":[{"env":"X","value":"y"}]}}}}`,
+		},
+		{
+			name:     "empty scheme string",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"","placeholders":[{"env":"X","value":"y"}]}}}}`,
+		},
+		{
+			name:     "no placeholders key",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"bearer"}}}}`,
+		},
+		{
+			name:     "empty placeholders array",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[]}}}}`,
+		},
+		{
+			name:     "placeholder missing env",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[{"value":"y"}]}}}}`,
+		},
+		{
+			name:     "placeholder missing value",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[{"env":"X"}]}}}}`,
+		},
+		{
+			name:     "duplicate placeholder env",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"sigv4-resign","placeholders":[{"env":"X","value":"a"},{"env":"X","value":"b"}]}}}}`,
+		},
+		{
+			name:     "unknown key in credential block",
+			manifest: `{"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholder":[{"env":"X","value":"y"}]}}}}`,
+		},
+		{
+			name:     "malformed json",
+			manifest: `{"customizations":{"aileron":{"credential":{`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := ParseCredentialConvention([]byte(tt.manifest))
+			if err == nil {
+				t.Fatalf("expected error, got nil (result %+v, ok %v)", got, ok)
+			}
+			if ok {
+				t.Fatalf("ok = true on an invalid convention; want false")
+			}
+			// Malformed JSON is a decode error, not an ErrInvalidCredentialConvention;
+			// every other case is a present-but-broken convention.
+			if tt.name != "malformed json" && !errors.Is(err, ErrInvalidCredentialConvention) {
+				t.Fatalf("error %v does not wrap ErrInvalidCredentialConvention", err)
+			}
+			if tt.wantUnknownScheme && !errors.Is(err, inject.ErrUnknownScheme) {
+				t.Fatalf("error %v does not wrap inject.ErrUnknownScheme", err)
+			}
+		})
+	}
+}
+
+// TestLoadCredentialConvention_RepoCatalog asserts the loader yields exactly the
+// declared convention for each real catalog entry: aws-cli's sigv4-resign pair,
+// gh's bearer GH_TOKEN placeholder, and no convention for the agent Features.
+func TestLoadCredentialConvention_RepoCatalog(t *testing.T) {
+	root := featuresContext(t)
+
+	t.Run("aws-cli", func(t *testing.T) {
+		got, ok, err := LoadCredentialConvention(root, "aws-cli")
+		if err != nil {
+			t.Fatalf("load aws-cli: %v", err)
+		}
+		if !ok {
+			t.Fatalf("aws-cli must carry a credential convention")
+		}
+		// The placeholder values must equal the constants
+		// cmd/aileron/skill_launch_proxy.go plants today, so #1828 can swap the
+		// hardcoded pair for catalog data with zero behavior change at the proxy.
+		want := CredentialConvention{
+			Scheme: inject.SchemeSigV4Resign,
+			Placeholders: []CredentialPlaceholder{
+				{Env: "AWS_ACCESS_KEY_ID", Value: "AKIAIOSFODNN7PLACEHLDR"},
+				{Env: "AWS_SECRET_ACCESS_KEY", Value: "placeholderAileronInjectsRealSecretXXXXXX"},
+			},
+		}
+		assertConventionEqual(t, got, want)
+	})
+
+	t.Run("gh", func(t *testing.T) {
+		got, ok, err := LoadCredentialConvention(root, "gh")
+		if err != nil {
+			t.Fatalf("load gh: %v", err)
+		}
+		if !ok {
+			t.Fatalf("gh must carry a credential convention")
+		}
+		want := CredentialConvention{
+			Scheme: inject.SchemeBearer,
+			Placeholders: []CredentialPlaceholder{
+				{Env: "GH_TOKEN", Value: "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"},
+			},
+		}
+		assertConventionEqual(t, got, want)
+	})
+
+	for _, agent := range []string{"claude", "codex"} {
+		agent := agent
+		t.Run(agent, func(t *testing.T) {
+			got, ok, err := LoadCredentialConvention(root, agent)
+			if err != nil {
+				t.Fatalf("load %s: %v", agent, err)
+			}
+			if ok {
+				t.Fatalf("agent Feature %s must carry no credential convention, got %+v", agent, got)
+			}
+		})
+	}
+}
+
+// TestLoadCredentialConvention_MissingManifest asserts a nonexistent tool entry
+// is an error, not a silent (zero, false, nil).
+func TestLoadCredentialConvention_MissingManifest(t *testing.T) {
+	root := featuresContext(t)
+	if _, _, err := LoadCredentialConvention(root, "does-not-exist"); err == nil {
+		t.Fatalf("expected error loading a missing manifest, got nil")
+	}
+}
+
+// ghSealingManifest decodes the api.github.com sentinel-swap entry from gh's
+// customizations.aileron.cli.sealing block so the drift guard can compare it
+// against the credential convention without importing internal/cli.
+type ghSealingManifest struct {
+	Customizations struct {
+		Aileron struct {
+			CLI struct {
+				Sealing []struct {
+					Host          string `json:"host"`
+					Scheme        string `json:"scheme"`
+					EmitMechanism string `json:"emit_mechanism"`
+					Sentinel      struct {
+						Value string `json:"value"`
+						Env   string `json:"env"`
+					} `json:"sentinel"`
+				} `json:"sealing"`
+			} `json:"cli"`
+		} `json:"aileron"`
+	} `json:"customizations"`
+}
+
+// TestGHConventionMatchesSealingSentinel is the Unit 2 drift guard: gh's new
+// customizations.aileron.credential convention must not silently diverge from
+// the sentinel-swap entry in its own customizations.aileron.cli.sealing block.
+// The credential convention's scheme, placeholder env, and placeholder value
+// must equal the api.github.com sealing entry's scheme, sentinel env, and
+// sentinel value. This keeps the two declarations in lockstep without forking
+// the loader into a derive-from-sealing second path.
+func TestGHConventionMatchesSealingSentinel(t *testing.T) {
+	root := featuresContext(t)
+	path := filepath.Join(root, "gh", "devcontainer-feature.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	conv, ok, err := ParseCredentialConvention(raw)
+	if err != nil {
+		t.Fatalf("parse gh convention: %v", err)
+	}
+	if !ok {
+		t.Fatalf("gh must carry a credential convention")
+	}
+	if len(conv.Placeholders) != 1 {
+		t.Fatalf("gh convention has %d placeholders, want 1", len(conv.Placeholders))
+	}
+
+	var sealing ghSealingManifest
+	if err := json.Unmarshal(raw, &sealing); err != nil {
+		t.Fatalf("decode gh sealing block: %v", err)
+	}
+	var swap *struct {
+		Host          string `json:"host"`
+		Scheme        string `json:"scheme"`
+		EmitMechanism string `json:"emit_mechanism"`
+		Sentinel      struct {
+			Value string `json:"value"`
+			Env   string `json:"env"`
+		} `json:"sentinel"`
+	}
+	for i := range sealing.Customizations.Aileron.CLI.Sealing {
+		if sealing.Customizations.Aileron.CLI.Sealing[i].EmitMechanism == "sentinel-swap" {
+			swap = &sealing.Customizations.Aileron.CLI.Sealing[i]
+			break
+		}
+	}
+	if swap == nil {
+		t.Fatalf("gh cli.sealing has no sentinel-swap entry to compare against")
+	}
+
+	if string(conv.Scheme) != swap.Scheme {
+		t.Fatalf("convention scheme %q != sealing sentinel-swap scheme %q", conv.Scheme, swap.Scheme)
+	}
+	if conv.Placeholders[0].Env != swap.Sentinel.Env {
+		t.Fatalf("convention placeholder env %q != sealing sentinel env %q", conv.Placeholders[0].Env, swap.Sentinel.Env)
+	}
+	if conv.Placeholders[0].Value != swap.Sentinel.Value {
+		t.Fatalf("convention placeholder value %q != sealing sentinel value %q", conv.Placeholders[0].Value, swap.Sentinel.Value)
+	}
+}
+
+func assertConventionEqual(t *testing.T, got, want CredentialConvention) {
+	t.Helper()
+	if got.Scheme != want.Scheme {
+		t.Fatalf("scheme = %q, want %q", got.Scheme, want.Scheme)
+	}
+	if len(got.Placeholders) != len(want.Placeholders) {
+		t.Fatalf("placeholders len = %d, want %d (%+v)", len(got.Placeholders), len(want.Placeholders), got.Placeholders)
+	}
+	for i := range want.Placeholders {
+		if got.Placeholders[i] != want.Placeholders[i] {
+			t.Fatalf("placeholder %d = %+v, want %+v", i, got.Placeholders[i], want.Placeholders[i])
+		}
+	}
+}

--- a/internal/sandbox/composition/convention_test.go
+++ b/internal/sandbox/composition/convention_test.go
@@ -311,13 +311,14 @@ func TestGHConventionMatchesSealingSentinel(t *testing.T) {
 		} `json:"sentinel"`
 	}
 	for i := range sealing.Customizations.Aileron.CLI.Sealing {
-		if sealing.Customizations.Aileron.CLI.Sealing[i].EmitMechanism == "sentinel-swap" {
+		if sealing.Customizations.Aileron.CLI.Sealing[i].Host == "api.github.com" &&
+			sealing.Customizations.Aileron.CLI.Sealing[i].EmitMechanism == "sentinel-swap" {
 			swap = &sealing.Customizations.Aileron.CLI.Sealing[i]
 			break
 		}
 	}
 	if swap == nil {
-		t.Fatalf("gh cli.sealing has no sentinel-swap entry to compare against")
+		t.Fatalf("gh cli.sealing has no api.github.com sentinel-swap entry to compare against")
 	}
 
 	if string(conv.Scheme) != swap.Scheme {

--- a/internal/sandbox/composition/features_test.go
+++ b/internal/sandbox/composition/features_test.go
@@ -47,13 +47,13 @@ type featureManifest struct {
 }
 
 // featureIDs is every Feature published from images/sandbox-features: the npm
-// agent Features (claude, codex) plus the apk-only CLI-capability Feature (gh).
-// The shared manifest-validity and install-presence contracts apply to all of
-// them; the npm-recipe parity and scaffold-reference contracts apply only to
-// the agent Features (see TestFeatureInstallScriptsMatchCanonicalRecipe and
-// TestScaffoldFeatureReferenceMatchesManifestVersion, which keep their own
+// agent Features (claude, codex) plus the apk-only CLI-capability Features (gh,
+// aws-cli). The shared manifest-validity and install-presence contracts apply
+// to all of them; the npm-recipe parity and scaffold-reference contracts apply
+// only to the agent Features (see TestFeatureInstallScriptsMatchCanonicalRecipe
+// and TestScaffoldFeatureReferenceMatchesManifestVersion, which keep their own
 // agent-only lists).
-var featureIDs = []string{"claude", "codex", "gh"}
+var featureIDs = []string{"claude", "codex", "gh", "aws-cli"}
 
 func TestFeatureManifestsAreValid(t *testing.T) {
 	root := featuresContext(t)
@@ -352,6 +352,54 @@ func TestGHFeatureInstallScriptMatchesBaseContainerfile(t *testing.T) {
 	for _, secret := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
 		if strings.Contains(body, secret) {
 			t.Fatalf("%s references credential env var %q; the gh Feature must not read or bake credentials:\n%s", path, secret, body)
+		}
+	}
+}
+
+// TestAWSCLIFeatureInstallScript is the aws-cli-specific install parity check.
+// Like gh, aws-cli is an apk-only CLI-capability Feature (no @vendor/pkg, not in
+// agentRecipes), so it is excluded from
+// TestFeatureInstallScriptsMatchCanonicalRecipe. Its parity target is Alpine's
+// community aws-cli package with the same v3.24 community-repo scoping gh uses,
+// apk-only, and with no baked credential: the credential convention lives in the
+// manifest's customizations.aileron.credential block, never in the install
+// script.
+func TestAWSCLIFeatureInstallScript(t *testing.T) {
+	root := featuresContext(t)
+	path := filepath.Join(root, "aws-cli", "install.sh")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	body := string(raw)
+
+	// apk-only: the Alpine base has no apt-get, and aws-cli has no npm package.
+	if !strings.Contains(body, "apk add") {
+		t.Fatalf("%s must install via apk (the Alpine base has no apt-get):\n%s", path, body)
+	}
+	if strings.Contains(body, "apt-get") {
+		t.Fatalf("%s uses apt-get; the Alpine base requires apk:\n%s", path, body)
+	}
+	if strings.Contains(body, "npm install") {
+		t.Fatalf("%s installs via npm; aws-cli is an apk-only CLI Feature, not an npm agent recipe:\n%s", path, body)
+	}
+
+	// Installs the aws-cli apk package, scoped to the v3.24 community repo,
+	// mirroring the gh Feature's community-repo scoping.
+	if !strings.Contains(body, "aws-cli") {
+		t.Fatalf("%s must install the aws-cli apk package:\n%s", path, body)
+	}
+	const communityRepo = "--repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community"
+	if !strings.Contains(body, communityRepo) {
+		t.Fatalf("%s must scope the v3.24 community repo with %q (parity with the gh Feature):\n%s", path, communityRepo, body)
+	}
+
+	// No credential reads baked into the Feature: the placeholder data lives in
+	// the manifest's customizations.aileron.credential block, never in the
+	// install script.
+	for _, secret := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("%s references credential env var %q; the aws-cli Feature must not read or bake credentials:\n%s", path, secret, body)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Foundation sub-issue of umbrella #1824. Adds a `customizations.aileron.credential` convention block to the sandbox tool catalog (`images/sandbox-features`) plus a typed Go loader in `internal/sandbox/composition`, so the freeze (#1827) and launch (#1828) sub-issues can resolve each catalog entry's injection scheme and non-secret placeholder pairs from catalog data instead of hardcoded Go constants.

- **New `aws-cli` Feature (0.0.1):** apk-only install of Alpine's community `aws-cli` package (v2, confirmed present in v3.24 community), scoped with the same `--repository=.../v3.24/community` line gh uses. Carries a `sigv4-resign` convention whose placeholder values reuse the AWS constants in `cmd/aileron/skill_launch_proxy.go` **byte-for-byte** (`AKIAIOSFODNN7PLACEHLDR` / `placeholderAileronInjectsRealSecretXXXXXX`), so #1828 can swap the hardcoded pair for catalog data with zero behavior change at the proxy.
- **gh Feature (0.0.1 → 0.0.2):** gains a sibling `customizations.aileron.credential` block (`bearer` / `GH_TOKEN`) expressed in the exact same vocabulary as aws-cli. The `customizations.aileron.cli` block is left byte-identical (it drives the live capture/sealing layers via `unitloader` and is pinned by `internal/app` + `internal/cli` drift guards). A new drift guard pins the convention to the `cli.sealing` `api.github.com` sentinel-swap entry so the two declarations cannot silently diverge.
- **Loader:** `ParseCredentialConvention(manifest []byte)` (pure, byte-driven) and `LoadCredentialConvention(featuresRoot, toolID string)` (filesystem). Fail-closed validation: scheme required and routed through `inject.ParseScheme` (unknown scheme wraps `inject.ErrUnknownScheme`), at least one placeholder, non-empty env/value, no duplicate env, strict decode of the block (unknown keys rejected). An absent block is a clean `(zero, false, nil)` no-convention result (agent Features claude/codex); a present-but-broken block is a loud error wrapping `ErrInvalidCredentialConvention`.

### Scope

No schema resolution (#1826), no freeze composition (#1827), no launch env injection or removal of the hardcoded AWS constants (#1828), no runtime dispatch (#1829), no docs retirement (#1830). No changes to `internal/cli`, `internal/cli/unitloader`, `internal/proxybinding`, or `internal/credential/inject` (the loader consumes inject's closed set read-only). No OpenAPI change. Versions stay 0.0.x.

## Test plan

- `go test -cover ./internal/sandbox/composition/...` — green; new `convention.go` at **100% statement coverage** (all three functions), package at 94.8%.
- `go test ./internal/cli/... ./internal/app/...` — green, proving gh's `cli` block is untouched.
- New contract tests (table-driven, inline JSON fixtures): valid bearer + sigv4-resign parses; absent block → no convention; unknown/missing/empty scheme; missing/empty placeholders; placeholder missing env or value; duplicate env; malformed JSON; unknown key in block; repo-catalog assertions for aws-cli / gh / claude / codex; missing-manifest error; gh convention ↔ sealing-sentinel drift guard.
- `TestAWSCLIFeatureInstallScript` mirrors the gh install-parity posture (apk-only, community-repo scoping, no baked credential env vars).
- `gofmt`, `go vet`, and JSON validation clean. CodeRabbit review clean after one fix (drift guard now matches by host).
- CI: the `sandbox-features.yml` PR leg exercises `devcontainer features package` over the new aws-cli entry.

**Operator note:** the first publish of the new `aws-cli` GHCR Feature package needs the one-time manual public-visibility flip documented in `docs/development/sandbox-composition.md`, same as the other Features.

Closes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an AWS CLI sandbox feature.
  * Expanded GitHub CLI feature metadata to include credential handling details.

* **Bug Fixes**
  * Improved validation for sandbox feature credential settings, helping prevent misconfigured or incomplete setups.
  * Updated sandbox feature coverage so published and validated feature lists include AWS CLI.

* **Tests**
  * Added checks to keep sandbox feature install scripts and credential conventions consistent across supported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->