### PR TITLE
feat(launch): inject the proxy environment at whole-plan boot

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -31,11 +31,14 @@ var newLaunchAuditSink = func(stderr io.Writer) runtime.AuditSink { return daemo
 // image string and never touches Docker, mirroring the other launch seams.
 // The production runner injects the daemon-backed env resolver so the
 // re-entered in-container launch reaches the SAME host daemon action + audit
-// boundary and its records surface in the host `aileron audit list` (#1759).
-// The resolver stays passthrough (injects no env) when no daemon config is
-// resolvable, gating on config presence, so a no-daemon launch still boots.
+// boundary and its records surface in the host `aileron audit list` (#1759),
+// and the daemon-backed plan proxy bootstrapper so the booted plan container's
+// HTTPS egress routes through the ADR-0019 daemon forward proxy for host-binding
+// credential injection (#1828). Both seams stay passthrough (inject nothing)
+// when no daemon config is resolvable, gating on config presence, so a no-daemon
+// launch still boots.
 var newLaunchImageRunner = func() runtime.ImageRunner {
-	return containerImageRunner{daemonEnv: daemonImageEnv{}}
+	return containerImageRunner{daemonEnv: daemonImageEnv{}, proxy: daemonPlanProxyBootstrapper{}}
 }
 
 // newLaunchToolImageRunner returns the production tool-image runner that
@@ -43,12 +46,13 @@ var newLaunchImageRunner = func() runtime.ImageRunner {
 // collect I/O (#1733). It is a package-level seam so CLI tests swap in a fake
 // that records the pinned image and mount/collect wiring and never touches
 // Docker, mirroring newLaunchImageRunner.
-// The production runner injects the daemon-backed proxy bootstrapper so a
-// rung-3 tool step's HTTPS egress is routed through the ADR-0019 daemon forward
-// proxy for host-binding credential injection (#1769). The bootstrapper stays
-// passthrough when no daemon config is resolvable.
+// Per-dispatch egress is UN-PROXIED in the interim window (#1828/#1829): the
+// boot-time credential injection moved to the whole-plan boot
+// (newLaunchImageRunner wires daemonPlanProxyBootstrapper). A rung-3 tool step
+// therefore egresses passthrough until #1829 retargets per-step proxy scoping
+// onto this dispatch.
 var newLaunchToolImageRunner = func() runtime.ToolImageRunner {
-	return containerToolImageRunner{proxy: daemonToolProxyBootstrapper{}}
+	return containerToolImageRunner{}
 }
 
 // launchSeamForTest is the LLM seam the launch wires into the runtime. It is

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -43,11 +43,22 @@ import (
 // host can query. A zero-value runner has daemonEnv == nil and injects no env,
 // keeping the CLI unit tests deterministic irrespective of any live ~/.aileron
 // daemon; production wires the daemon-backed resolver via newLaunchImageRunner.
+//
+// Boot-time credential injection (#1828): when proxy is non-nil the runner
+// routes the whole booted plan container's HTTPS egress through the ADR-0019
+// daemon forward proxy via env-based CA trust, so a matched host binding injects
+// the operator's vault-bound credential at the boundary. No credential BYTES
+// cross this boundary in the image, env, mounts, or args: only a read-only CA
+// and the catalog-derived placeholder (non-secret) creds are set. A zero-value
+// runner has proxy == nil and stays passthrough.
 type containerImageRunner struct {
 	// daemonEnv, when non-nil, resolves the daemon env injected into the boot so
 	// the in-container launch reaches the host daemon. nil (the zero value) is
 	// passthrough (no injected env).
 	daemonEnv imageDaemonEnv
+	// proxy, when non-nil, enriches the boot with proxy egress + CA trust +
+	// catalog-derived placeholder creds. nil (the zero value) is passthrough.
+	proxy planProxyBootstrapper
 	// diag is where the pre-boot CLI-version-skew warning is written. nil (the
 	// zero value) means os.Stderr in production; tests set a buffer to assert the
 	// warning end-to-end through Run.
@@ -218,6 +229,41 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		}
 	}
 
+	// Boot-time credential injection (#1828): when a proxy bootstrapper is wired,
+	// route the whole booted plan container's HTTPS egress through the ADR-0019
+	// daemon forward proxy via env-based CA trust so a matched host binding
+	// injects the operator's vault-bound credential at the boundary. Prepare
+	// fails closed: a boot that resolved daemon config but could not write its
+	// session CA (or whose declared conventions were malformed) must NOT silently
+	// egress un-proxied — it runs cleanup and fails the boot. The proxy env and
+	// the sentinel + daemon env are disjoint key sets
+	// (HTTPS_PROXY/CA/placeholders vs
+	// AILERON_SKILL_IMAGE_BOOTED/AILERON_API_URL/AILERON_TOKEN), so the merge
+	// never clobbers the sentinel or daemon coordinates. Cleanup is deferred so
+	// the session CA is removed after the (synchronous) run completes.
+	if r.proxy != nil {
+		bootstrap, cleanup, ok, err := r.proxy.Prepare(ctx, runtimeName, spec.Image, spec.Name)
+		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			return runtime.ImageRunResult{}, err
+		}
+		if ok {
+			if cleanup != nil {
+				defer cleanup()
+			}
+			opts.Volumes = append(opts.Volumes, bootstrap.Mount)
+			if opts.Env == nil {
+				opts.Env = bootstrap.Env
+			} else {
+				for k, v := range bootstrap.Env {
+					opts.Env[k] = v
+				}
+			}
+		}
+	}
+
 	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, os.Stderr, opts); err != nil {
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: run pinned image %q: %w", spec.Image, err)
 	}
@@ -243,19 +289,15 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 // containerRunToolImage indirection so CLI tests swap a fake and never touch
 // Docker.
 //
-// Credential injection (#1769): when proxy is non-nil the runner routes the
-// tool container's HTTPS egress through the ADR-0019 daemon forward proxy via
-// env-based CA trust, so a matched host binding injects the operator's
-// vault-bound credential at the boundary. No credential BYTES cross this
-// boundary in the image, env, mounts, or args: only a read-only CA and
-// placeholder (non-secret) creds are set. A zero-value runner has proxy == nil
-// and stays passthrough (no CA mount, no env), which keeps the CLI unit tests
-// deterministic irrespective of any live ~/.aileron daemon.
-type containerToolImageRunner struct {
-	// proxy, when non-nil, enriches the dispatch with proxy egress + CA trust.
-	// nil (the zero value) is passthrough.
-	proxy toolProxyBootstrapper
-}
+// Per-dispatch egress is UN-PROXIED in the interim window (#1828/#1829): the
+// boot-time credential injection moved to the whole-plan boot
+// (containerImageRunner), so a rung-3 per-step tool dispatch currently egresses
+// passthrough (direct, no forward proxy, no CA, no placeholder creds). #1829
+// retargets per-step proxy scoping onto this dispatch; until it lands a step's
+// outbound HTTPS is un-mediated. The step input written to the read-only mount
+// is binding-resolved data only and never a credential, so no secret bytes
+// cross this boundary regardless.
+type containerToolImageRunner struct{}
 
 // containerToolInputFile is the filename the resolved step input is written to
 // inside the mount dir. The tool reads its input from MountPath/<this>.
@@ -336,31 +378,6 @@ func (r containerToolImageRunner) Run(ctx context.Context, spec runtime.ToolRunS
 		// and no implicit operator-CWD workspace mount is emitted — the tool
 		// sees exactly the declared mounts above and nothing else.
 		ToolDispatch: true,
-	}
-
-	// Credential-injection enrichment (#1769): when a proxy bootstrapper is
-	// wired, route the tool container's HTTPS egress through the ADR-0019 daemon
-	// forward proxy via env-based CA trust so a matched host binding injects the
-	// operator's vault-bound credential at the boundary. Prepare fails closed: a
-	// dispatch that resolved daemon config but could not write its session CA
-	// must NOT silently egress un-proxied. The cleanup is deferred so the
-	// session CA is removed even if the boot below fails. RunOptions.Command is
-	// never set — the tool image's own entrypoint must run.
-	if r.proxy != nil {
-		bootstrap, cleanup, ok, err := r.proxy.Prepare(runtimeName, spec.StepID)
-		if err != nil {
-			// Prepare may have written a partial session CA before failing; run
-			// its cleanup so nothing leaks on the fail-closed path.
-			if cleanup != nil {
-				cleanup()
-			}
-			return runtime.ToolRunResult{}, err
-		}
-		if ok {
-			defer cleanup()
-			opts.Volumes = append(opts.Volumes, bootstrap.Mount)
-			opts.Env = bootstrap.Env
-		}
 	}
 
 	if _, err := containerRunToolImage(ctx, runtimeName, os.Stdout, os.Stderr, opts); err != nil {

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -361,10 +361,11 @@ func TestContainerImageRunner_ZeroValueInjectsNoEnv(t *testing.T) {
 	}
 }
 
-// TestNewLaunchImageRunner_WiresDaemonEnvResolver proves the production seam
-// wires the daemon-backed env resolver so production boots carry the host daemon
-// coordinates (#1759), mirroring newLaunchToolImageRunner's proxy wiring.
-func TestNewLaunchImageRunner_WiresDaemonEnvResolver(t *testing.T) {
+// TestNewLaunchImageRunner_WiresDaemonEnvAndProxy proves the production seam
+// wires both the daemon-backed env resolver (#1759) and the daemon-backed plan
+// proxy bootstrapper (#1828) so production boots carry the host daemon
+// coordinates AND the proxy/CA/placeholder enrichment.
+func TestNewLaunchImageRunner_WiresDaemonEnvAndProxy(t *testing.T) {
 	runner, ok := newLaunchImageRunner().(containerImageRunner)
 	if !ok {
 		t.Fatalf("newLaunchImageRunner returned %T, want containerImageRunner", newLaunchImageRunner())
@@ -372,8 +373,197 @@ func TestNewLaunchImageRunner_WiresDaemonEnvResolver(t *testing.T) {
 	if _, ok := runner.daemonEnv.(daemonImageEnv); !ok {
 		t.Errorf("daemonEnv = %T, want daemonImageEnv (the production resolver)", runner.daemonEnv)
 	}
+	if _, ok := runner.proxy.(daemonPlanProxyBootstrapper); !ok {
+		t.Errorf("proxy = %T, want daemonPlanProxyBootstrapper (the production bootstrapper)", runner.proxy)
+	}
 	if runner.diag != nil {
 		t.Errorf("newLaunchImageRunner diag = %v, want nil (os.Stderr in production)", runner.diag)
+	}
+}
+
+// TestNewLaunchToolImageRunner_ZeroValue proves the per-dispatch tool runner is
+// wired with no proxy in the interim window (#1828/#1829): per-step egress is
+// un-proxied until #1829 retargets per-step scoping onto it.
+func TestNewLaunchToolImageRunner_ZeroValue(t *testing.T) {
+	if _, ok := newLaunchToolImageRunner().(containerToolImageRunner); !ok {
+		t.Fatalf("newLaunchToolImageRunner returned %T, want containerToolImageRunner", newLaunchToolImageRunner())
+	}
+}
+
+// fakePlanProxyBootstrapper is a test double for planProxyBootstrapper. It
+// records that Prepare/cleanup ran and returns a canned enrichment so the
+// enriched boot RunOptions shape is asserted with no live daemon and no Docker.
+type fakePlanProxyBootstrapper struct {
+	env         map[string]string
+	mount       sandboxcontainer.Volume
+	ok          bool
+	err         error
+	prepared    bool
+	cleaned     bool
+	gotRuntime  string
+	gotImage    string
+	gotPlanName string
+}
+
+func (f *fakePlanProxyBootstrapper) Prepare(_ context.Context, runtimeName, image, planName string) (planProxyBootstrap, func(), bool, error) {
+	f.prepared = true
+	f.gotRuntime = runtimeName
+	f.gotImage = image
+	f.gotPlanName = planName
+	if f.err != nil {
+		return planProxyBootstrap{}, func() { f.cleaned = true }, false, f.err
+	}
+	return planProxyBootstrap{Env: f.env, Mount: f.mount}, func() { f.cleaned = true }, f.ok, nil
+}
+
+// TestContainerImageRunner_ProxyEnrichesBoot proves that when a proxy
+// bootstrapper is wired and resolves, the whole-plan boot appends the read-only
+// CA mount and merges the proxy/CA/placeholder env alongside the boot sentinel
+// and daemon env (#1828). The distinct key sets never clobber each other, and
+// cleanup runs after the synchronous run.
+func TestContainerImageRunner_ProxyEnrichesBoot(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	daemon := &fakeImageDaemonEnv{
+		env: map[string]string{
+			"AILERON_API_URL": "http://host.docker.internal:48123/v1",
+			"AILERON_TOKEN":   "daemon-token",
+		},
+		ok: true,
+	}
+	proxy := &fakePlanProxyBootstrapper{
+		ok: true,
+		env: map[string]string{
+			"HTTPS_PROXY":       "http://sess:tok@host.docker.internal:48123",
+			"https_proxy":       "http://sess:tok@host.docker.internal:48123",
+			"NO_PROXY":          "localhost,127.0.0.1,::1,host.docker.internal",
+			"no_proxy":          "localhost,127.0.0.1,::1,host.docker.internal",
+			"AWS_CA_BUNDLE":     "/etc/aileron/proxy/ca.pem",
+			"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7PLACEHLDR",
+			"GH_TOKEN":          "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA",
+		},
+		mount: sandboxcontainer.Volume{Source: "/host/ca.pem", Target: "/etc/aileron/proxy/ca.pem", ReadOnly: true},
+	}
+	spec := runtime.ImageRunSpec{
+		Image: "registry.example.com/runner@sha256:abc",
+		Name:  "weekly-metrics-digest",
+	}
+	if _, err := (containerImageRunner{daemonEnv: daemon, proxy: proxy}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !proxy.prepared {
+		t.Error("Prepare must be called when a proxy bootstrapper is wired")
+	}
+	if proxy.gotImage != spec.Image {
+		t.Errorf("Prepare image = %q, want the spec image", proxy.gotImage)
+	}
+	if proxy.gotPlanName != spec.Name {
+		t.Errorf("Prepare planName = %q, want the spec name", proxy.gotPlanName)
+	}
+	if !proxy.cleaned {
+		t.Error("cleanup must run after the synchronous boot")
+	}
+
+	// The CA mount is appended read-only at the well-known in-container CA path.
+	var caMountRO bool
+	for _, v := range got.Volumes {
+		if v.Target == "/etc/aileron/proxy/ca.pem" && v.ReadOnly {
+			caMountRO = true
+		}
+	}
+	if !caMountRO {
+		t.Errorf("CA must be mounted read-only at /etc/aileron/proxy/ca.pem, got %+v", got.Volumes)
+	}
+
+	// The proxy env is merged in alongside the sentinel + daemon env; the three
+	// key sets are disjoint, so none clobbers another.
+	if got.Env[envSkillImageBooted] != "1" {
+		t.Errorf("%s = %q, want the boot sentinel preserved after the proxy merge", envSkillImageBooted, got.Env[envSkillImageBooted])
+	}
+	if got.Env["AILERON_API_URL"] != "http://host.docker.internal:48123/v1" || got.Env["AILERON_TOKEN"] != "daemon-token" {
+		t.Errorf("daemon env must survive the proxy merge, got API_URL=%q TOKEN=%q", got.Env["AILERON_API_URL"], got.Env["AILERON_TOKEN"])
+	}
+	if !strings.Contains(got.Env["HTTPS_PROXY"], "host.docker.internal") {
+		t.Errorf("HTTPS_PROXY = %q, want the proxy URL", got.Env["HTTPS_PROXY"])
+	}
+	if got.Env["NO_PROXY"] != "localhost,127.0.0.1,::1,host.docker.internal" {
+		t.Errorf("NO_PROXY = %q, want the loopback+daemon bypass list", got.Env["NO_PROXY"])
+	}
+	if got.Env["AWS_CA_BUNDLE"] != "/etc/aileron/proxy/ca.pem" {
+		t.Errorf("AWS_CA_BUNDLE = %q, want the container CA path", got.Env["AWS_CA_BUNDLE"])
+	}
+	if got.Env["AWS_ACCESS_KEY_ID"] != "AKIAIOSFODNN7PLACEHLDR" || got.Env["GH_TOKEN"] != "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA" {
+		t.Errorf("placeholder creds missing from the merged boot env: %+v", got.Env)
+	}
+}
+
+// TestContainerImageRunner_ProxyPassthroughWhenNotOK proves a bootstrapper
+// returning ok=false leaves the boot un-enriched: no CA mount, only the boot
+// sentinel on the env (#1828).
+func TestContainerImageRunner_ProxyPassthroughWhenNotOK(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+
+	proxy := &fakePlanProxyBootstrapper{ok: false}
+	spec := runtime.ImageRunSpec{Image: "img@sha256:abc", Name: "p"}
+	if _, err := (containerImageRunner{proxy: proxy}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !proxy.prepared {
+		t.Error("Prepare must still be consulted")
+	}
+	for _, v := range got.Volumes {
+		if v.Target == "/etc/aileron/proxy/ca.pem" {
+			t.Errorf("passthrough boot must not mount a CA, got %+v", got.Volumes)
+		}
+	}
+	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the passthrough (ok=false) boot", got.Env)
+	}
+}
+
+// TestContainerImageRunner_ProxyPrepareErrorFailsClosed proves a Prepare error
+// (daemon config resolved but the CA could not be written, or a malformed
+// metadata convention) fails the boot rather than silently egressing
+// un-proxied, and runs the returned cleanup (#1828).
+func TestContainerImageRunner_ProxyPrepareErrorFailsClosed(t *testing.T) {
+	storeDir := t.TempDir()
+	origStore := skillStoreDir
+	skillStoreDir = storeDir
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	var got sandboxcontainer.RunOptions
+	booted := false
+	orig := containerRunFlightPlan
+	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+		booted = true
+		got = opts
+		return sandboxcontainer.RunResult{}, nil
+	}
+	t.Cleanup(func() { containerRunFlightPlan = orig })
+
+	proxy := &fakePlanProxyBootstrapper{err: errors.New("ca write failed")}
+	_, err := (containerImageRunner{proxy: proxy}).Run(context.Background(), runtime.ImageRunSpec{Image: "img@sha256:abc", Name: "p"})
+	if err == nil || !strings.Contains(err.Error(), "ca write failed") {
+		t.Fatalf("Prepare error must fail the boot closed, got %v", err)
+	}
+	if booted {
+		t.Errorf("the image must NOT boot after a fail-closed Prepare error, got %+v", got)
+	}
+	if !proxy.cleaned {
+		t.Error("the returned cleanup must run on the error path so a partial CA never leaks")
 	}
 }
 
@@ -693,156 +883,6 @@ func TestContainerToolImageRunner_SymlinkedCollectRefused(t *testing.T) {
 	}
 	if res.Output != nil {
 		t.Errorf("no host bytes must be smuggled into the output, got %v", res.Output)
-	}
-}
-
-// fakeToolProxyBootstrapper is a test double for toolProxyBootstrapper. It
-// records that Prepare/cleanup ran and returns a canned enrichment so the
-// enriched RunOptions shape is asserted with no live daemon and no Docker.
-type fakeToolProxyBootstrapper struct {
-	env        map[string]string
-	mount      sandboxcontainer.Volume
-	ok         bool
-	err        error
-	prepared   bool
-	cleaned    bool
-	gotRuntime string
-	gotStepID  string
-}
-
-func (f *fakeToolProxyBootstrapper) Prepare(runtimeName, stepID string) (toolProxyBootstrap, func(), bool, error) {
-	f.prepared = true
-	f.gotRuntime = runtimeName
-	f.gotStepID = stepID
-	if f.err != nil {
-		return toolProxyBootstrap{}, nil, false, f.err
-	}
-	return toolProxyBootstrap{Env: f.env, Mount: f.mount}, func() { f.cleaned = true }, f.ok, nil
-}
-
-// TestContainerToolImageRunner_ProxyEnrichesRunOptions proves that when a proxy
-// bootstrapper is wired, the dispatch appends the read-only CA mount, sets the
-// proxy/CA-bundle env, seeds placeholder creds, never sets a Command, and runs
-// cleanup after the boot. This is the #1769 credential-injection wiring proof:
-// the enriched RunOptions shape is asserted without touching Docker.
-func TestContainerToolImageRunner_ProxyEnrichesRunOptions(t *testing.T) {
-	var got sandboxcontainer.RunOptions
-	stubContainerToolBoot(t, &got, "out", "COLLECTED", nil)
-
-	fake := &fakeToolProxyBootstrapper{
-		ok: true,
-		env: map[string]string{
-			"HTTPS_PROXY":           "http://sess:tok@host.docker.internal:48123",
-			"https_proxy":           "http://sess:tok@host.docker.internal:48123",
-			"AWS_CA_BUNDLE":         "/etc/aileron/proxy/ca.pem",
-			"AWS_ACCESS_KEY_ID":     placeholderAWSAccessKeyID,
-			"AWS_SECRET_ACCESS_KEY": placeholderAWSSecretKey,
-		},
-		mount: sandboxcontainer.Volume{Source: "/host/ca.pem", Target: "/etc/aileron/proxy/ca.pem", ReadOnly: true},
-	}
-	runner := containerToolImageRunner{proxy: fake}
-
-	spec := runtime.ToolRunSpec{
-		Image:       "amazon/aws-cli@sha256:abc",
-		StepID:      "query-athena",
-		MountPath:   "/work/in",
-		Input:       map[string]any{"sql": "SELECT 1"},
-		CollectPath: "/work/out/out",
-	}
-	if _, err := runner.Run(context.Background(), spec); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	if !fake.prepared {
-		t.Error("Prepare must be called when a proxy bootstrapper is wired")
-	}
-	if fake.gotStepID != "query-athena" {
-		t.Errorf("Prepare stepID = %q, want the spec step id", fake.gotStepID)
-	}
-	if !fake.cleaned {
-		t.Error("cleanup must run after the boot")
-	}
-
-	// The CA mount is appended read-only at the well-known in-container CA path,
-	// alongside the mount/collect volumes.
-	var caMountRO bool
-	for _, v := range got.Volumes {
-		if v.Target == "/etc/aileron/proxy/ca.pem" && v.ReadOnly {
-			caMountRO = true
-		}
-	}
-	if !caMountRO {
-		t.Errorf("CA must be mounted read-only at /etc/aileron/proxy/ca.pem, got %+v", got.Volumes)
-	}
-
-	// The proxy + CA-bundle + placeholder-cred env is set on the run.
-	if !strings.Contains(got.Env["HTTPS_PROXY"], "host.docker.internal") {
-		t.Errorf("HTTPS_PROXY = %q, want host.docker.internal", got.Env["HTTPS_PROXY"])
-	}
-	if got.Env["AWS_CA_BUNDLE"] != "/etc/aileron/proxy/ca.pem" {
-		t.Errorf("AWS_CA_BUNDLE = %q, want the container CA path", got.Env["AWS_CA_BUNDLE"])
-	}
-	if got.Env["AWS_ACCESS_KEY_ID"] != placeholderAWSAccessKeyID {
-		t.Errorf("AWS_ACCESS_KEY_ID = %q, want placeholder", got.Env["AWS_ACCESS_KEY_ID"])
-	}
-
-	// The tool image's own entrypoint must run: Command is NEVER set.
-	if len(got.Command) != 0 {
-		t.Errorf("Command must never be set for a tool dispatch, got %v", got.Command)
-	}
-}
-
-// TestContainerToolImageRunner_ProxyPassthroughWhenNotOK proves that a
-// bootstrapper returning ok=false leaves the dispatch un-enriched (no CA mount,
-// no env) and still cleans up nothing.
-func TestContainerToolImageRunner_ProxyPassthroughWhenNotOK(t *testing.T) {
-	var got sandboxcontainer.RunOptions
-	stubContainerToolBoot(t, &got, "out", "COLLECTED", nil)
-
-	fake := &fakeToolProxyBootstrapper{ok: false}
-	runner := containerToolImageRunner{proxy: fake}
-
-	if _, err := runner.Run(context.Background(), runtime.ToolRunSpec{
-		Image:       "img@sha256:abc",
-		StepID:      "s1",
-		CollectPath: "/work/out/out",
-	}); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if !fake.prepared {
-		t.Error("Prepare must still be consulted")
-	}
-	for _, v := range got.Volumes {
-		if v.Target == "/etc/aileron/proxy/ca.pem" {
-			t.Errorf("passthrough dispatch must not mount a CA, got %+v", got.Volumes)
-		}
-	}
-	if len(got.Env) != 0 {
-		t.Errorf("passthrough dispatch must set no env, got %+v", got.Env)
-	}
-}
-
-// TestContainerToolImageRunner_ProxyPrepareErrorFailsClosed proves that a
-// Prepare error (daemon config resolved but the CA could not be written) fails
-// the dispatch rather than silently egressing un-proxied.
-func TestContainerToolImageRunner_ProxyPrepareErrorFailsClosed(t *testing.T) {
-	var got sandboxcontainer.RunOptions
-	booted := false
-	orig := containerRunToolImage
-	containerRunToolImage = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
-		booted = true
-		got = opts
-		return sandboxcontainer.RunResult{}, nil
-	}
-	t.Cleanup(func() { containerRunToolImage = orig })
-
-	runner := containerToolImageRunner{proxy: &fakeToolProxyBootstrapper{err: errors.New("ca write failed")}}
-	_, err := runner.Run(context.Background(), runtime.ToolRunSpec{Image: "img@sha256:abc", StepID: "s1"})
-	if err == nil || !strings.Contains(err.Error(), "ca write failed") {
-		t.Fatalf("Prepare error must fail the dispatch closed, got %v", err)
-	}
-	if booted {
-		t.Errorf("the tool image must NOT boot after a fail-closed Prepare error, got %+v", got)
 	}
 }
 

--- a/cmd/aileron/skill_launch_proxy.go
+++ b/cmd/aileron/skill_launch_proxy.go
@@ -1,42 +1,48 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
-// toolProxyBootstrapper is the seam the rung-3 tool-container dispatch uses to
-// route a step's HTTPS egress through the ADR-0019 daemon forward proxy so a
-// matched host binding injects the operator's vault-bound credential at the
-// boundary (#1769). It is injected onto containerToolImageRunner rather than
-// read from ambient config: a zero-value runner has proxy == nil and stays
+// planProxyBootstrapper is the seam the whole-plan image boot uses to route the
+// booted plan container's HTTPS egress through the ADR-0019 daemon forward proxy
+// so a matched host binding injects the operator's vault-bound credential at the
+// boundary (#1828). It is injected onto containerImageRunner rather than read
+// from ambient config: a zero-value runner has proxy == nil and stays
 // passthrough, which keeps the CLI unit tests deterministic irrespective of any
 // live ~/.aileron daemon on the dev/CI box. Production wires the daemon-backed
-// bootstrapper via newLaunchToolImageRunner.
-type toolProxyBootstrapper interface {
-	// Prepare provisions a fresh session CA + authed proxy URL for one tool
-	// dispatch and returns the env/CA enrichment, a cleanup func to remove the
+// bootstrapper via newLaunchImageRunner.
+type planProxyBootstrapper interface {
+	// Prepare provisions a fresh session CA + authed proxy URL for one whole-plan
+	// boot and returns the env/CA enrichment, a cleanup func to remove the
 	// session CA after the run, and ok=false when daemon config is absent
-	// (passthrough). A non-nil error means daemon config resolved but the CA
-	// could not be written; the dispatch must fail closed rather than egress
-	// un-proxied.
-	Prepare(runtimeName, stepID string) (toolProxyBootstrap, func(), bool, error)
+	// (passthrough). A non-nil error means daemon config resolved but the boot
+	// could not be provisioned (CA write failed, or the image's declared
+	// credential conventions were malformed); the boot must fail closed rather
+	// than egress un-proxied. On the error path the returned cleanup is still
+	// runnable so a partial session CA never leaks.
+	Prepare(ctx context.Context, runtimeName, image, planName string) (planProxyBootstrap, func(), bool, error)
 }
 
-// toolProxyBootstrap carries the enrichment applied to a tool dispatch's
+// planProxyBootstrap carries the enrichment applied to a whole-plan boot's
 // RunOptions: the environment variables that point the container's HTTPS client
 // at the proxy and trust the mounted CA, plus the read-only CA bind mount.
-type toolProxyBootstrap struct {
+type planProxyBootstrap struct {
 	// Env is merged onto RunOptions.Env: the CA-bundle vars pointing at the
-	// mounted CA, HTTPS_PROXY/https_proxy carrying the authed proxy URL, and the
-	// placeholder AWS creds that make botocore pre-sign so the proxy can re-sign.
+	// mounted CA, HTTPS_PROXY/https_proxy carrying the authed proxy URL,
+	// NO_PROXY/no_proxy so loopback/daemon traffic bypasses the proxy, and the
+	// catalog-derived placeholder creds that make each declared tool pre-sign so
+	// the proxy can re-sign or swap at the boundary.
 	Env map[string]string
-	// Mount is the read-only CA bind mount appended to the run's volumes.
+	// Mount is the read-only CA bind mount appended to the boot's volumes.
 	Mount sandboxcontainer.Volume
 }
 
@@ -55,73 +61,104 @@ var caBundleEnvVars = []string{
 	"CURL_CA_BUNDLE",
 }
 
-// Placeholder AWS credentials seeded into the tool container so botocore
-// pre-signs the request locally; the daemon proxy Header.Del's the client
-// signature and re-signs with the vault secret at the boundary. These are
-// non-secret constants, harmless when unused by a non-AWS tool: they carry no
-// entitlement and never reach an AWS endpoint (the proxy discards the
-// placeholder-derived signature). They exist only so a request leaves the
-// container in a shape the proxy can re-sign.
-const (
-	placeholderAWSAccessKeyID = "AKIAIOSFODNN7PLACEHLDR"
-	placeholderAWSSecretKey   = "placeholderAileronInjectsRealSecretXXXXXX"
-)
+// bootNoProxyHosts are the hosts the booted plan container must reach WITHOUT
+// routing through the egress proxy. Unlike a per-step tool container, the booted
+// plan container calls the host daemon (AILERON_API_URL at host.docker.internal,
+// #1759) for every action + audit POST; loopback and the daemon host must never
+// CONNECT through the forward proxy. This is a deliberate delta from the removed
+// per-dispatch env set, which carried no NO_PROXY.
+const bootNoProxyHosts = "localhost,127.0.0.1,::1,host.docker.internal"
 
-// daemonToolProxyBootstrapper is the production toolProxyBootstrapper. It
+// containerImageMetadataLabel reads the devcontainer.metadata OCI label of the
+// pinned image (empty when unlabeled or uninspectable). It is a package variable
+// so the CLI tests swap it for a fake and never shell out to
+// `docker image inspect`, mirroring the containerBakedCLIVersion seam. The
+// label carries the declared tools' merged customizations.aileron.credential
+// blocks, from which the boot derives the placeholder env union.
+var containerImageMetadataLabel = func(ctx context.Context, runtimeName, image string) string {
+	return sandboxcontainer.ImageMetadataLabel(ctx, sandboxcontainer.DefaultRunner(), runtimeName, image)
+}
+
+// daemonPlanProxyBootstrapper is the production planProxyBootstrapper. It
 // resolves the daemon base URL, auth token, and state dir WITHOUT triggering a
 // daemon spawn (it reads env/discovery only), so a launch with no running
 // daemon stays passthrough rather than forcing a daemon boot. When config
-// resolves it provisions the session CA via launch.PrepareToolContainerProxy
-// and assembles the env map.
+// resolves it provisions the session CA via launch.PrepareContainerProxy, reads
+// the booted image's declared credential conventions from its
+// devcontainer.metadata label, and assembles the env map.
 //
 // Activation gates on daemon-config PRESENCE (token + base URL from
 // AILERON_TOKEN/AILERON_API_URL or ~/.aileron discovery), not on daemon
 // LIVENESS: a stale ~/.aileron discovery entry (token present) with no daemon
-// actually listening still enriches HTTPS_PROXY/CA and routes every rung-3 tool
-// step through a non-existent proxy, failing with CONNECT connection-refused — a
-// regression versus direct-egress passthrough. Config-presence gating is
+// actually listening still enriches HTTPS_PROXY/CA and routes the booted plan's
+// egress through a non-existent proxy, failing with CONNECT connection-refused —
+// a regression versus direct-egress passthrough. Config-presence gating is
 // accepted; liveness-probing / fail-open is deferred to a follow-up. See
-// ADR-0019, "Rung-3 tool-container egress reuses the data plane".
-type daemonToolProxyBootstrapper struct{}
+// ADR-0019.
+type daemonPlanProxyBootstrapper struct{}
 
-func (daemonToolProxyBootstrapper) Prepare(runtimeName, stepID string) (toolProxyBootstrap, func(), bool, error) {
+func (daemonPlanProxyBootstrapper) Prepare(ctx context.Context, runtimeName, image, planName string) (planProxyBootstrap, func(), bool, error) {
 	stateDir, err := defaultStateDir()
 	if err != nil {
-		return toolProxyBootstrap{}, nil, false, nil
+		return planProxyBootstrap{}, nil, false, nil
 	}
 	root, ok := resolveDaemonRootURL(stateDir)
 	if !ok {
-		return toolProxyBootstrap{}, nil, false, nil
+		return planProxyBootstrap{}, nil, false, nil
 	}
 	token, ok := resolveDaemonProxyToken(stateDir)
 	if !ok {
-		return toolProxyBootstrap{}, nil, false, nil
+		return planProxyBootstrap{}, nil, false, nil
 	}
 
-	// Mint a UNIQUE session id per dispatch so no two dispatches (and no agent
-	// launch) share a session CA directory. The cleanup closure is defined
-	// against that id up front and returned on BOTH the success and the
-	// error path, so a PrepareToolContainerProxy that fails after writing a
-	// partial CA dir never leaks daemon-side state: the caller runs cleanup.
-	sessionID := "flightplan-tool-" + sanitizeSessionSegment(stepID) + "-" + randomSuffix()
-	cleanup := func() { _ = launch.CleanupToolContainerProxy(stateDir, sessionID) }
+	// Mint a UNIQUE session id per boot so no two boots (and no agent launch)
+	// share a session CA directory. The cleanup closure is defined against that
+	// id up front and returned on BOTH the success and the error path, so a
+	// PrepareContainerProxy that fails after writing a partial CA dir, or a
+	// malformed-metadata refusal after the CA is written, never leaks daemon-side
+	// state: the caller runs cleanup.
+	sessionID := "flightplan-boot-" + sanitizeSessionSegment(planName) + "-" + randomSuffix()
+	cleanup := func() { _ = launch.CleanupContainerProxy(stateDir, sessionID) }
 
-	prepared, err := launch.PrepareToolContainerProxy(stateDir, sessionID, root, runtimeName, token)
+	prepared, err := launch.PrepareContainerProxy(stateDir, sessionID, root, runtimeName, token)
 	if err != nil {
-		return toolProxyBootstrap{}, cleanup, false, fmt.Errorf("skill launch: provision tool container proxy: %w", err)
+		return planProxyBootstrap{}, cleanup, false, fmt.Errorf("skill launch: provision plan container proxy: %w", err)
 	}
 
-	env := map[string]string{
-		"HTTPS_PROXY":           prepared.ProxyURL,
-		"https_proxy":           prepared.ProxyURL,
-		"AWS_ACCESS_KEY_ID":     placeholderAWSAccessKeyID,
-		"AWS_SECRET_ACCESS_KEY": placeholderAWSSecretKey,
+	// Read the declared tools' credential conventions off the exact signed pin
+	// being booted (its devcontainer.metadata label) and derive the placeholder
+	// env union. An unlabeled/uninspectable image reads as "" and contributes an
+	// empty union (fail-soft, matching ImageMetadataLabel's posture); a present
+	// but malformed convention is a loud error that refuses the boot (a
+	// present-but-broken convention must not silently ship nothing — #1825).
+	convs, err := composition.ConventionsFromMetadata([]byte(containerImageMetadataLabel(ctx, runtimeName, image)))
+	if err != nil {
+		return planProxyBootstrap{}, cleanup, false, fmt.Errorf("skill launch: read image credential conventions: %w", err)
 	}
+	placeholders, err := composition.PlaceholderEnv(convs)
+	if err != nil {
+		return planProxyBootstrap{}, cleanup, false, fmt.Errorf("skill launch: assemble placeholder env: %w", err)
+	}
+
+	// Seed the catalog-derived placeholders FIRST, then let the reserved
+	// proxy/CA keys overwrite them, so an image-declared placeholder can never
+	// clobber the authoritative HTTPS_PROXY/NO_PROXY/CA-bundle settings and
+	// weaken the fail-closed egress mediation. A placeholder that (mis)declares a
+	// reserved env is silently overridden by the reserved value below rather than
+	// winning.
+	env := map[string]string{}
+	for k, v := range placeholders {
+		env[k] = v
+	}
+	env["HTTPS_PROXY"] = prepared.ProxyURL
+	env["https_proxy"] = prepared.ProxyURL
+	env["NO_PROXY"] = bootNoProxyHosts
+	env["no_proxy"] = bootNoProxyHosts
 	for _, v := range caBundleEnvVars {
 		env[v] = prepared.CAContainerPath
 	}
 
-	return toolProxyBootstrap{Env: env, Mount: prepared.CAMount}, cleanup, true, nil
+	return planProxyBootstrap{Env: env, Mount: prepared.CAMount}, cleanup, true, nil
 }
 
 // imageDaemonEnv is the seam the Flight Plan image-boot path (#1759) uses to
@@ -151,7 +188,7 @@ type imageDaemonEnv interface {
 // actually listening still injects env, and the inner launch's audit POST fails
 // with connection-refused — a regression versus the ephemeral in-container
 // daemon. Config-presence gating is accepted; liveness-probing / fail-open is
-// deferred to a follow-up, mirroring daemonToolProxyBootstrapper.
+// deferred to a follow-up, mirroring daemonPlanProxyBootstrapper.
 type daemonImageEnv struct{}
 
 func (daemonImageEnv) Env(runtimeName string) (map[string]string, bool) {
@@ -177,8 +214,8 @@ func (daemonImageEnv) Env(runtimeName string) (map[string]string, bool) {
 // container: the daemon root (no /v1) is loopback-rewritten to
 // host.docker.internal so the in-container process reaches the host-bound
 // daemon, then the /v1 API prefix is appended. The inner launch's
-// bindingAPIBaseURL uses this value directly as `base + "/actions/..."` and
-// `base + "/audit"`, so the injected value MUST carry the /v1 suffix (the host
+// bindingAPIBaseURL uses this value directly as base + "/actions/..." and
+// base + "/audit", so the injected value MUST carry the /v1 suffix (the host
 // rewrite is applied to the host portion only and preserves the path). This is
 // the container-facing analogue of internal/launch's daemonAPIBaseURL over
 // ContainerURLForRuntime.
@@ -204,8 +241,7 @@ func resolveDaemonRootURL(stateDir string) (string, bool) {
 // resolveDaemonProxyToken resolves the daemon auth token from AILERON_TOKEN or
 // discovery, without spawning a daemon. It returns ok=false when neither source
 // yields a token: the CONNECT handshake authenticates password=daemonToken, so
-// a missing token means the proxy would 407 and the dispatch must stay
-// passthrough.
+// a missing token means the proxy would 407 and the boot must stay passthrough.
 //
 // The token resolved here is the FULL daemon token, and daemonImageEnv.Env
 // injects it verbatim as AILERON_TOKEN into the booted container. This differs
@@ -235,13 +271,13 @@ func stripV1Suffix(raw string) string {
 	return strings.TrimSuffix(trimmed, "/v1")
 }
 
-// sanitizeSessionSegment reduces a step id to a safe path segment for the
-// session directory name so an odd step id can never escape the sessions tree
-// (the launch primitive also guards this). It keeps alphanumerics, '-' and '_'
-// and replaces everything else with '-', defaulting to "step" when empty.
-func sanitizeSessionSegment(stepID string) string {
+// sanitizeSessionSegment reduces an id to a safe path segment for the session
+// directory name so an odd plan name can never escape the sessions tree (the
+// launch primitive also guards this). It keeps alphanumerics, '-' and '_' and
+// replaces everything else with '-', defaulting to "plan" when empty.
+func sanitizeSessionSegment(id string) string {
 	var b strings.Builder
-	for _, r := range stepID {
+	for _, r := range id {
 		switch {
 		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
 			b.WriteRune(r)
@@ -250,7 +286,7 @@ func sanitizeSessionSegment(stepID string) string {
 		}
 	}
 	if b.Len() == 0 {
-		return "step"
+		return "plan"
 	}
 	return b.String()
 }

--- a/cmd/aileron/skill_launch_proxy_test.go
+++ b/cmd/aileron/skill_launch_proxy_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -40,11 +42,29 @@ func withHomeAndEnv(t *testing.T) string {
 	return stateDir
 }
 
-func TestDaemonToolProxyBootstrapper_AssemblesEnvAndCAFromDiscovery(t *testing.T) {
+// setMetadataLabel swaps the containerImageMetadataLabel seam to return a fixed
+// label for the duration of the test, so the plan bootstrapper never shells out
+// to `docker image inspect`.
+func setMetadataLabel(t *testing.T, label string) {
+	t.Helper()
+	prev := containerImageMetadataLabel
+	containerImageMetadataLabel = func(_ context.Context, _, _ string) string { return label }
+	t.Cleanup(func() { containerImageMetadataLabel = prev })
+}
+
+// twoToolMetadata is a devcontainer.metadata label carrying the aws-cli and gh
+// credential conventions, the multi-tool union the boot must plant.
+const twoToolMetadata = `[
+  {"id":"aws-cli","customizations":{"aileron":{"credential":{"scheme":"sigv4-resign","placeholders":[{"env":"AWS_ACCESS_KEY_ID","value":"AKIAIOSFODNN7PLACEHLDR"},{"env":"AWS_SECRET_ACCESS_KEY","value":"placeholderAileronInjectsRealSecretXXXXXX"}]}}}},
+  {"id":"gh","customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[{"env":"GH_TOKEN","value":"ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"}]}}}}
+]`
+
+func TestDaemonPlanProxyBootstrapper_AssemblesExactEnvAndCAFromDiscovery(t *testing.T) {
 	stateDir := withHomeAndEnv(t)
 	writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "daemon-token")
+	setMetadataLabel(t, twoToolMetadata)
 
-	bootstrap, cleanup, ok, err := daemonToolProxyBootstrapper{}.Prepare("docker", "extract")
+	bootstrap, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "example.com/plan@sha256:abc", "myplan")
 	if err != nil {
 		t.Fatalf("Prepare: %v", err)
 	}
@@ -57,62 +77,72 @@ func TestDaemonToolProxyBootstrapper_AssemblesEnvAndCAFromDiscovery(t *testing.T
 	if bootstrap.Mount.Target != "/etc/aileron/proxy/ca.pem" || !bootstrap.Mount.ReadOnly {
 		t.Fatalf("CA mount = %+v, want RO at /etc/aileron/proxy/ca.pem", bootstrap.Mount)
 	}
-	// The CA exists on disk under the session dir.
+	// ca.pem exists on disk under the boot session dir.
 	if _, err := os.Stat(bootstrap.Mount.Source); err != nil {
 		t.Fatalf("CA not written on disk: %v", err)
 	}
-
-	// HTTPS_PROXY (both cases) is loopback-rewritten to host.docker.internal and
-	// carries the session:token userinfo the CONNECT handshake authenticates.
-	for _, key := range []string{"HTTPS_PROXY", "https_proxy"} {
-		got := bootstrap.Env[key]
-		if !strings.Contains(got, "host.docker.internal:48123") {
-			t.Errorf("%s = %q, want host.docker.internal rewrite", key, got)
-		}
-		if !strings.Contains(got, ":daemon-token@") {
-			t.Errorf("%s = %q, want :daemon-token@ userinfo", key, got)
-		}
+	if !strings.Contains(bootstrap.Mount.Source, filepath.Join("sessions", "flightplan-boot-myplan-")) {
+		t.Errorf("CA source %q not under the flightplan-boot session dir", bootstrap.Mount.Source)
 	}
 
-	// Every CA-bundle var points at the mounted CA path.
-	for _, key := range caBundleEnvVars {
-		if got := bootstrap.Env[key]; got != "/etc/aileron/proxy/ca.pem" {
-			t.Errorf("%s = %q, want the container CA path", key, got)
-		}
+	// The env is EXACTLY the expected map — the authed loopback-rewritten proxy
+	// URL, the six CA vars, NO_PROXY/no_proxy, and the aws-cli + gh placeholder
+	// union — and NOTHING ELSE. Exact-map equality is the "never a real secret"
+	// assertion at this layer.
+	proxyURL := bootstrap.Env["HTTPS_PROXY"]
+	want := map[string]string{
+		"HTTPS_PROXY":           proxyURL,
+		"https_proxy":           proxyURL,
+		"NO_PROXY":              "localhost,127.0.0.1,::1,host.docker.internal",
+		"no_proxy":              "localhost,127.0.0.1,::1,host.docker.internal",
+		"AWS_CA_BUNDLE":         "/etc/aileron/proxy/ca.pem",
+		"REQUESTS_CA_BUNDLE":    "/etc/aileron/proxy/ca.pem",
+		"NODE_EXTRA_CA_CERTS":   "/etc/aileron/proxy/ca.pem",
+		"SSL_CERT_FILE":         "/etc/aileron/proxy/ca.pem",
+		"GIT_SSL_CAINFO":        "/etc/aileron/proxy/ca.pem",
+		"CURL_CA_BUNDLE":        "/etc/aileron/proxy/ca.pem",
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7PLACEHLDR",
+		"AWS_SECRET_ACCESS_KEY": "placeholderAileronInjectsRealSecretXXXXXX",
+		"GH_TOKEN":              "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA",
+	}
+	if !reflect.DeepEqual(bootstrap.Env, want) {
+		t.Fatalf("boot env = %#v\nwant %#v", bootstrap.Env, want)
 	}
 
-	// Placeholder (non-secret) AWS creds are seeded so botocore pre-signs.
-	if bootstrap.Env["AWS_ACCESS_KEY_ID"] != placeholderAWSAccessKeyID {
-		t.Errorf("AWS_ACCESS_KEY_ID = %q, want placeholder", bootstrap.Env["AWS_ACCESS_KEY_ID"])
+	// The proxy URL is loopback-rewritten to host.docker.internal and carries the
+	// session:token userinfo the CONNECT handshake authenticates.
+	if !strings.Contains(proxyURL, "host.docker.internal:48123") {
+		t.Errorf("HTTPS_PROXY = %q, want host.docker.internal rewrite", proxyURL)
 	}
-	if bootstrap.Env["AWS_SECRET_ACCESS_KEY"] != placeholderAWSSecretKey {
-		t.Errorf("AWS_SECRET_ACCESS_KEY = %q, want placeholder", bootstrap.Env["AWS_SECRET_ACCESS_KEY"])
+	if !strings.Contains(proxyURL, ":daemon-token@") {
+		t.Errorf("HTTPS_PROXY = %q, want :daemon-token@ userinfo", proxyURL)
 	}
 
 	// The real daemon token is a proxy-auth credential, not a network secret; it
 	// must appear ONLY in the proxy URL userinfo, never leaked into a CA-bundle
-	// or credential var.
-	for _, key := range append(append([]string{}, caBundleEnvVars...), "AWS_SECRET_ACCESS_KEY") {
+	// or placeholder var.
+	for _, key := range append(append([]string{}, caBundleEnvVars...), "AWS_SECRET_ACCESS_KEY", "GH_TOKEN") {
 		if strings.Contains(bootstrap.Env[key], "daemon-token") {
 			t.Errorf("%s leaked the daemon token: %q", key, bootstrap.Env[key])
 		}
 	}
 
-	// Cleanup removes the session CA directory.
+	// Cleanup removes the boot session CA directory.
 	cleanup()
 	if _, err := os.Stat(bootstrap.Mount.Source); !os.IsNotExist(err) {
 		t.Fatalf("cleanup must remove the session CA, stat err = %v", err)
 	}
 }
 
-func TestDaemonToolProxyBootstrapper_PrefersEnvOverDiscovery(t *testing.T) {
+func TestDaemonPlanProxyBootstrapper_PrefersEnvOverDiscovery(t *testing.T) {
 	stateDir := withHomeAndEnv(t)
 	// Discovery carries a different URL/token; the env must win.
 	writeDiscovery(t, stateDir, "http://127.0.0.1:1/", "discovery-token")
 	t.Setenv("AILERON_API_URL", "http://127.0.0.1:55555/v1")
 	t.Setenv("AILERON_TOKEN", "env-token")
+	setMetadataLabel(t, "")
 
-	bootstrap, cleanup, ok, err := daemonToolProxyBootstrapper{}.Prepare("docker", "s1")
+	bootstrap, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
 	if err != nil {
 		t.Fatalf("Prepare: %v", err)
 	}
@@ -133,10 +163,120 @@ func TestDaemonToolProxyBootstrapper_PrefersEnvOverDiscovery(t *testing.T) {
 	}
 }
 
-func TestDaemonToolProxyBootstrapper_PassthroughWhenConfigAbsent(t *testing.T) {
+func TestDaemonPlanProxyBootstrapper_EmptyMetadataLabelYieldsNoPlaceholders(t *testing.T) {
+	stateDir := withHomeAndEnv(t)
+	writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "daemon-token")
+	setMetadataLabel(t, "") // unlabeled / uninspectable image
+
+	bootstrap, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
+	if err != nil {
+		t.Fatalf("Prepare must fail-soft on an empty label: %v", err)
+	}
+	if !ok {
+		t.Fatal("Prepare must still enrich proxy env + CA on an empty label")
+	}
+	t.Cleanup(cleanup)
+
+	// Proxy + CA are present, but no placeholder creds.
+	if bootstrap.Env["HTTPS_PROXY"] == "" {
+		t.Error("HTTPS_PROXY must still be set with an empty metadata label")
+	}
+	for _, k := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "GH_TOKEN"} {
+		if _, present := bootstrap.Env[k]; present {
+			t.Errorf("placeholder %s must be absent when the label carries no conventions", k)
+		}
+	}
+}
+
+func TestDaemonPlanProxyBootstrapper_MalformedMetadataFailsClosed(t *testing.T) {
+	stateDir := withHomeAndEnv(t)
+	writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "daemon-token")
+	// A present-but-invalid credential block (unknown scheme) must refuse the
+	// boot rather than silently ship no placeholders.
+	setMetadataLabel(t, `[{"customizations":{"aileron":{"credential":{"scheme":"nope","placeholders":[{"env":"X","value":"y"}]}}}}]`)
+
+	_, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
+	if err == nil {
+		t.Fatal("Prepare must error on a malformed metadata label")
+	}
+	if ok {
+		t.Fatal("Prepare must not report ok on the fail-closed path")
+	}
+	// The error path still returns a runnable cleanup so the partial CA is
+	// removed rather than leaked.
+	if cleanup == nil {
+		t.Fatal("Prepare must return a runnable cleanup on the error path")
+	}
+	cleanup()
+}
+
+func TestDaemonPlanProxyBootstrapper_ReservedKeysWinOverPlaceholders(t *testing.T) {
+	stateDir := withHomeAndEnv(t)
+	writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "daemon-token")
+	// A (mis)declared placeholder trying to claim a reserved proxy/CA env must
+	// NOT clobber the authoritative value — reserved keys always win, so the
+	// fail-closed egress mediation cannot be weakened by image metadata.
+	setMetadataLabel(t, `[
+  {"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[
+    {"env":"HTTPS_PROXY","value":"http://evil.example"},
+    {"env":"NO_PROXY","value":"*"},
+    {"env":"AWS_CA_BUNDLE","value":"/tmp/evil.pem"},
+    {"env":"GH_TOKEN","value":"ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"}
+  ]}}}}
+]`)
+
+	bootstrap, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if !ok {
+		t.Fatal("Prepare must resolve")
+	}
+	t.Cleanup(cleanup)
+
+	if strings.Contains(bootstrap.Env["HTTPS_PROXY"], "evil.example") {
+		t.Errorf("HTTPS_PROXY = %q, a placeholder must never override the authoritative proxy URL", bootstrap.Env["HTTPS_PROXY"])
+	}
+	if bootstrap.Env["NO_PROXY"] != "localhost,127.0.0.1,::1,host.docker.internal" {
+		t.Errorf("NO_PROXY = %q, a placeholder must never override the reserved bypass list", bootstrap.Env["NO_PROXY"])
+	}
+	if bootstrap.Env["AWS_CA_BUNDLE"] != "/etc/aileron/proxy/ca.pem" {
+		t.Errorf("AWS_CA_BUNDLE = %q, a placeholder must never override the mounted CA path", bootstrap.Env["AWS_CA_BUNDLE"])
+	}
+	// A non-reserved placeholder (GH_TOKEN) still lands.
+	if bootstrap.Env["GH_TOKEN"] != "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA" {
+		t.Errorf("GH_TOKEN = %q, a non-reserved placeholder must still be planted", bootstrap.Env["GH_TOKEN"])
+	}
+}
+
+func TestDaemonPlanProxyBootstrapper_ConflictingPlaceholdersFailClosed(t *testing.T) {
+	stateDir := withHomeAndEnv(t)
+	writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "daemon-token")
+	// Two elements declare GH_TOKEN with different values: the union is a
+	// conflict and the boot must refuse rather than last-wins-ship a placeholder.
+	setMetadataLabel(t, `[
+  {"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[{"env":"GH_TOKEN","value":"ghp_a"}]}}}},
+  {"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[{"env":"GH_TOKEN","value":"ghp_b"}]}}}}
+]`)
+
+	_, cleanup, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
+	if err == nil {
+		t.Fatal("Prepare must error on conflicting placeholder values")
+	}
+	if ok {
+		t.Fatal("Prepare must not report ok on the fail-closed path")
+	}
+	if cleanup == nil {
+		t.Fatal("Prepare must return a runnable cleanup on the error path")
+	}
+	cleanup()
+}
+
+func TestDaemonPlanProxyBootstrapper_PassthroughWhenConfigAbsent(t *testing.T) {
 	t.Run("no daemon config at all", func(t *testing.T) {
 		withHomeAndEnv(t) // empty state dir, no env
-		_, _, ok, err := daemonToolProxyBootstrapper{}.Prepare("docker", "s1")
+		setMetadataLabel(t, twoToolMetadata)
+		_, _, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
 		if err != nil {
 			t.Fatalf("Prepare must not error on absent config: %v", err)
 		}
@@ -148,7 +288,8 @@ func TestDaemonToolProxyBootstrapper_PassthroughWhenConfigAbsent(t *testing.T) {
 	t.Run("url present but token absent", func(t *testing.T) {
 		stateDir := withHomeAndEnv(t)
 		writeDiscovery(t, stateDir, "http://127.0.0.1:48123", "") // no token
-		_, _, ok, err := daemonToolProxyBootstrapper{}.Prepare("docker", "s1")
+		setMetadataLabel(t, twoToolMetadata)
+		_, _, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
 		if err != nil {
 			t.Fatalf("Prepare: %v", err)
 		}
@@ -160,7 +301,8 @@ func TestDaemonToolProxyBootstrapper_PassthroughWhenConfigAbsent(t *testing.T) {
 	t.Run("token present but url absent", func(t *testing.T) {
 		withHomeAndEnv(t)
 		t.Setenv("AILERON_TOKEN", "env-token") // token but no URL / discovery
-		_, _, ok, err := daemonToolProxyBootstrapper{}.Prepare("docker", "s1")
+		setMetadataLabel(t, twoToolMetadata)
+		_, _, ok, err := daemonPlanProxyBootstrapper{}.Prepare(context.Background(), "docker", "img", "p")
 		if err != nil {
 			t.Fatalf("Prepare: %v", err)
 		}
@@ -190,7 +332,7 @@ func TestSanitizeSessionSegment(t *testing.T) {
 		"step_1-2":   "step_1-2",
 		"a/b":        "a-b",
 		"../escape":  "---escape",
-		"":           "step",
+		"":           "plan",
 		"with space": "with-space",
 	}
 	for in, want := range cases {

--- a/internal/launch/proxy_bootstrap.go
+++ b/internal/launch/proxy_bootstrap.go
@@ -183,56 +183,60 @@ func prepareSandboxProxyBootstrap(stateDir, sessionID, agentEndpointURL, daemonT
 	}, nil
 }
 
-// ToolContainerProxy is the result of provisioning a session CA + authed proxy
-// URL for a rung-3 tool container dispatch (#1769). Unlike the agent bootstrap
-// (which drives aileron-run-with-proxy-ca via AILERON_SANDBOX_PROXY_* env), the
-// tool-container path trusts the mounted CA purely through the standard
-// CA-bundle env vars the caller assembles from these fields; no agent preflight
-// runs. The three fields carry everything the dispatch needs: the authed proxy
-// URL to set on HTTPS_PROXY, the read-only CA Volume to append to the run's
-// mounts, and the in-container path the mounted CA lands at.
-type ToolContainerProxy struct {
+// ContainerProxy is the result of provisioning a session CA + authed proxy
+// URL for a container boot that routes its HTTPS egress through the ADR-0019
+// daemon forward proxy (#1769). The sole caller after #1828 is the whole-plan
+// image boot, which enriches the booted plan container with these fields;
+// #1829's step-scoped credentials will reuse the same primitive. Unlike the
+// agent bootstrap (which drives aileron-run-with-proxy-ca via
+// AILERON_SANDBOX_PROXY_* env), this path trusts the mounted CA purely through
+// the standard CA-bundle env vars the caller assembles from these fields; no
+// agent preflight runs. The three fields carry everything the boot needs: the
+// authed proxy URL to set on HTTPS_PROXY, the read-only CA Volume to append to
+// the run's mounts, and the in-container path the mounted CA lands at.
+type ContainerProxy struct {
 	// ProxyURL is the daemon forward-proxy root, loopback-rewritten to
 	// host.docker.internal, carrying the sessionID:token userinfo the CONNECT
 	// handshake authenticates against.
 	ProxyURL string
 	// CAMount is the read-only bind mount placing the freshly generated session
-	// CA at CAContainerPath inside the tool container.
+	// CA at CAContainerPath inside the booted container.
 	CAMount sandboxcontainer.Volume
 	// CAContainerPath is the in-container path the CA is mounted at; the caller
 	// points the CA-bundle env vars at it.
 	CAContainerPath string
 }
 
-// PrepareToolContainerProxy provisions a fresh session CA for a rung-3 tool
-// container and returns the authed proxy URL, the read-only CA mount, and the
-// in-container CA path. It reuses the exact on-disk CA layout the daemon reader
-// expects (<stateDir>/sessions/<sessionID>/sandbox-proxy/{ca.pem,ca.key}) and
-// the same session-authed proxy-URL shape as the agent path, so the daemon
-// MITM machinery accepts the CONNECT and signs per-host leaves from this CA.
+// PrepareContainerProxy provisions a fresh session CA for a container boot and
+// returns the authed proxy URL, the read-only CA mount, and the in-container CA
+// path. It reuses the exact on-disk CA layout the daemon reader expects
+// (<stateDir>/sessions/<sessionID>/sandbox-proxy/{ca.pem,ca.key}) and the same
+// session-authed proxy-URL shape as the agent path, so the daemon MITM
+// machinery accepts the CONNECT and signs per-host leaves from this CA. The
+// whole-plan image boot (#1828) is the caller.
 //
 // daemonRootURL is the daemon base WITHOUT the /v1 suffix; it is
 // loopback-rewritten to host.docker.internal via ContainerURLForRuntime so a
 // process inside the container reaches the host-bound daemon. The agent
 // bootstrap (prepareSandboxProxyBootstrap / applySandboxProxyBootstrapEnv) is
-// deliberately left untouched: this is a dedicated seam for the tool-container
-// dispatch that never runs the sandbox-base preflight.
+// deliberately left untouched: this is a dedicated seam for the plan/tool
+// container path that never runs the sandbox-base preflight.
 //
-// The sessionID MUST be UNIQUE per dispatch. This is a per-dispatch primitive:
-// it regenerates the session CA and CleanupToolContainerProxy removes the whole
+// The sessionID MUST be UNIQUE per boot. This is a per-boot primitive: it
+// regenerates the session CA and CleanupContainerProxy removes the whole
 // session directory, so two callers sharing a session id would clobber each
-// other's CA. The production caller mints a fresh id per dispatch, disjoint from
+// other's CA. The production caller mints a fresh id per boot, disjoint from
 // the agent path's session ids, so no sharing occurs.
-func PrepareToolContainerProxy(stateDir, sessionID, daemonRootURL, runtimeName, daemonToken string) (ToolContainerProxy, error) {
+func PrepareContainerProxy(stateDir, sessionID, daemonRootURL, runtimeName, daemonToken string) (ContainerProxy, error) {
 	if strings.TrimSpace(sessionID) == "" {
-		return ToolContainerProxy{}, fmt.Errorf("session id is required")
+		return ContainerProxy{}, fmt.Errorf("session id is required")
 	}
 	if err := validateProxyBootstrapSessionID(sessionID); err != nil {
-		return ToolContainerProxy{}, err
+		return ContainerProxy{}, err
 	}
 	root := strings.TrimSpace(daemonRootURL)
 	if root == "" {
-		return ToolContainerProxy{}, fmt.Errorf("daemon root URL is required")
+		return ContainerProxy{}, fmt.Errorf("daemon root URL is required")
 	}
 	// Rewrite loopback -> host.docker.internal so the in-container client reaches
 	// the host daemon, then attach the session:token userinfo the CONNECT
@@ -240,15 +244,15 @@ func PrepareToolContainerProxy(stateDir, sessionID, daemonRootURL, runtimeName, 
 	containerURL := ContainerURLForRuntime(strings.TrimRight(root, "/"), runtimeName)
 	proxyURL, err := sandboxProxyURLWithSessionAuth(containerURL, sessionID, daemonToken)
 	if err != nil {
-		return ToolContainerProxy{}, err
+		return ContainerProxy{}, err
 	}
 	caDir := filepath.Join(stateDir, "sessions", sessionID, "sandbox-proxy")
 	caPath := filepath.Join(caDir, "ca.pem")
 	keyPath := filepath.Join(caDir, "ca.key")
 	if err := writeSessionCA(caPath, keyPath, sessionID); err != nil {
-		return ToolContainerProxy{}, err
+		return ContainerProxy{}, err
 	}
-	return ToolContainerProxy{
+	return ContainerProxy{
 		ProxyURL: proxyURL,
 		CAMount: sandboxcontainer.Volume{
 			Source:   caPath,
@@ -259,11 +263,11 @@ func PrepareToolContainerProxy(stateDir, sessionID, daemonRootURL, runtimeName, 
 	}, nil
 }
 
-// CleanupToolContainerProxy removes the per-dispatch session CA directory
-// written by PrepareToolContainerProxy. It applies the same
+// CleanupContainerProxy removes the per-boot session CA directory
+// written by PrepareContainerProxy. It applies the same
 // validateProxyBootstrapSessionID guard so a malformed session id can never
 // direct the RemoveAll outside the sessions tree.
-func CleanupToolContainerProxy(stateDir, sessionID string) error {
+func CleanupContainerProxy(stateDir, sessionID string) error {
 	if err := validateProxyBootstrapSessionID(sessionID); err != nil {
 		return err
 	}

--- a/internal/launch/proxy_bootstrap_test.go
+++ b/internal/launch/proxy_bootstrap_test.go
@@ -77,13 +77,13 @@ func TestPrepareSandboxProxyBootstrap_RejectsInvalidAgentEndpointURL(t *testing.
 	}
 }
 
-func TestPrepareToolContainerProxy_WritesCARewritesURLAndMountsRO(t *testing.T) {
+func TestPrepareContainerProxy_WritesCARewritesURLAndMountsRO(t *testing.T) {
 	stateDir := t.TempDir()
 	// A loopback daemon root (no /v1) must be rewritten to host.docker.internal
 	// and carry the sessionID:token userinfo the CONNECT handshake needs.
-	got, err := PrepareToolContainerProxy(stateDir, "session-abc", "http://127.0.0.1:48123", "docker", "daemon-token")
+	got, err := PrepareContainerProxy(stateDir, "session-abc", "http://127.0.0.1:48123", "docker", "daemon-token")
 	if err != nil {
-		t.Fatalf("PrepareToolContainerProxy: %v", err)
+		t.Fatalf("PrepareContainerProxy: %v", err)
 	}
 	if got.ProxyURL != "http://session-abc:daemon-token@host.docker.internal:48123" {
 		t.Fatalf("ProxyURL = %q, want loopback rewritten + authed", got.ProxyURL)
@@ -121,49 +121,49 @@ func TestPrepareToolContainerProxy_WritesCARewritesURLAndMountsRO(t *testing.T) 
 	}
 }
 
-func TestPrepareToolContainerProxy_NoTokenOmitsPassword(t *testing.T) {
-	got, err := PrepareToolContainerProxy(t.TempDir(), "session-abc", "http://localhost:9999", "docker", "")
+func TestPrepareContainerProxy_NoTokenOmitsPassword(t *testing.T) {
+	got, err := PrepareContainerProxy(t.TempDir(), "session-abc", "http://localhost:9999", "docker", "")
 	if err != nil {
-		t.Fatalf("PrepareToolContainerProxy: %v", err)
+		t.Fatalf("PrepareContainerProxy: %v", err)
 	}
 	if got.ProxyURL != "http://session-abc@host.docker.internal:9999" {
 		t.Fatalf("ProxyURL = %q, want session userinfo with no password", got.ProxyURL)
 	}
 }
 
-func TestPrepareToolContainerProxy_RejectsBadInput(t *testing.T) {
-	if _, err := PrepareToolContainerProxy(t.TempDir(), "", "http://127.0.0.1:1", "docker", ""); err == nil {
+func TestPrepareContainerProxy_RejectsBadInput(t *testing.T) {
+	if _, err := PrepareContainerProxy(t.TempDir(), "", "http://127.0.0.1:1", "docker", ""); err == nil {
 		t.Fatal("expected empty session id error")
 	}
-	if _, err := PrepareToolContainerProxy(t.TempDir(), "../escape", "http://127.0.0.1:1", "docker", ""); err == nil {
+	if _, err := PrepareContainerProxy(t.TempDir(), "../escape", "http://127.0.0.1:1", "docker", ""); err == nil {
 		t.Fatal("expected unsafe session id error")
 	}
-	if _, err := PrepareToolContainerProxy(t.TempDir(), "session-abc", "", "docker", ""); err == nil {
+	if _, err := PrepareContainerProxy(t.TempDir(), "session-abc", "", "docker", ""); err == nil {
 		t.Fatal("expected empty daemon root error")
 	}
-	if _, err := PrepareToolContainerProxy(t.TempDir(), "session-abc", "http://", "docker", ""); err == nil {
+	if _, err := PrepareContainerProxy(t.TempDir(), "session-abc", "http://", "docker", ""); err == nil {
 		t.Fatal("expected invalid daemon root error")
 	}
 }
 
-func TestCleanupToolContainerProxy_RemovesSessionDirAndGuardsID(t *testing.T) {
+func TestCleanupContainerProxy_RemovesSessionDirAndGuardsID(t *testing.T) {
 	stateDir := t.TempDir()
-	if _, err := PrepareToolContainerProxy(stateDir, "session-abc", "http://127.0.0.1:1", "docker", "t"); err != nil {
-		t.Fatalf("PrepareToolContainerProxy: %v", err)
+	if _, err := PrepareContainerProxy(stateDir, "session-abc", "http://127.0.0.1:1", "docker", "t"); err != nil {
+		t.Fatalf("PrepareContainerProxy: %v", err)
 	}
 	dir := filepath.Join(stateDir, "sessions", "session-abc", "sandbox-proxy")
 	if _, err := os.Stat(dir); err != nil {
 		t.Fatalf("session dir must exist before cleanup: %v", err)
 	}
-	if err := CleanupToolContainerProxy(stateDir, "session-abc"); err != nil {
-		t.Fatalf("CleanupToolContainerProxy: %v", err)
+	if err := CleanupContainerProxy(stateDir, "session-abc"); err != nil {
+		t.Fatalf("CleanupContainerProxy: %v", err)
 	}
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("session dir must be removed after cleanup, stat err = %v", err)
 	}
 	// An unsafe session id is rejected before any RemoveAll so the guard can
 	// never direct the delete outside the sessions tree.
-	if err := CleanupToolContainerProxy(stateDir, "../escape"); err == nil {
+	if err := CleanupContainerProxy(stateDir, "../escape"); err == nil {
 		t.Fatal("expected unsafe session id rejection")
 	}
 }

--- a/internal/sandbox/composition/convention_metadata.go
+++ b/internal/sandbox/composition/convention_metadata.go
@@ -1,0 +1,81 @@
+package composition
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// This file bridges from a booted image's devcontainer.metadata OCI label value
+// to the placeholder environment the whole-plan boot injects. The declared
+// tools' Feature customizations are merged into the composed image's
+// devcontainer.metadata label (the mechanism internal/cli/unitloader already
+// reads for CLI units), so the credential conventions are read from the exact
+// signed pin being booted rather than a repo checkout. Each metadata array
+// element carries the same customizations.aileron.credential path
+// ParseCredentialConvention decodes, so element bytes feed it directly.
+
+// ConventionsFromMetadata parses a devcontainer.metadata label value into zero
+// or more credential conventions. The label value is the devcontainer CLI's
+// merged metadata array: a JSON array of per-Feature objects. Each element is
+// fed to ParseCredentialConvention (which decodes the
+// customizations.aileron.credential path itself), so an element carrying a
+// present, valid block contributes one convention in array order.
+//
+// An empty or whitespace-only label is a clean no-op returning (nil, nil),
+// matching ImageMetadataLabel's "" sentinel for an unlabeled image. An array
+// element with no customizations.aileron.credential block (e.g. an agent
+// Feature) contributes nothing. Malformed JSON, or a present-but-invalid
+// credential block, is an error: a present-but-broken convention fails loudly
+// rather than silently shipping nothing (#1825's fail-closed posture).
+func ConventionsFromMetadata(metadata []byte) ([]CredentialConvention, error) {
+	if len(strings.TrimSpace(string(metadata))) == 0 {
+		return nil, nil
+	}
+
+	var elements []json.RawMessage
+	if err := json.Unmarshal(metadata, &elements); err != nil {
+		return nil, fmt.Errorf("composition: parse devcontainer.metadata array: %w", err)
+	}
+
+	var convs []CredentialConvention
+	for i := range elements {
+		conv, ok, err := ParseCredentialConvention(elements[i])
+		if err != nil {
+			return nil, fmt.Errorf("composition: credential convention at element %d: %w", i, err)
+		}
+		if !ok {
+			continue
+		}
+		convs = append(convs, conv)
+	}
+	return convs, nil
+}
+
+// PlaceholderEnv unions the non-secret placeholder pairs across the given
+// credential conventions into the env map the whole-plan boot plants into the
+// booted container. Each placeholder's Env becomes a key and its Value the
+// value.
+//
+// The union is fail-closed on conflict: two placeholders sharing an env with
+// the SAME value dedupe to one entry, but two sharing an env with DIFFERENT
+// values are a loud error naming the env, never a silent last-wins. Empty input
+// (no conventions, or conventions with no placeholders) returns (nil, nil).
+func PlaceholderEnv(convs []CredentialConvention) (map[string]string, error) {
+	var env map[string]string
+	for _, conv := range convs {
+		for _, p := range conv.Placeholders {
+			if existing, seen := env[p.Env]; seen {
+				if existing != p.Value {
+					return nil, fmt.Errorf("composition: conflicting placeholder values for env %q: %q vs %q", p.Env, existing, p.Value)
+				}
+				continue
+			}
+			if env == nil {
+				env = map[string]string{}
+			}
+			env[p.Env] = p.Value
+		}
+	}
+	return env, nil
+}

--- a/internal/sandbox/composition/convention_metadata_test.go
+++ b/internal/sandbox/composition/convention_metadata_test.go
@@ -1,0 +1,208 @@
+package composition
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// awsCredentialElement is one devcontainer.metadata array element carrying the
+// aws-cli credential convention (sigv4-resign + the AWS placeholder pair),
+// byte-shaped like the real Feature manifest.
+const awsCredentialElement = `{
+  "id": "aws-cli",
+  "customizations": {
+    "aileron": {
+      "credential": {
+        "scheme": "sigv4-resign",
+        "placeholders": [
+          {"env": "AWS_ACCESS_KEY_ID", "value": "AKIAIOSFODNN7PLACEHLDR"},
+          {"env": "AWS_SECRET_ACCESS_KEY", "value": "placeholderAileronInjectsRealSecretXXXXXX"}
+        ]
+      }
+    }
+  }
+}`
+
+// ghCredentialElement carries gh's credential convention (bearer + the GH_TOKEN
+// placeholder).
+const ghCredentialElement = `{
+  "id": "gh",
+  "customizations": {
+    "aileron": {
+      "credential": {
+        "scheme": "bearer",
+        "placeholders": [
+          {"env": "GH_TOKEN", "value": "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"}
+        ]
+      }
+    }
+  }
+}`
+
+// agentElement is a metadata element with no credential block (an agent
+// Feature): it must contribute nothing.
+const agentElement = `{"id": "claude", "customizations": {"aileron": {"cli": {"name": "gh"}}}}`
+
+func TestConventionsFromMetadata_EmptyAndWhitespace(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\t ", "[]"} {
+		convs, err := ConventionsFromMetadata([]byte(in))
+		if err != nil {
+			t.Fatalf("ConventionsFromMetadata(%q): unexpected error %v", in, err)
+		}
+		if convs != nil {
+			t.Fatalf("ConventionsFromMetadata(%q) = %v, want nil", in, convs)
+		}
+	}
+}
+
+func TestConventionsFromMetadata_TwoElementsInOrder(t *testing.T) {
+	metadata := []byte("[" + awsCredentialElement + "," + ghCredentialElement + "]")
+	convs, err := ConventionsFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("ConventionsFromMetadata: %v", err)
+	}
+	if len(convs) != 2 {
+		t.Fatalf("got %d conventions, want 2", len(convs))
+	}
+	if convs[0].Scheme != inject.SchemeSigV4Resign {
+		t.Fatalf("convs[0].Scheme = %q, want sigv4-resign", convs[0].Scheme)
+	}
+	if convs[1].Scheme != inject.SchemeBearer {
+		t.Fatalf("convs[1].Scheme = %q, want bearer", convs[1].Scheme)
+	}
+}
+
+func TestConventionsFromMetadata_ElementWithoutCredentialContributesNothing(t *testing.T) {
+	metadata := []byte("[" + agentElement + "," + ghCredentialElement + "]")
+	convs, err := ConventionsFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("ConventionsFromMetadata: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("got %d conventions, want 1 (the agent element contributes nothing)", len(convs))
+	}
+	if convs[0].Scheme != inject.SchemeBearer {
+		t.Fatalf("convs[0].Scheme = %q, want bearer", convs[0].Scheme)
+	}
+}
+
+func TestConventionsFromMetadata_NonArrayIsError(t *testing.T) {
+	if _, err := ConventionsFromMetadata([]byte(awsCredentialElement)); err == nil {
+		t.Fatal("expected error for non-array JSON, got nil")
+	}
+}
+
+func TestConventionsFromMetadata_PresentButInvalidBlockIsError(t *testing.T) {
+	unknownScheme := `[{"customizations":{"aileron":{"credential":{"scheme":"not-a-scheme","placeholders":[{"env":"X","value":"y"}]}}}}]`
+	_, err := ConventionsFromMetadata([]byte(unknownScheme))
+	if err == nil {
+		t.Fatal("expected error for unknown scheme, got nil")
+	}
+	if !errors.Is(err, ErrInvalidCredentialConvention) {
+		t.Fatalf("error %v does not wrap ErrInvalidCredentialConvention", err)
+	}
+
+	zeroPlaceholders := `[{"customizations":{"aileron":{"credential":{"scheme":"bearer","placeholders":[]}}}}]`
+	if _, err := ConventionsFromMetadata([]byte(zeroPlaceholders)); err == nil {
+		t.Fatal("expected error for zero placeholders, got nil")
+	}
+}
+
+func TestPlaceholderEnv_UnionOfAWSAndGH(t *testing.T) {
+	metadata := []byte("[" + awsCredentialElement + "," + ghCredentialElement + "]")
+	convs, err := ConventionsFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("ConventionsFromMetadata: %v", err)
+	}
+	env, err := PlaceholderEnv(convs)
+	if err != nil {
+		t.Fatalf("PlaceholderEnv: %v", err)
+	}
+	want := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7PLACEHLDR",
+		"AWS_SECRET_ACCESS_KEY": "placeholderAileronInjectsRealSecretXXXXXX",
+		"GH_TOKEN":              "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("PlaceholderEnv = %v, want %v", env, want)
+	}
+}
+
+func TestPlaceholderEnv_NilInput(t *testing.T) {
+	env, err := PlaceholderEnv(nil)
+	if err != nil {
+		t.Fatalf("PlaceholderEnv(nil): %v", err)
+	}
+	if env != nil {
+		t.Fatalf("PlaceholderEnv(nil) = %v, want nil", env)
+	}
+}
+
+func TestPlaceholderEnv_DuplicateIdenticalDedupes(t *testing.T) {
+	conv := CredentialConvention{
+		Scheme: inject.SchemeBearer,
+		Placeholders: []CredentialPlaceholder{
+			{Env: "GH_TOKEN", Value: "ghp_x"},
+		},
+	}
+	env, err := PlaceholderEnv([]CredentialConvention{conv, conv})
+	if err != nil {
+		t.Fatalf("PlaceholderEnv: %v", err)
+	}
+	want := map[string]string{"GH_TOKEN": "ghp_x"}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("PlaceholderEnv = %v, want %v", env, want)
+	}
+}
+
+func TestPlaceholderEnv_ConflictingValuesError(t *testing.T) {
+	convA := CredentialConvention{
+		Scheme:       inject.SchemeBearer,
+		Placeholders: []CredentialPlaceholder{{Env: "GH_TOKEN", Value: "ghp_a"}},
+	}
+	convB := CredentialConvention{
+		Scheme:       inject.SchemeBearer,
+		Placeholders: []CredentialPlaceholder{{Env: "GH_TOKEN", Value: "ghp_b"}},
+	}
+	_, err := PlaceholderEnv([]CredentialConvention{convA, convB})
+	if err == nil {
+		t.Fatal("expected error for conflicting placeholder values, got nil")
+	}
+	if !strings.Contains(err.Error(), "GH_TOKEN") {
+		t.Fatalf("error %v does not name the conflicting env GH_TOKEN", err)
+	}
+}
+
+// TestPlaceholderEnv_RealCatalogUnion loads the actual repo manifests through
+// LoadCredentialConvention (the aws-cli + gh multi-tool union the brief
+// requires) and asserts PlaceholderEnv yields both conventions' placeholders
+// byte-for-byte and nothing else, pinned to real catalog data.
+func TestPlaceholderEnv_RealCatalogUnion(t *testing.T) {
+	root := featuresContext(t)
+
+	aws, ok, err := LoadCredentialConvention(root, "aws-cli")
+	if err != nil || !ok {
+		t.Fatalf("LoadCredentialConvention(aws-cli): ok=%v err=%v", ok, err)
+	}
+	gh, ok, err := LoadCredentialConvention(root, "gh")
+	if err != nil || !ok {
+		t.Fatalf("LoadCredentialConvention(gh): ok=%v err=%v", ok, err)
+	}
+
+	env, err := PlaceholderEnv([]CredentialConvention{aws, gh})
+	if err != nil {
+		t.Fatalf("PlaceholderEnv: %v", err)
+	}
+	want := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7PLACEHLDR",
+		"AWS_SECRET_ACCESS_KEY": "placeholderAileronInjectsRealSecretXXXXXX",
+		"GH_TOKEN":              "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("real-catalog PlaceholderEnv = %v, want %v", env, want)
+	}
+}


### PR DESCRIPTION
## Summary

Retires the per-dispatch rung-3 credential injection and moves ADR-0019 forward-proxy egress mediation to the **whole-plan image boot** (#1828, umbrella #1824 "one sealed environment"). The booted plan container now receives, once at boot:

- the read-only session CA mount,
- the authed `HTTPS_PROXY`/`https_proxy` URL,
- `NO_PROXY`/`no_proxy` (`localhost,127.0.0.1,::1,host.docker.internal`) so the daemon/loopback traffic the boot depends on (#1759) never routes through the egress proxy,
- the **catalog-derived placeholder credential union**, read from the booted image's own `devcontainer.metadata` label (the exact signed pin), not a repo checkout or the freeze lock.

### What changed

- **`internal/sandbox/composition` (new `convention_metadata.go`):** `ConventionsFromMetadata(metadata)` walks the `devcontainer.metadata` array and parses each element's `customizations.aileron.credential` block via the existing `ParseCredentialConvention`; `PlaceholderEnv(convs)` unions the placeholders. Empty/whitespace label → `(nil, nil)`; an element without a credential block contributes nothing; a malformed/invalid block or a **conflicting** placeholder value is a loud fail-closed error (never last-wins).
- **`internal/launch/proxy_bootstrap.go`:** renamed `PrepareToolContainerProxy`/`CleanupToolContainerProxy`/`ToolContainerProxy` → `PrepareContainerProxy`/`CleanupContainerProxy`/`ContainerProxy`. Behavior, signature, and the on-disk CA layout (`<stateDir>/sessions/<id>/sandbox-proxy/{ca.pem,ca.key}`) are unchanged; the whole-plan boot is now the sole caller. The agent-sandbox bootstrap (`prepareSandboxProxyBootstrap` and friends) is untouched.
- **`cmd/aileron`:** added `planProxyBootstrapper` + `daemonPlanProxyBootstrapper` and the `containerImageMetadataLabel` seam (so tests never shell to Docker); `containerImageRunner.Run` enriches the boot after the daemon-env block. Removed `toolProxyBootstrapper`, `daemonToolProxyBootstrapper`, and the hardcoded `placeholderAWS*` constants (those values now live solely in the aws-cli catalog Feature, per #1832). Per-step tool egress is **un-proxied in the interim** until #1829 retargets per-step scoping — documented honestly in the runner's doc comment.

### Fail-closed postures

- Daemon config absent → passthrough boot (`ok=false`, no error), config-presence gating (matches the `#1759` precedent).
- Config present but session-CA write fails, or a malformed/conflicting convention → boot **refused**, cleanup returned and run so a partial CA never leaks.
- Unlabeled/uninspectable image (`""` label) → proxy env + CA still injected, empty placeholder set (fail-soft, matches `ImageMetadataLabel`).
- **Reserved keys always win:** image-declared placeholders are seeded first and the authoritative `HTTPS_PROXY`/`NO_PROXY`/CA-bundle values overwrite them, so metadata can never weaken the egress mediation.

## Test plan

- `go test ./internal/sandbox/composition/...` — contract tests for `ConventionsFromMetadata`/`PlaceholderEnv` incl. a real-catalog aws-cli + gh union pinned to the shipped Feature manifests.
- `go test ./internal/launch/...` — renamed identifiers, assertions unchanged.
- `go test ./cmd/aileron/...` — `daemonPlanProxyBootstrapper` exact-env assertion (authed proxy URL, six CA vars, NO_PROXY, aws-cli + gh placeholders, and nothing else), passthrough/discovery/env-precedence paths, empty-label fail-soft, malformed-label + conflicting-placeholder fail-closed, reserved-keys-win regression, `containerImageRunner` boot enrichment + merge disjointness + fail-closed cleanup, and the production wiring seam.
- Full `internal` module test suite green.
- `coderabbit review --agent --base main`: 2 findings (reserved-key override hardening + cleanup nil-guard consistency), both fixed with a regression test; re-review rate-limited, fixes are exactly CodeRabbit's recommendations.

### Out of scope (per the brief)

Egress re-signing (`handlers_sandbox_forward_proxy.go`, `credential/inject`), flightplan schema/freeze/lock (#1826/#1827), per-step proxy retargeting (#1829), docs-site (#1830), OpenAPI (no API surface moves).

Closes #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
