### PR TITLE
feat(freeze)!: compose one image from the runtime base plus declared tools

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -20,8 +20,8 @@ import (
 
 // newDigestResolver and newFeatureComposer are package-level seams so CLI
 // tests exercise the freeze orchestration without a container runtime. The
-// production implementations wire container.DefaultRunner() (rung-1 image
-// inspect) and container.Builder (rung-2 Feature composition).
+// production implementations wire container.DefaultRunner() (base-image
+// inspect) and container.Builder (environment-tools Feature composition).
 var newDigestResolver = func() freeze.DigestResolver { return runtimeDigestResolver{} }
 var newFeatureComposer = func() freeze.FeatureComposer { return builderFeatureComposer{} }
 
@@ -162,7 +162,7 @@ func (in imageInspector) inspectFormat(ctx context.Context, image, format string
 	return out.Bytes(), nil
 }
 
-// runtimeDigestResolver resolves a rung-1 image reference to its digest by
+// runtimeDigestResolver resolves a base-image reference to its digest by
 // pulling (best-effort) then inspecting RepoDigests through the shared
 // container Runner seam. It pins by digest, never by tag.
 type runtimeDigestResolver struct{}
@@ -242,20 +242,22 @@ func repoOfRef(ref string) string {
 	return ref
 }
 
-// builderFeatureComposer composes a rung-2 capability-unit Feature set
-// through the container Builder (the #1454 build pipeline) and returns the
-// built image's digest. It routes rung-2 through the same Builder /
-// composition path the sandbox uses, not a bespoke build.
+// builderFeatureComposer composes catalog-resolved Feature references onto
+// the digest-pinned base image through the container Builder (the #1454
+// build pipeline) and returns the built image's digest. It routes the
+// environment-tools composition through the same Builder / composition path
+// the sandbox uses (composition.ToolsPlan's synthesized devcontainer), not a
+// bespoke build.
 type builderFeatureComposer struct{}
 
-func (builderFeatureComposer) ComposeDigest(ctx context.Context, features []string) (string, error) {
+func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, features []string) (string, error) {
 	in, err := newImageInspector()
 	if err != nil {
 		return "", err
 	}
-	// Compose the Features onto the Aileron base image via the standard
-	// composition Plan, build through the Builder, then resolve the built
-	// image's digest with the same inspector used for rung-1.
+	// Compose the Features onto the given base via the standard composition
+	// Plan, build through the Builder, then resolve the built image's digest
+	// with the same inspector the base-image resolver uses.
 	b := container.Builder{
 		Runtime: in.runtime,
 		Runner:  in.runner,
@@ -263,30 +265,15 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, features []stri
 		Stderr:  io.Discard,
 	}
 	result, err := b.Build(ctx, container.BuildOptions{
-		Plan:   rung2Plan(features),
+		Plan:   composition.ToolsPlan(base, features),
 		Policy: container.BuildPolicyAlways,
 	})
 	if err != nil {
-		return "", fmt.Errorf("compose rung-2 features: %w", err)
+		return "", fmt.Errorf("compose environment tools: %w", err)
 	}
 	// The built image is a local tag; resolve it to a digest. A locally-built
 	// image typically has no RepoDigests, so fall back to its image Id.
 	return in.localImageDigest(ctx, result.Image)
-}
-
-// rung2Plan builds the composition Plan that composes the given
-// capability-unit Features onto the Aileron base image. Routing rung-2
-// through composition.Plan + the Builder keeps freeze on the same build
-// path the sandbox uses rather than a bespoke build.
-func rung2Plan(features []string) composition.Plan {
-	plan := composition.Plan{
-		Tier:     composition.TierDevcontainer,
-		Features: make(map[string]json.RawMessage, len(features)),
-	}
-	for _, f := range features {
-		plan.Features[f] = json.RawMessage("{}")
-	}
-	return plan
 }
 
 // localImageDigest resolves a locally-built image tag to a content digest.

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -35,7 +35,7 @@ func stubFreezeResolvers(t *testing.T, digest string) {
 		return freeze.DigestResolverFunc(func(context.Context, string) (string, error) { return digest, nil })
 	}
 	newFeatureComposer = func() freeze.FeatureComposer {
-		return freeze.FeatureComposerFunc(func(context.Context, []string) (string, error) { return digest, nil })
+		return freeze.FeatureComposerFunc(func(context.Context, string, []string) (string, error) { return digest, nil })
 	}
 	t.Cleanup(func() { newDigestResolver, newFeatureComposer = origDR, origFC })
 }
@@ -340,6 +340,105 @@ aileron:
 	}
 }
 
+// TestRunSkillFreeze_ToolsComposeOntoCustomBase proves the CLI freeze path
+// for the composed environment: a skill declaring a custom base image AND
+// curated tools freezes by digest-resolving the base, then handing the
+// composer the DIGEST-PINNED base plus the CATALOG-RESOLVED Feature
+// references. The lockfile pins the composed digest and records the declared
+// tools as the capability set.
+func TestRunSkillFreeze_ToolsComposeOntoCustomBase(t *testing.T) {
+	storeDir := withTempStore(t)
+	key := writeSigningKey(t)
+
+	baseDigest := "sha256:" + strings.Repeat("a", 64)
+	composedDigest := "sha256:" + strings.Repeat("b", 64)
+	origDR, origFC := newDigestResolver, newFeatureComposer
+	var resolvedRef, composeBase string
+	var composeFeatures []string
+	newDigestResolver = func() freeze.DigestResolver {
+		return freeze.DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+			resolvedRef = ref
+			return baseDigest, nil
+		})
+	}
+	newFeatureComposer = func() freeze.FeatureComposer {
+		return freeze.FeatureComposerFunc(func(_ context.Context, base string, features []string) (string, error) {
+			composeBase = base
+			composeFeatures = features
+			return composedDigest, nil
+		})
+	}
+	t.Cleanup(func() { newDigestResolver, newFeatureComposer = origDR, origFC })
+
+	const toolsMD = `---
+name: tools-on-base
+description: Curated tools onto a custom base.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  environment:
+    image: registry.example.com/base:1.4
+    tools:
+      - aws-cli@2.x
+  inputs: []
+  outputs: []
+---
+
+# Tools On Base
+`
+	dir := filepath.Join(storeDir, "tools-on-base")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(toolsMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "tools-on-base"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("a tools+custom-base freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+	if resolvedRef != "registry.example.com/base:1.4" {
+		t.Errorf("resolver got %q, want the declared custom base", resolvedRef)
+	}
+	if want := "registry.example.com/base:1.4@" + baseDigest; composeBase != want {
+		t.Errorf("composer got base %q, want the digest-pinned base %q", composeBase, want)
+	}
+	if want := composition.FeatureReference("aws-cli"); strings.Join(composeFeatures, ",") != want {
+		t.Errorf("composer got features %v, want the catalog-resolved %q", composeFeatures, want)
+	}
+
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("tools-on-base")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("FrozenVersions = %v, %v", ids, err)
+	}
+	v, err := s.ReadFrozen("tools-on-base", ids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(v.Lockfile), composedDigest) {
+		t.Errorf("the lockfile must pin the composed digest:\n%s", v.Lockfile)
+	}
+	if !strings.Contains(string(v.Lockfile), "aws-cli@2.x") {
+		t.Errorf("the lockfile must record the declared tools:\n%s", v.Lockfile)
+	}
+}
+
 func TestRunSkillFreeze_FromPath(t *testing.T) {
 	withTempStore(t)
 	stubFreezeResolvers(t, fakeFreezeDigest)
@@ -502,7 +601,7 @@ func TestBuilderFeatureComposer_InspectorError(t *testing.T) {
 		return imageInspector{}, errTestInspect
 	}
 	t.Cleanup(func() { newImageInspector = orig })
-	if _, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), []string{"f"}); err == nil {
+	if _, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), "base@"+fakeFreezeDigest, []string{"f"}); err == nil {
 		t.Error("an inspector-construction error must surface from ComposeDigest")
 	}
 }
@@ -626,22 +725,6 @@ func TestReadSkillForFreeze_DirectoryWithoutSkill(t *testing.T) {
 	withTempStore(t)
 	if _, err := readSkillForFreeze(t.TempDir()); err == nil {
 		t.Error("a directory with no SKILL.md must error")
-	}
-}
-
-func TestRung2Plan(t *testing.T) {
-	features := []string{"ghcr.io/x/a:1", "ghcr.io/x/b:1"}
-	plan := rung2Plan(features)
-	if plan.Tier != composition.TierDevcontainer {
-		t.Errorf("tier = %s", plan.Tier)
-	}
-	if len(plan.Features) != 2 {
-		t.Errorf("features = %v", plan.Features)
-	}
-	for _, f := range features {
-		if _, ok := plan.Features[f]; !ok {
-			t.Errorf("feature %q missing from plan", f)
-		}
 	}
 }
 

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -611,12 +611,12 @@
     },
     "lock": {
       "type": "object",
-      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved image digests and the resolved capability set, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
+      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved environment image digest, records the resolved capability set and the step-keyed sealed trust reach, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
       "additionalProperties": false,
       "properties": {
         "resolvedImages": {
           "type": "array",
-          "description": "The resolved image digest pins. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest.",
+          "description": "The resolved image digest pins. The plan runs in one container, so a plan with a declared environment pins exactly one image: the digest-resolved custom base, or the image composed from the runtime base plus the declared tools. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest and carries no per-step linkage; the step-keyed sealed reach lives in the sibling stepTrust section.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -627,20 +627,6 @@
                 "type": "string",
                 "description": "The resolved content-addressed digest.",
                 "pattern": "^sha256:[a-f0-9]{64}$"
-              },
-              "id": {
-                "type": "string",
-                "description": "For a per-step pin, the id of the step that dispatches to this image (its declared `id`, or a positional fallback). Links the pin to its step so association does not key on the mutable image reference. Absent for whole-plan environment pins, which boot a single image with no per-step linkage.",
-                "minLength": 1
-              },
-              "hosts": {
-                "type": "array",
-                "description": "For a per-step pin, the network reach freeze sealed from the step's declared trust contract. Each entry is a host with an optional port, no scheme, no path, reusing the trustContract `hosts` vocabulary. Freeze stamps the declared reach here so it is covered by the content hash and signature: a resolved, signed assertion of the step's reach that cannot be re-supplied at launch. Absent for whole-plan environment pins and for a step that declares no trust contract.",
-                "items": {
-                  "type": "string",
-                  "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
-                  "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
-                }
               }
             }
           }
@@ -649,6 +635,30 @@
           "type": "array",
           "description": "The resolved capability set the freeze pinned.",
           "items": { "type": "string", "minLength": 1 }
+        },
+        "stepTrust": {
+          "type": "object",
+          "description": "The step-keyed sealed trust section. Keyed by tool-step id; each entry carries the network reach freeze sealed from that step's declared trust contract. Hosts only: the full contract stays in the signed frontmatter, and this section is the resolved reach launch and runtime consume. Freeze stamps it here so the reach is covered by the content hash and signature and cannot be re-supplied at launch. A tool step that declares no trust contract has no entry.",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["hosts"],
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "description": "The sealed network reach from the step's declared trust contract. Each entry is a host with an optional port, no scheme, no path, reusing the trustContract `hosts` vocabulary.",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
+                  "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
+                }
+              }
+            }
+          }
         },
         "contentHash": {
           "type": "string",

--- a/internal/flightplan/freeze/freeze.go
+++ b/internal/flightplan/freeze/freeze.go
@@ -55,21 +55,25 @@ type Options struct {
 	// Version is the semver label recorded in the lock. Optional; empty
 	// records no version label.
 	Version string
-	// CLIVersion is the Aileron CLI build version that drives the default
-	// runner image reference in the retained legacy default-image branch
-	// (#1808, dormant until #1827 rewires it). It is distinct from Version
-	// (the skill's semver label): CLIVersion picks the floating sandbox-base
-	// tag the default resolves from. An empty value behaves as a dev build
-	// (resolves the :edge tag), matching the CLI's version default.
+	// CLIVersion is the Aileron CLI build version. It drives the default
+	// composition base: a tools-declaring skill with no custom image composes
+	// onto the Aileron runner base for this version (composition.BaseImage).
+	// It is distinct from Version (the skill's semver label): CLIVersion
+	// picks the floating sandbox-base tag the default resolves from. An empty
+	// value behaves as a dev build (resolves the :edge tag), matching the
+	// CLI's version default.
 	CLIVersion string
 	// SigningKeyPath is the path to the PEM ed25519 private key. Empty falls
 	// back to $AILERON_SIGNING_KEY (see LoadSigningKey).
 	SigningKeyPath string
-	// Resolver resolves an environment custom-base image reference to a
-	// digest. May be nil for instruction-only / no-environment skills.
+	// Resolver resolves a base image reference (the runner base or an
+	// environment custom image) to a digest. Required for any
+	// environment-declaring skill; may be nil for instruction-only /
+	// no-environment skills.
 	Resolver DigestResolver
-	// Composer composes a declared environment tool set and pins the built
-	// image's digest. May be nil when no tools-declaring skill is frozen.
+	// Composer composes catalog-resolved Feature references onto the
+	// digest-pinned base and pins the built image's digest. May be nil when
+	// no tools-declaring skill is frozen.
 	Composer FeatureComposer
 }
 
@@ -105,9 +109,20 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
+	// Seal each contracted tool step's declared reach into the step-keyed
+	// lock section, so the content hash and signature cover it.
+	var stepTrust map[string]StepReach
+	if !m.InstructionOnly {
+		stepTrust, err = sealStepTrust(m.Aileron.Steps)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
 	lock := Lockfile{
 		ResolvedImages:        pins,
 		ResolvedCapabilitySet: capSet,
+		StepTrust:             stepTrust,
 		Version:               opts.Version,
 	}
 

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func fakeComposer(digest string) FeatureComposer {
-	return FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+	return FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
 		return digest, nil
 	})
 }
@@ -19,6 +19,7 @@ func TestRun_EnvironmentToolsHappyPath(t *testing.T) {
 	res, err := Run(context.Background(), exampleSkillMD(t), Options{
 		Version:        "1.0.0",
 		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
 		Composer:       fakeComposer(fakeDigest),
 	})
 	if err != nil {
@@ -126,35 +127,112 @@ func TestRun_EnvironmentImagePinsAndSigns(t *testing.T) {
 
 func TestRun_Reproducible(t *testing.T) {
 	_, keyPath := genSigningKey(t)
-	opts := Options{Version: "1.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)}
-	a, err := Run(context.Background(), exampleSkillMD(t), opts)
-	if err != nil {
-		t.Fatalf("Run a: %v", err)
-	}
-	b, err := Run(context.Background(), exampleSkillMD(t), opts)
-	if err != nil {
-		t.Fatalf("Run b: %v", err)
-	}
-	if a.ContentHash != b.ContentHash {
-		t.Errorf("contentHash not reproducible: %q != %q", a.ContentHash, b.ContentHash)
-	}
-	if string(a.FrozenManifest) != string(b.FrozenManifest) {
-		t.Error("frozen manifest bytes not reproducible")
+	opts := Options{Version: "1.0.0", SigningKeyPath: keyPath, Resolver: dummyResolver(), Composer: fakeComposer(fakeDigest)}
+	// The tool-steps fixture carries a MULTI-ENTRY stepTrust section, so this
+	// also proves the step-keyed map marshals byte-deterministically (two
+	// freezes of the same input produce byte-identical artifacts).
+	for name, fixture := range map[string][]byte{
+		"environment tools": exampleSkillMD(t),
+		"tool steps":        []byte(toolStepsMD),
+	} {
+		t.Run(name, func(t *testing.T) {
+			a, err := Run(context.Background(), fixture, opts)
+			if err != nil {
+				t.Fatalf("Run a: %v", err)
+			}
+			b, err := Run(context.Background(), fixture, opts)
+			if err != nil {
+				t.Fatalf("Run b: %v", err)
+			}
+			if a.ContentHash != b.ContentHash {
+				t.Errorf("contentHash not reproducible: %q != %q", a.ContentHash, b.ContentHash)
+			}
+			if string(a.FrozenManifest) != string(b.FrozenManifest) {
+				t.Error("frozen manifest bytes not reproducible")
+			}
+			if string(a.Lockfile) != string(b.Lockfile) {
+				t.Error("lockfile bytes not reproducible")
+			}
+		})
 	}
 }
 
 func TestRun_ContentHashChangesWithVersion(t *testing.T) {
 	_, keyPath := genSigningKey(t)
-	a, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "1.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)})
+	a, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "1.0.0", SigningKeyPath: keyPath, Resolver: dummyResolver(), Composer: fakeComposer(fakeDigest)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "2.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)})
+	b, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "2.0.0", SigningKeyPath: keyPath, Resolver: dummyResolver(), Composer: fakeComposer(fakeDigest)})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if a.ContentHash == b.ContentHash {
 		t.Error("a different version label must change the content hash")
+	}
+}
+
+// TestRun_ToolStepsSealStepTrust is the end-to-end proof of the step-keyed
+// trust seal: a freeze over a manifest with tool steps produces a lockfile
+// whose stepTrust carries exactly the contracted steps' declared hosts under
+// the schema field names, and the emitted YAML round-trips.
+func TestRun_ToolStepsSealStepTrust(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), []byte(toolStepsMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
+		Composer:       fakeComposer(fakeDigest2),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Lock.StepTrust) != 2 {
+		t.Fatalf("StepTrust = %+v, want the two contracted steps", res.Lock.StepTrust)
+	}
+	if strings.Join(res.Lock.StepTrust["fetch"].Hosts, ",") != "s3.amazonaws.com,s3.amazonaws.com:443" {
+		t.Errorf("fetch reach = %v", res.Lock.StepTrust["fetch"].Hosts)
+	}
+	if strings.Join(res.Lock.StepTrust["file"].Hosts, ",") != "api.github.com" {
+		t.Errorf("file reach = %v", res.Lock.StepTrust["file"].Hosts)
+	}
+	// The emitted lockfile uses the schema field names.
+	lf := string(res.Lockfile)
+	for _, key := range []string{"stepTrust:", "fetch:", "file:", "hosts:"} {
+		if !strings.Contains(lf, key) {
+			t.Errorf("lockfile missing %q:\n%s", key, lf)
+		}
+	}
+	if strings.Contains(lf, "version:\n") {
+		t.Errorf("the uncontracted step must not appear in stepTrust:\n%s", lf)
+	}
+	// The frozen manifest re-parses and its lock block carries the section.
+	fm, err := manifest.Parse(res.FrozenManifest)
+	if err != nil {
+		t.Fatalf("frozen manifest must re-parse: %v", err)
+	}
+	if _, ok := fm.Aileron.Lock["stepTrust"]; !ok {
+		t.Error("frozen manifest lock block must carry stepTrust")
+	}
+}
+
+// TestRun_MalformedToolStepTrustRefuses proves a tool step declaring an
+// empty reach refuses to freeze. Run parses raw bytes, so the schema rejects
+// the shape at the validation gate (sealStepTrust's own backstop for direct
+// constructs is covered in steptrust_test.go); either way the refusal lands
+// before signing, which is the fail-closed contract.
+func TestRun_MalformedToolStepTrustRefuses(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	bad := strings.Replace(toolStepsMD, "        hosts:\n          - s3.amazonaws.com\n          - s3.amazonaws.com:443\n", "        hosts: []\n", 1)
+	if bad == toolStepsMD {
+		t.Fatal("test setup: fixture hosts not found to malform")
+	}
+	if _, err := Run(context.Background(), []byte(bad), Options{
+		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
+		Composer:       fakeComposer(fakeDigest2),
+	}); err == nil {
+		t.Error("a tool step with an empty declared reach must refuse to freeze")
 	}
 }
 
@@ -263,7 +341,8 @@ aileron:
 	composerHit := false
 	_, err := Run(context.Background(), []byte(strings.Replace(badMD, "kind: action-call", "kind: not-a-kind", 1)), Options{
 		SigningKeyPath: keyPath,
-		Composer: FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+		Resolver:       dummyResolver(),
+		Composer: FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
 			composerHit = true
 			return fakeDigest, nil
 		}),

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -20,24 +20,24 @@ var digestPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 // core free of a container runtime: production wires a resolver over
 // container.Runner / container.Builder, tests inject a fake.
 type DigestResolver interface {
-	// ResolveDigest resolves an OCI image reference (a tag, for an
-	// environment custom base image) to its `sha256:` digest. The returned
-	// digest MUST match digestPattern.
+	// ResolveDigest resolves an OCI image reference (a tag: the runner base
+	// or an environment custom base image) to its `sha256:` digest. The
+	// returned digest MUST match digestPattern.
 	ResolveDigest(ctx context.Context, ref string) (string, error)
 }
 
-// FeatureComposer composes a declared reference set onto the Aileron base
-// image and returns the built image's `sha256:` digest. It is the seam over
+// FeatureComposer composes a devcontainer Feature set onto a base image and
+// returns the built image's `sha256:` digest. It is the seam over
 // container.Builder + composition so freeze's composed-environment path is
-// testable without Docker.
-//
-// INTERIM (#1827): the environment bridge passes raw `<name>@<version>` tool
-// refs through this seam; the successor resolves them against the curated
-// catalog to real devcontainer Feature recipes before composing.
+// testable without Docker. base is a digest-pinned image reference
+// (`<ref>@sha256:...`): freeze resolves the base digest BEFORE composing so
+// the compose input can never drift under a floating tag. features are the
+// catalog-resolved published Feature references (see
+// composition.ResolveToolFeatureRef), never raw `<name>@<version>` tool refs.
 type FeatureComposer interface {
-	// ComposeDigest builds the image composed from the given references and
-	// returns its `sha256:` digest.
-	ComposeDigest(ctx context.Context, features []string) (string, error)
+	// ComposeDigest builds the image composed from the given Features onto
+	// base and returns its `sha256:` digest.
+	ComposeDigest(ctx context.Context, base string, features []string) (string, error)
 }
 
 // DigestResolverFunc adapts a function to DigestResolver.
@@ -52,197 +52,107 @@ func (f DigestResolverFunc) ResolveDigest(ctx context.Context, ref string) (stri
 }
 
 // FeatureComposerFunc adapts a function to FeatureComposer.
-type FeatureComposerFunc func(ctx context.Context, features []string) (string, error)
+type FeatureComposerFunc func(ctx context.Context, base string, features []string) (string, error)
 
 // ComposeDigest calls f, or errors when f is nil (a zero-valued adapter).
-func (f FeatureComposerFunc) ComposeDigest(ctx context.Context, features []string) (string, error) {
+func (f FeatureComposerFunc) ComposeDigest(ctx context.Context, base string, features []string) (string, error) {
 	if f == nil {
 		return "", fmt.Errorf("freeze: nil feature composer")
 	}
-	return f(ctx, features)
+	return f(ctx, base, features)
 }
 
-// rung3Name is the execution-environment key for rung-3 (per-step
-// sibling-image dispatch).
-const rung3Name = "rung3PerStepImages"
-
 // resolveImages resolves a manifest's declared environment to the pinned
-// image set and resolved capability set the lockfile records. The cases:
+// image and resolved capability set the lockfile records. The plan runs in
+// one container, so every case yields at most ONE pin:
 //
 //   - instruction-only / no environment block: empty pins, no error
 //     (the skill still gets a contentHash and signature);
 //   - environment.image alone: resolve the custom base image to a digest pin;
-//   - environment.tools alone: compose the declared tools and pin the built
-//     image's digest plus the resolved capability set;
-//   - both declared: refused until #1827 lands tools-onto-custom-base
-//     composition (never silently drop declared tools from a signed pin).
+//   - environment.tools declared (with or without a custom base): resolve the
+//     base — the declared custom image, or the Aileron runner base for
+//     cliVersion (composition.BaseImage) — to its digest, resolve each tool
+//     ref against the curated catalog to its published Feature reference,
+//     compose the Features onto the digest-pinned base, and pin the built
+//     image's digest. The resolved capability set records the declared tools
+//     verbatim (reproducibility comes from the composed digest pin, not the
+//     Feature tag).
 //
-// Every resolved digest is checked against digestPattern: a resolver that
-// yields a tag rather than a digest is rejected (pin by digest, never tag).
-// cliVersion is the Aileron CLI build version; the retained legacy rung
-// branches below use it to resolve the default runner image
-// (composition.BaseImage). It is distinct from the skill's semver label
-// recorded in the lock (Options.Version).
-//
-// The rung1Image/rung2CapabilityUnits/rung3PerStepImages branches below are
-// DORMANT: the schema no longer admits requires.executionEnvironment, so
-// manifest.Parse can never populate the field they read. They are retained,
-// with their direct-construct tests, for #1827 (freeze) and #1829 (runtime)
-// to rewire or delete.
+// Every resolved digest is checked against digestPattern: a resolver or
+// composer that yields a tag rather than a digest is rejected (pin by digest,
+// never tag). cliVersion is the Aileron CLI build version; it selects the
+// default runner-base tag the tools path composes onto when no custom image
+// is declared. It is distinct from the skill's semver label recorded in the
+// lock (Options.Version).
 func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer, cliVersion string) (pins []ImagePin, capSet []string, err error) {
 	if m == nil || m.InstructionOnly {
 		return nil, nil, nil
 	}
-
-	// INTERIM (#1827): the environment block is bridged onto the existing
-	// resolver/composer seams so the tree stays green while the real
-	// catalog-resolved single-composition path lands. Tool refs pass through
-	// RAW (no catalog resolution to Feature recipes, no runner-base
-	// inclusion) and a custom base with declared tools is refused.
-	if env := m.Aileron.Environment; env != nil {
-		if env.Image != "" {
-			// INTERIM (#1827): composing declared tools onto a custom base is
-			// the successor's job. Until it lands, a block declaring both is
-			// refused outright: silently freezing a signed artifact that
-			// omits declared tools would be capability drift.
-			if len(env.Tools) > 0 {
-				return nil, nil, fmt.Errorf("freeze: environment declares both image and tools; composing tools onto a custom base is not yet supported (#1827)")
-			}
-			if dr == nil {
-				return nil, nil, fmt.Errorf("freeze: environment image %q requires a digest resolver", env.Image)
-			}
-			digest, err := dr.ResolveDigest(ctx, env.Image)
-			if err != nil {
-				return nil, nil, fmt.Errorf("freeze: resolve environment image %q: %w", env.Image, err)
-			}
-			if err := requireDigest(env.Image, digest); err != nil {
-				return nil, nil, err
-			}
-			return []ImagePin{{Ref: env.Image, Digest: digest}}, nil, nil
-		}
-		tools := append([]string(nil), env.Tools...)
-		if len(tools) == 0 {
-			// The schema requires tools or image on a present block; this is
-			// the freeze-time defensive backstop for a direct construct.
-			return nil, nil, fmt.Errorf("freeze: environment declares neither tools nor image")
-		}
-		// INTERIM (#1827): the raw <name>@<version> refs go straight through
-		// the composer seam and the resolved capability set records the
-		// declared tools verbatim.
-		if fc == nil {
-			return nil, nil, fmt.Errorf("freeze: environment tools require a feature composer")
-		}
-		digest, err := fc.ComposeDigest(ctx, tools)
-		if err != nil {
-			return nil, nil, fmt.Errorf("freeze: compose environment tools: %w", err)
-		}
-		if err := requireDigest("environment:"+joinFeatures(tools), digest); err != nil {
-			return nil, nil, err
-		}
-		return []ImagePin{{Ref: composedToolsRef(tools), Digest: digest}}, tools, nil
-	}
-
-	env := m.Aileron.Requires.ExecutionEnvironment
-	if len(env) == 0 {
+	env := m.Aileron.Environment
+	if env == nil {
 		// No environment declared: an instruction/composition-only skill
 		// freezes with an empty resolvedImages set.
 		return nil, nil, nil
 	}
 
-	rung1, hasRung1 := env["rung1Image"]
-	rung2, hasRung2 := env["rung2CapabilityUnits"]
-	rung3, hasRung3 := env[rung3Name]
-	switch {
-	case moreThanOne(hasRung1, hasRung2, hasRung3):
-		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares more than one of rung1Image, rung2CapabilityUnits, rung3PerStepImages; exactly one is permitted")
-	case hasRung1:
-		ref, err := rung1ImageRef(rung1)
-		if err != nil {
-			return nil, nil, err
-		}
-		if ref == "" {
-			// No ref declared: resolve the Aileron-provided runner image for the
-			// freezing CLI's version (#1808). The default flows through the same
-			// named-ref resolution below (resolver, requireDigest, digest pin), so
-			// the lock records the concrete resolved ref plus digest exactly as a
-			// named ref does.
-			ref = composition.BaseImage(cliVersion)
-		}
-		if dr == nil {
-			return nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
-		}
-		digest, err := dr.ResolveDigest(ctx, ref)
-		if err != nil {
-			return nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
-		}
-		if err := requireDigest(ref, digest); err != nil {
-			return nil, nil, err
-		}
-		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil
-	case hasRung2:
-		features, err := rung2Features(rung2)
-		if err != nil {
-			return nil, nil, err
-		}
-		if fc == nil {
-			return nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
-		}
-		digest, err := fc.ComposeDigest(ctx, features)
-		if err != nil {
-			return nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
-		}
-		if err := requireDigest("rung2:"+joinFeatures(features), digest); err != nil {
-			return nil, nil, err
-		}
-		// The pre-freeze "ref" for a composed image is the feature set; the
-		// resolved capability set is the same features, pinned.
-		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil
-	case hasRung3:
-		// Rung-3 (per-step sibling-image dispatch) is a built image rung
-		// (ADR-0027): freeze resolves each step's sibling image to a digest
-		// and pins one ImagePin per step. The pins flow into resolvedImages
-		// alongside the rung-1/rung-2 pins, so the plan content hash and
-		// signature cover them.
-		steps, err := rung3StepImages(rung3)
-		if err != nil {
-			return nil, nil, err
-		}
-		if dr == nil {
-			return nil, nil, fmt.Errorf("freeze: rung-3 per-step images require a digest resolver")
-		}
-		out := make([]ImagePin, 0, len(steps))
-		for _, s := range steps {
-			digest, err := dr.ResolveDigest(ctx, s.image)
-			if err != nil {
-				return nil, nil, fmt.Errorf("freeze: resolve rung-3 image %q: %w", s.image, err)
-			}
-			if err := requireDigest(s.image, digest); err != nil {
-				return nil, nil, err
-			}
-			// Stamp the step's declared id (or its positional fallback) onto the
-			// pin so the runtime associates a step to its pin by id, never by the
-			// shared image tag (the #1739 tag-collision ambiguity). The declared
-			// trust-contract hosts are sealed onto the pin so the reach is covered
-			// by the content hash and signature (#1775).
-			out = append(out, ImagePin{Ref: s.image, Digest: digest, StepID: s.id, Hosts: s.hosts})
-		}
-		return out, nil, nil
-	default:
-		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares no image rung (rung1Image, rung2CapabilityUnits, or rung3PerStepImages)")
+	tools := append([]string(nil), env.Tools...)
+	if len(tools) == 0 && env.Image == "" {
+		// The schema requires tools or image on a present block; this is
+		// the freeze-time defensive backstop for a direct construct.
+		return nil, nil, fmt.Errorf("freeze: environment declares neither tools nor image")
 	}
-}
 
-// moreThanOne reports whether more than one of the given booleans is true. It
-// is the exactly-one-rung guard: the schema already forbids two image rungs,
-// so this is the freeze-time defensive backstop.
-func moreThanOne(bs ...bool) bool {
-	n := 0
-	for _, b := range bs {
-		if b {
-			n++
+	// Resolve declared tool refs against the curated catalog and check the
+	// seams FIRST, so a bad manifest or a missing adapter fails before any
+	// container work.
+	featureRefs := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		featureRef, err := composition.ResolveToolFeatureRef(tool)
+		if err != nil {
+			return nil, nil, fmt.Errorf("freeze: resolve environment tool: %w", err)
 		}
+		featureRefs = append(featureRefs, featureRef)
 	}
-	return n > 1
+	if len(tools) > 0 && fc == nil {
+		return nil, nil, fmt.Errorf("freeze: environment tools require a feature composer")
+	}
+
+	// Resolve the base image to its digest. Both paths need it: the
+	// image-only path pins it directly, and the tools path composes onto the
+	// digest-pinned base so the compose input can never drift under a
+	// floating tag.
+	base := env.Image
+	if base == "" {
+		base = composition.BaseImage(cliVersion)
+	}
+	if dr == nil {
+		return nil, nil, fmt.Errorf("freeze: environment base image %q requires a digest resolver", base)
+	}
+	baseDigest, err := dr.ResolveDigest(ctx, base)
+	if err != nil {
+		return nil, nil, fmt.Errorf("freeze: resolve environment base image %q: %w", base, err)
+	}
+	if err := requireDigest(base, baseDigest); err != nil {
+		return nil, nil, err
+	}
+
+	if len(tools) == 0 {
+		// environment.image alone: the digest-resolved custom base IS the
+		// plan image.
+		return []ImagePin{{Ref: env.Image, Digest: baseDigest}}, nil, nil
+	}
+
+	// Compose the catalog-resolved Feature references onto the digest-pinned
+	// base.
+	pinnedBase := base + "@" + baseDigest
+	digest, err := fc.ComposeDigest(ctx, pinnedBase, featureRefs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("freeze: compose environment tools: %w", err)
+	}
+	if err := requireDigest("environment:"+strings.Join(tools, ","), digest); err != nil {
+		return nil, nil, err
+	}
+	return []ImagePin{{Ref: composedToolsRef(pinnedBase, tools), Digest: digest}}, tools, nil
 }
 
 // requireDigest enforces the pin-by-digest invariant: a resolved value that
@@ -254,172 +164,9 @@ func requireDigest(ref, digest string) error {
 	return nil
 }
 
-// rung1ImageRef extracts rung1Image.ref from the untyped execution
-// environment block. An absent ref key is the default-runner contract
-// (#1808): it returns ("", nil), meaning "resolve the Aileron-provided
-// runner image for this CLI version". A ref key that IS present but is not a
-// real, non-empty string (non-string scalar, null, empty, or whitespace-only)
-// is a hard error, not a default: coercing it into an image reference would
-// silently produce a bad pin, and an explicit empty-string ref stays rejected
-// exactly as the schema rejects it.
-func rung1ImageRef(v any) (string, error) {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("freeze: rung1Image is not a mapping")
-	}
-	raw, present := m["ref"]
-	if !present {
-		// No ref declared: use the default Aileron runner image (#1808).
-		return "", nil
-	}
-	ref, ok := raw.(string)
-	if !ok || strings.TrimSpace(ref) == "" {
-		return "", fmt.Errorf("freeze: rung1Image.ref is present but empty or not a string")
-	}
-	return strings.TrimSpace(ref), nil
-}
-
-// rung2Features extracts rung2CapabilityUnits.features from the untyped
-// execution environment block. Each Feature reference MUST be a real,
-// non-empty string; a non-string entry is rejected rather than stringified.
-func rung2Features(v any) ([]string, error) {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("freeze: rung2CapabilityUnits is not a mapping")
-	}
-	rawList, ok := m["features"].([]any)
-	if !ok || len(rawList) == 0 {
-		return nil, fmt.Errorf("freeze: rung2CapabilityUnits.features is missing or empty")
-	}
-	features := make([]string, 0, len(rawList))
-	for _, f := range rawList {
-		s, ok := f.(string)
-		if !ok || strings.TrimSpace(s) == "" {
-			return nil, fmt.Errorf("freeze: rung2CapabilityUnits.features contains an empty or non-string entry")
-		}
-		features = append(features, strings.TrimSpace(s))
-	}
-	return features, nil
-}
-
-// rung3StepImage is one rung-3 step's freeze-relevant fields: the sibling
-// image reference, the id used to link the resolved pin back to the step, and
-// the declared trust-contract hosts freeze seals onto the pin (nil when the
-// step declares no trust contract).
-type rung3StepImage struct {
-	id    string
-	image string
-	hosts []string
-}
-
-// rung3StepImages extracts each rung3PerStepImages.steps[] entry from the
-// untyped execution environment block, returning the per-step image reference
-// and linking id in declared order. Each step MUST be a mapping carrying a
-// non-empty string image; a non-mapping step, a missing/empty steps list, or a
-// non-string/empty image is rejected rather than stringified so a bad step
-// never silently produces a wrong pin. The `id` is optional in the schema: when
-// a step declares one it is carried onto the pin; when absent, a positional
-// fallback (`#<index>`) is used so every pin still traces to exactly one step
-// and the runtime can associate positionally.
-func rung3StepImages(v any) ([]rung3StepImage, error) {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("freeze: rung3PerStepImages is not a mapping")
-	}
-	rawList, ok := m["steps"].([]any)
-	if !ok || len(rawList) == 0 {
-		return nil, fmt.Errorf("freeze: rung3PerStepImages.steps is missing or empty")
-	}
-	steps := make([]rung3StepImage, 0, len(rawList))
-	for i, s := range rawList {
-		step, ok := s.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("freeze: rung3PerStepImages.steps contains a non-mapping entry")
-		}
-		img, ok := step["image"].(string)
-		if !ok || strings.TrimSpace(img) == "" {
-			return nil, fmt.Errorf("freeze: rung3PerStepImages.steps contains a step with an empty or non-string image")
-		}
-		id := rung3StepID(step, i)
-		hosts, err := rung3StepHosts(step)
-		if err != nil {
-			return nil, err
-		}
-		steps = append(steps, rung3StepImage{id: id, image: strings.TrimSpace(img), hosts: hosts})
-	}
-	return steps, nil
-}
-
-// rung3StepHosts extracts the declared trust-contract hosts from a rung-3
-// step's untyped map. It returns nil when the step declares no trustContract
-// (an optional block: absent means the step declares no reach). A declared
-// trustContract whose hosts are missing, empty, or carry a non-string/empty
-// entry is rejected rather than sealing a partial reach: the same guard the
-// image extraction applies, so a malformed reach never silently produces a
-// wrong pin. The schema's hosts minItems:1 rejects an empty declared list
-// before freeze runs; this is the freeze-time defensive backstop.
-func rung3StepHosts(step map[string]any) ([]string, error) {
-	raw, ok := step["trustContract"]
-	if !ok || raw == nil {
-		return nil, nil
-	}
-	tc, ok := raw.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("freeze: rung3PerStepImages.steps contains a step whose trustContract is not a mapping")
-	}
-	hostsRaw, ok := tc["hosts"]
-	if !ok || hostsRaw == nil {
-		return nil, fmt.Errorf("freeze: rung3PerStepImages.steps declares a trustContract with no hosts (access scope is the boundary)")
-	}
-	list, ok := hostsRaw.([]any)
-	if !ok || len(list) == 0 {
-		return nil, fmt.Errorf("freeze: rung3PerStepImages.steps declares a trustContract with an empty or non-array hosts")
-	}
-	hosts := make([]string, 0, len(list))
-	for _, h := range list {
-		s, ok := h.(string)
-		if !ok || strings.TrimSpace(s) == "" {
-			return nil, fmt.Errorf("freeze: rung3PerStepImages.steps declares a trustContract host that is empty or not a string")
-		}
-		hosts = append(hosts, strings.TrimSpace(s))
-	}
-	return hosts, nil
-}
-
-// rung3StepID returns a step's declared `id` when present and a non-empty
-// string, or a positional fallback (`#<index>`) otherwise. The schema makes
-// `id` optional; a non-string or empty id is treated as absent (the schema's
-// minLength:1 rejects an empty string before freeze runs, so this is the
-// defensive backstop) and the positional fallback keeps the pin traceable.
-func rung3StepID(step map[string]any, index int) string {
-	if raw, ok := step["id"].(string); ok {
-		if id := strings.TrimSpace(raw); id != "" {
-			return id
-		}
-	}
-	return fmt.Sprintf("#%d", index)
-}
-
-// composedRef renders a stable pre-freeze reference for a composed rung-2
-// image so the lock entry records what was composed.
-func composedRef(features []string) string {
-	return "aileron-base+features(" + joinFeatures(features) + ")"
-}
-
-// composedToolsRef renders a stable pre-freeze reference for an image
-// composed from declared environment tools so the lock entry records what
-// was composed.
-func composedToolsRef(tools []string) string {
-	return "aileron-base+tools(" + joinFeatures(tools) + ")"
-}
-
-func joinFeatures(features []string) string {
-	out := ""
-	for i, f := range features {
-		if i > 0 {
-			out += ","
-		}
-		out += f
-	}
-	return out
+// composedToolsRef renders a stable, descriptive pre-freeze reference for an
+// image composed from declared environment tools, so the lock entry records
+// what was composed and onto which digest-pinned base.
+func composedToolsRef(pinnedBase string, tools []string) string {
+	return pinnedBase + "+tools(" + strings.Join(tools, ",") + ")"
 }

--- a/internal/flightplan/freeze/images_malformed_test.go
+++ b/internal/flightplan/freeze/images_malformed_test.go
@@ -3,183 +3,13 @@ package freeze
 import (
 	"context"
 	"testing"
-
-	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
 )
 
-// These manifests are built directly (not through manifest.Parse) so the
-// defensive shape checks in resolveImages are exercised: resolveImages is
-// the freeze-time backstop, so malformed executionEnvironment shapes that
-// the schema would reject must still produce a clear error here.
-func mWithExecEnv(env map[string]any) *manifest.Manifest {
-	return &manifest.Manifest{
-		Name: "x",
-		Aileron: manifest.AileronBlock{
-			Requires: manifest.Requires{ExecutionEnvironment: env},
-		},
-	}
-}
-
-// dummyResolver returns a resolver that yields a valid digest, so a malformed
-// executionEnvironment shape surfaces its parse error rather than a
-// nil-resolver error. The shape checks run before resolution, so the resolver
-// is never actually called on these malformed cases.
+// dummyResolver returns a resolver that yields a valid digest, so a test that
+// exercises a later failure (composer, catalog resolution) never trips over
+// base resolution.
 func dummyResolver() DigestResolver {
 	return DigestResolverFunc(func(context.Context, string) (string, error) { return fakeDigest, nil })
-}
-
-func TestResolveImages_BothRungsRejected(t *testing.T) {
-	m := mWithExecEnv(map[string]any{
-		"rung1Image":           map[string]any{"ref": "a:1"},
-		"rung2CapabilityUnits": map[string]any{"features": []any{"f"}},
-	})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
-		t.Error("declaring both rungs must error")
-	}
-}
-
-func TestResolveImages_Rung3AlongsideRung1Rejected(t *testing.T) {
-	m := mWithExecEnv(map[string]any{
-		"rung1Image":         map[string]any{"ref": "a:1"},
-		"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": "b:1"}}},
-	})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("declaring rung-3 alongside rung-1 must error (exactly one image rung)")
-	}
-}
-
-// TestResolveImages_Rung1InvalidRef proves that a rung1Image whose ref key is
-// present but not a real, non-empty string stays rejected at the freeze
-// backstop (an absent key is the default and is covered separately). An empty
-// string, a non-string scalar, and a null are each a hard error, never coerced
-// into a default or a bad pin.
-func TestResolveImages_Rung1InvalidRef(t *testing.T) {
-	cases := map[string]any{
-		"empty string": "",
-		"non-string":   7,
-		"null":         nil,
-	}
-	for name, ref := range cases {
-		t.Run(name, func(t *testing.T) {
-			m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{"ref": ref}})
-			if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-				t.Errorf("rung1Image with a %s ref must error", name)
-			}
-		})
-	}
-}
-
-func TestResolveImages_Rung1NotMapping(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung1Image": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
-		t.Error("rung1Image that is not a mapping must error")
-	}
-}
-
-func TestResolveImages_Rung2EmptyFeatures(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
-		t.Error("rung2 with empty features must error")
-	}
-}
-
-func TestResolveImages_Rung2EmptyFeatureEntry(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{""}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
-		t.Error("rung2 with an empty feature entry must error")
-	}
-}
-
-func TestResolveImages_Rung2NotMapping(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest), ""); err == nil {
-		t.Error("rung2CapabilityUnits that is not a mapping must error")
-	}
-}
-
-func TestResolveImages_Rung3NotMapping(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("rung3PerStepImages that is not a mapping must error")
-	}
-}
-
-func TestResolveImages_Rung3MissingSteps(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("rung3PerStepImages with no steps must error")
-	}
-}
-
-func TestResolveImages_Rung3EmptySteps(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("rung3PerStepImages with an empty steps list must error")
-	}
-}
-
-func TestResolveImages_Rung3StepNotMapping(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{"scalar"}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 step that is not a mapping must error")
-	}
-}
-
-func TestResolveImages_Rung3StepEmptyImage(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": ""}}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 step with an empty image must error")
-	}
-}
-
-func TestResolveImages_Rung3StepNonStringImage(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{map[string]any{"image": 42}}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 step with a non-string image must error")
-	}
-}
-
-func TestResolveImages_Rung3TrustContractNotMapping(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
-		map[string]any{"image": "b:1", "trustContract": "scalar"},
-	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 step whose trustContract is not a mapping must error")
-	}
-}
-
-func TestResolveImages_Rung3TrustContractNoHosts(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
-		map[string]any{"image": "b:1", "trustContract": map[string]any{"effect": "read"}},
-	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 trustContract with no hosts must error")
-	}
-}
-
-func TestResolveImages_Rung3TrustContractNonStringHost(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
-		map[string]any{"image": "b:1", "trustContract": map[string]any{"hosts": []any{42}}},
-	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 trustContract with a non-string host must error")
-	}
-}
-
-func TestResolveImages_Rung3TrustContractEmptyHosts(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": []any{
-		map[string]any{"image": "b:1", "trustContract": map[string]any{"hosts": []any{}}},
-	}}})
-	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, ""); err == nil {
-		t.Error("a rung-3 trustContract with an empty hosts list must error")
-	}
-}
-
-func TestResolveImages_NeitherRung(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"somethingElse": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
-		t.Error("an executionEnvironment with neither rung must error")
-	}
 }
 
 func TestNilAdapters_ErrorNotPanic(t *testing.T) {
@@ -188,7 +18,7 @@ func TestNilAdapters_ErrorNotPanic(t *testing.T) {
 		t.Error("a nil DigestResolverFunc must return an error, not panic")
 	}
 	var fc FeatureComposerFunc
-	if _, err := fc.ComposeDigest(context.Background(), []string{"f"}); err == nil {
+	if _, err := fc.ComposeDigest(context.Background(), "base@"+fakeDigest, []string{"f"}); err == nil {
 		t.Error("a nil FeatureComposerFunc must return an error, not panic")
 	}
 }

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -19,8 +19,9 @@ func parseM(t *testing.T, raw []byte) *manifest.Manifest {
 }
 
 // mWithEnvironment builds a manifest directly with the given typed
-// environment, for interim-branch cases that have no parseable fixture (the
-// schema rejects them before resolveImages could see them).
+// environment, for defensive-backstop cases that have no parseable fixture
+// (the schema rejects them before resolveImages could see them) and for
+// direct-construct composition cases.
 func mWithEnvironment(env *manifest.Environment) *manifest.Manifest {
 	return &manifest.Manifest{
 		Name:    "x",
@@ -28,17 +29,29 @@ func mWithEnvironment(env *manifest.Environment) *manifest.Manifest {
 	}
 }
 
-// TestResolveImages_EnvironmentImageResolvesToDigest proves the
-// environment.image path: the named custom base resolves to exactly one
-// digest pin with no capability set.
+// resolverReturning returns a DigestResolver that records the ref it was
+// asked for into *gotRef and returns digest.
+func resolverReturning(digest string, gotRef *string) DigestResolver {
+	return DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		if gotRef != nil {
+			*gotRef = ref
+		}
+		return digest, nil
+	})
+}
+
+// TestResolveImages_EnvironmentImageResolvesToDigest proves the image-only
+// path: the named custom base resolves to exactly one digest pin with no
+// capability set and the composer seam is never touched.
 func TestResolveImages_EnvironmentImageResolvesToDigest(t *testing.T) {
 	m := parseM(t, []byte(envImageMD))
 	var gotRef string
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		gotRef = ref
-		return fakeDigest, nil
+	composerHit := false
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
+		composerHit = true
+		return fakeDigest2, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "")
+	pins, capSet, err := resolveImages(context.Background(), m, resolverReturning(fakeDigest, &gotRef), fc, "")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -51,68 +64,105 @@ func TestResolveImages_EnvironmentImageResolvesToDigest(t *testing.T) {
 	if capSet != nil {
 		t.Errorf("an image-only environment must have no capability set, got %v", capSet)
 	}
+	if composerHit {
+		t.Error("an image-only environment must never touch the composer seam")
+	}
 }
 
-// TestResolveImages_EnvironmentToolsComposesAndPins proves the
-// environment.tools path over the committed worked example: the declared
-// tool refs pass through the composer seam (raw, per the #1827 interim
-// bridge), the built image pins to one digest, and the resolved capability
-// set records the declared tools.
-func TestResolveImages_EnvironmentToolsComposesAndPins(t *testing.T) {
+// TestResolveImages_ToolsComposeOntoDefaultBase proves the tools path over
+// the committed worked example: the runner base for the CLI version is
+// digest-resolved, the composer receives the DIGEST-PINNED base plus the
+// CATALOG-RESOLVED Feature references (never raw tool refs), the built image
+// pins to exactly one digest, and the resolved capability set records the
+// declared tools verbatim.
+func TestResolveImages_ToolsComposeOntoDefaultBase(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	var gotTools []string
-	fc := FeatureComposerFunc(func(_ context.Context, tools []string) (string, error) {
-		gotTools = tools
-		return fakeDigest, nil
+	var gotBaseRef string
+	var gotComposeBase string
+	var gotFeatures []string
+	fc := FeatureComposerFunc(func(_ context.Context, base string, features []string) (string, error) {
+		gotComposeBase = base
+		gotFeatures = features
+		return fakeDigest2, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, nil, fc, "")
+	pins, capSet, err := resolveImages(context.Background(), m, resolverReturning(fakeDigest, &gotBaseRef), fc, "dev")
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
-	wantTools := []string{"aws-cli@2.x"}
-	if strings.Join(gotTools, ",") != strings.Join(wantTools, ",") {
-		t.Errorf("composer got tools %v, want %v", gotTools, wantTools)
+	wantBase := "ghcr.io/alrubinger/aileron-sandbox-base:edge"
+	if gotBaseRef != wantBase {
+		t.Errorf("resolver got base ref %q, want the default runner base %q", gotBaseRef, wantBase)
 	}
-	if len(pins) != 1 || pins[0].Digest != fakeDigest {
-		t.Errorf("pins = %+v", pins)
+	if gotComposeBase != wantBase+"@"+fakeDigest {
+		t.Errorf("composer got base %q, want the digest-pinned base %q", gotComposeBase, wantBase+"@"+fakeDigest)
 	}
-	if strings.Join(capSet, ",") != strings.Join(wantTools, ",") {
-		t.Errorf("resolved capability set = %v, want %v", capSet, wantTools)
+	wantFeatures := "ghcr.io/alrubinger/aileron-features/aws-cli:0"
+	if strings.Join(gotFeatures, ",") != wantFeatures {
+		t.Errorf("composer got features %v, want the catalog-resolved %q", gotFeatures, wantFeatures)
+	}
+	if len(pins) != 1 || pins[0].Digest != fakeDigest2 {
+		t.Fatalf("a tools environment must pin exactly one image with the composed digest, got %+v", pins)
+	}
+	if !strings.Contains(pins[0].Ref, wantBase+"@"+fakeDigest) || !strings.Contains(pins[0].Ref, "aws-cli@2.x") {
+		t.Errorf("the pin ref must record the pinned base and the composed tools, got %q", pins[0].Ref)
+	}
+	if strings.Join(capSet, ",") != "aws-cli@2.x" {
+		t.Errorf("resolved capability set must record the declared tools verbatim, got %v", capSet)
+	}
+	if pins[0].StepID != "" || pins[0].Hosts != nil {
+		t.Errorf("a composed pin must carry no per-pin step linkage, got %+v", pins[0])
 	}
 }
 
-// TestResolveImages_EnvironmentImageWithToolsRefusedInterim documents the
-// INTERIM (#1827) behavior for a block declaring both image and tools: the
-// schema accepts the combination (the target contract composes the tools
-// onto the custom base), but until #1827 lands that composition, freeze
-// refuses rather than silently pinning a signed artifact that omits the
-// declared tools. This test is expected to change with #1827.
-func TestResolveImages_EnvironmentImageWithToolsRefusedInterim(t *testing.T) {
+// TestResolveImages_ToolsDefaultBaseReleaseUsesLatest proves the CLI-version
+// tag split on the default composition base: a release version resolves the
+// runner base at :latest, matching composition.BaseImage.
+func TestResolveImages_ToolsDefaultBaseReleaseUsesLatest(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	var gotBaseRef string
+	if _, _, err := resolveImages(context.Background(), m, resolverReturning(fakeDigest, &gotBaseRef), fakeComposer(fakeDigest2), "0.0.3"); err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if want := "ghcr.io/alrubinger/aileron-sandbox-base:latest"; gotBaseRef != want {
+		t.Errorf("a release CLI version must compose onto %q, got %q", want, gotBaseRef)
+	}
+}
+
+// TestResolveImages_ToolsComposeOntoCustomImage proves the both-declared
+// contract (#1827): a block declaring image AND tools composes the declared
+// tools onto the digest-resolved custom base, never silently dropping either.
+func TestResolveImages_ToolsComposeOntoCustomImage(t *testing.T) {
 	m := mWithEnvironment(&manifest.Environment{
 		Image: "registry.example.com/base:1",
-		Tools: []string{"gh@2"},
+		Tools: []string{"gh@2", "aws-cli@2.x"},
 	})
-	resolverHit, composerHit := false, false
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		resolverHit = true
-		return fakeDigest, nil
-	})
-	fc := FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
-		composerHit = true
+	var gotBaseRef string
+	var gotComposeBase string
+	var gotFeatures []string
+	fc := FeatureComposerFunc(func(_ context.Context, base string, features []string) (string, error) {
+		gotComposeBase = base
+		gotFeatures = features
 		return fakeDigest2, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, fc, "")
-	if err == nil {
-		t.Fatal("INTERIM: image+tools must be refused until #1827 composes tools onto a custom base")
+	pins, capSet, err := resolveImages(context.Background(), m, resolverReturning(fakeDigest, &gotBaseRef), fc, "dev")
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
 	}
-	if !strings.Contains(err.Error(), "#1827") {
-		t.Errorf("error should name the successor issue, got: %v", err)
+	if gotBaseRef != "registry.example.com/base:1" {
+		t.Errorf("resolver got %q, want the declared custom base", gotBaseRef)
 	}
-	if resolverHit || composerHit {
-		t.Errorf("a refused environment must touch no container seam (resolver=%v composer=%v)", resolverHit, composerHit)
+	if gotComposeBase != "registry.example.com/base:1@"+fakeDigest {
+		t.Errorf("composer got base %q, want the digest-pinned custom base", gotComposeBase)
 	}
-	if pins != nil || capSet != nil {
-		t.Errorf("a refused environment must pin nothing, got pins=%v cap=%v", pins, capSet)
+	want := "ghcr.io/alrubinger/aileron-features/gh:0,ghcr.io/alrubinger/aileron-features/aws-cli:0"
+	if strings.Join(gotFeatures, ",") != want {
+		t.Errorf("composer got features %v, want %q (declared order, catalog-resolved)", gotFeatures, want)
+	}
+	if len(pins) != 1 || pins[0].Digest != fakeDigest2 {
+		t.Fatalf("tools onto a custom base must pin exactly one image, got %+v", pins)
+	}
+	if strings.Join(capSet, ",") != "gh@2,aws-cli@2.x" {
+		t.Errorf("resolved capability set = %v, want the declared tools verbatim", capSet)
 	}
 }
 
@@ -162,15 +212,37 @@ func TestResolveImages_RejectsTagNotDigest(t *testing.T) {
 	}
 }
 
+// TestResolveImages_ToolsBaseTagNotDigestRejected proves the pin-by-digest
+// guard covers the composition base: a resolver that yields a tag for the
+// base is rejected BEFORE the composer runs, so a drifting base can never be
+// composed onto.
+func TestResolveImages_ToolsBaseTagNotDigestRejected(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		return ref, nil // echo the tag, not a digest
+	})
+	composerHit := false
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
+		composerHit = true
+		return fakeDigest2, nil
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, fc, "dev"); err == nil {
+		t.Fatal("a tag-resolved base must be rejected")
+	}
+	if composerHit {
+		t.Error("the composer must never run on an unpinned base")
+	}
+}
+
 // TestResolveImages_ToolsComposerTagRejected proves the pin-by-digest guard
-// covers the composed-tools path: a composer that yields a tag rather than a
+// covers the composed image: a composer that yields a tag rather than a
 // digest is rejected.
 func TestResolveImages_ToolsComposerTagRejected(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	fc := FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
 		return "aileron-composed:latest", nil // a tag, not a digest
 	})
-	_, _, err := resolveImages(context.Background(), m, nil, fc, "")
+	_, _, err := resolveImages(context.Background(), m, dummyResolver(), fc, "dev")
 	if err == nil {
 		t.Fatal("a composer returning a tag must be rejected")
 	}
@@ -189,14 +261,27 @@ func TestResolveImages_ResolverError(t *testing.T) {
 	}
 }
 
+// TestResolveImages_ToolsBaseResolverError proves a base-resolution failure
+// on the tools path surfaces as an error rather than a silent unpinned
+// composition.
+func TestResolveImages_ToolsBaseResolverError(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		return "", errors.New("base not found")
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, fakeComposer(fakeDigest2), "dev"); err == nil {
+		t.Error("an unresolvable composition base must error")
+	}
+}
+
 // TestResolveImages_ToolsComposerError proves a composer failure surfaces as
 // an error rather than a silent empty pin set.
 func TestResolveImages_ToolsComposerError(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	fc := FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
 		return "", errors.New("compose failed")
 	})
-	if _, _, err := resolveImages(context.Background(), m, nil, fc, ""); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), fc, "dev"); err == nil {
 		t.Error("a failing composer must error")
 	}
 }
@@ -208,10 +293,43 @@ func TestResolveImages_EnvironmentImageNeedsResolver(t *testing.T) {
 	}
 }
 
+// TestResolveImages_EnvironmentToolsNeedResolver proves the tools path
+// requires the digest resolver: the composition base must be digest-pinned
+// before composing, so a nil resolver is a hard error.
+func TestResolveImages_EnvironmentToolsNeedResolver(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest2), "dev"); err == nil {
+		t.Error("a tools environment with no resolver must error")
+	}
+}
+
 func TestResolveImages_EnvironmentToolsNeedComposer(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
+	if _, _, err := resolveImages(context.Background(), m, dummyResolver(), nil, "dev"); err == nil {
 		t.Error("a tools environment with no composer must error")
+	}
+}
+
+// TestResolveImages_UnknownToolRejected proves the freeze-time defensive
+// backstop for a direct-construct unknown tool (the schema's closed tool
+// pattern rejects it before this code runs on any parsed manifest): the
+// catalog resolution fails before any seam is touched.
+func TestResolveImages_UnknownToolRejected(t *testing.T) {
+	m := mWithEnvironment(&manifest.Environment{Tools: []string{"nmap@7.1"}})
+	resolverHit, composerHit := false, false
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		resolverHit = true
+		return fakeDigest, nil
+	})
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
+		composerHit = true
+		return fakeDigest2, nil
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, fc, "dev"); err == nil {
+		t.Fatal("an unknown tool name must be rejected")
+	}
+	if resolverHit || composerHit {
+		t.Errorf("a rejected tool must touch no container seam (resolver=%v composer=%v)", resolverHit, composerHit)
 	}
 }
 
@@ -227,29 +345,29 @@ func TestRequireDigest(t *testing.T) {
 }
 
 // TestResolveImages_DistinctToolSetsDistinctPins is the composition
-// divergence contract on the live environment path: two different declared
-// tool sets must produce two different pinned image digests, and the same
-// set must reproduce the same pin (determinism). The composer is a fake
-// mapping each distinct tool set to a distinct digest, proving the contract
-// at the freeze layer without a container runtime.
+// divergence contract: two different declared tool sets must produce two
+// different pinned image digests, and the same set must reproduce the same
+// pin (determinism). The composer is a fake mapping each distinct feature set
+// to a distinct digest, proving the contract at the freeze layer without a
+// container runtime.
 func TestResolveImages_DistinctToolSetsDistinctPins(t *testing.T) {
 	digestFor := map[string]string{
-		"aws-cli@2.x": fakeDigest,
-		"gh@2":        fakeDigest2,
+		"ghcr.io/alrubinger/aileron-features/aws-cli:0": fakeDigest,
+		"ghcr.io/alrubinger/aileron-features/gh:0":      fakeDigest2,
 	}
-	fc := FeatureComposerFunc(func(_ context.Context, tools []string) (string, error) {
-		return digestFor[joinFeatures(tools)], nil
+	fc := FeatureComposerFunc(func(_ context.Context, _ string, features []string) (string, error) {
+		return digestFor[strings.Join(features, ",")], nil
 	})
 
 	mWithTools := func(tools ...string) *manifest.Manifest {
 		return mWithEnvironment(&manifest.Environment{Tools: tools})
 	}
 
-	pinsA, capA, err := resolveImages(context.Background(), mWithTools("aws-cli@2.x"), nil, fc, "")
+	pinsA, capA, err := resolveImages(context.Background(), mWithTools("aws-cli@2.x"), dummyResolver(), fc, "dev")
 	if err != nil {
 		t.Fatalf("compose tool set A: %v", err)
 	}
-	pinsB, _, err := resolveImages(context.Background(), mWithTools("gh@2"), nil, fc, "")
+	pinsB, _, err := resolveImages(context.Background(), mWithTools("gh@2"), dummyResolver(), fc, "dev")
 	if err != nil {
 		t.Fatalf("compose tool set B: %v", err)
 	}
@@ -263,346 +381,11 @@ func TestResolveImages_DistinctToolSetsDistinctPins(t *testing.T) {
 		t.Errorf("resolved capability set must record the declared tools, got %v", capA)
 	}
 	// Same tool set must reproduce the same pin (determinism).
-	pinsA2, _, err := resolveImages(context.Background(), mWithTools("aws-cli@2.x"), nil, fc, "")
+	pinsA2, _, err := resolveImages(context.Background(), mWithTools("aws-cli@2.x"), dummyResolver(), fc, "dev")
 	if err != nil {
 		t.Fatalf("recompose tool set A: %v", err)
 	}
 	if pinsA2[0].Digest != pinsA[0].Digest {
 		t.Errorf("the same tool set must reproduce the same pin: %q vs %q", pinsA2[0].Digest, pinsA[0].Digest)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// DORMANT legacy rung coverage (#1827/#1829). The schema no longer admits
-// requires.executionEnvironment, so the fixtures below are built directly
-// (never parsed). They keep the retained rung branches in resolveImages
-// covered until their owners rewire or delete them.
-// ---------------------------------------------------------------------------
-
-// legacyRung1Default is a direct-construct rung-1 manifest that declares no
-// ref (the retained default-runner path, #1808).
-func legacyRung1Default() *manifest.Manifest {
-	return mWithExecEnv(map[string]any{"rung1Image": map[string]any{}})
-}
-
-// TestResolveImages_LegacyRung1DefaultResolvesBaseImage keeps the dormant
-// default-runner branch covered: a rung-1 declaration with no ref resolves
-// the Aileron-provided runner image for the CLI version (a dev version
-// selects the :edge tag).
-func TestResolveImages_LegacyRung1DefaultResolvesBaseImage(t *testing.T) {
-	var gotRef string
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		gotRef = ref
-		return fakeDigest, nil
-	})
-	pins, capSet, err := resolveImages(context.Background(), legacyRung1Default(), dr, nil, "dev")
-	if err != nil {
-		t.Fatalf("resolveImages: %v", err)
-	}
-	wantRef := "ghcr.io/alrubinger/aileron-sandbox-base:edge"
-	if gotRef != wantRef {
-		t.Errorf("resolver got ref %q, want the default runner image %q", gotRef, wantRef)
-	}
-	if len(pins) != 1 || pins[0].Ref != wantRef || pins[0].Digest != fakeDigest {
-		t.Errorf("default rung-1 must pin the concrete default ref + digest, got %+v", pins)
-	}
-	if capSet != nil {
-		t.Errorf("rung-1 must have no capability set, got %v", capSet)
-	}
-}
-
-// TestResolveImages_LegacyRung1DefaultReleaseUsesLatest keeps the CLI-version
-// tag split covered on the dormant branch: a release version resolves the
-// default runner image at :latest, matching composition.imageTag.
-func TestResolveImages_LegacyRung1DefaultReleaseUsesLatest(t *testing.T) {
-	var gotRef string
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		gotRef = ref
-		return fakeDigest, nil
-	})
-	if _, _, err := resolveImages(context.Background(), legacyRung1Default(), dr, nil, "0.0.3"); err != nil {
-		t.Fatalf("resolveImages: %v", err)
-	}
-	if want := "ghcr.io/alrubinger/aileron-sandbox-base:latest"; gotRef != want {
-		t.Errorf("a release CLI version must resolve the default at %q, got %q", want, gotRef)
-	}
-}
-
-// TestResolveImages_LegacyRung1NamedRef keeps the dormant named-ref rung-1
-// branch covered: the declared ref resolves to a digest pin.
-func TestResolveImages_LegacyRung1NamedRef(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{"ref": "registry.example.com/runner:1.4"}})
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		return fakeDigest, nil
-	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err != nil {
-		t.Fatalf("resolveImages: %v", err)
-	}
-	if len(pins) != 1 || pins[0].Ref != "registry.example.com/runner:1.4" || pins[0].Digest != fakeDigest {
-		t.Errorf("pins = %+v", pins)
-	}
-	if pins[0].StepID != "" {
-		t.Errorf("a rung-1 pin must carry no StepID, got %+v", pins[0])
-	}
-}
-
-// TestResolveImages_LegacyRung1NeedsResolver keeps the dormant nil-resolver
-// guard covered.
-func TestResolveImages_LegacyRung1NeedsResolver(t *testing.T) {
-	if _, _, err := resolveImages(context.Background(), legacyRung1Default(), nil, nil, "dev"); err == nil {
-		t.Error("a rung-1 manifest with no resolver must error")
-	}
-}
-
-// TestResolveImages_LegacyRung1RejectsTagNotDigest keeps the pin-by-digest
-// guard covered on the dormant rung-1 branch.
-func TestResolveImages_LegacyRung1RejectsTagNotDigest(t *testing.T) {
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		return ref, nil // echo the tag, not a digest
-	})
-	if _, _, err := resolveImages(context.Background(), legacyRung1Default(), dr, nil, "dev"); err == nil {
-		t.Error("a rung-1 resolver returning a tag must be rejected")
-	}
-}
-
-// TestResolveImages_LegacyRung1ResolverError keeps the resolver failure path
-// covered on the dormant rung-1 branch.
-func TestResolveImages_LegacyRung1ResolverError(t *testing.T) {
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return "", errors.New("image not found")
-	})
-	if _, _, err := resolveImages(context.Background(), legacyRung1Default(), dr, nil, "dev"); err == nil {
-		t.Error("an unresolvable rung-1 image must error")
-	}
-}
-
-// TestResolveImages_LegacyRung2ComposesAndPins keeps the dormant rung-2
-// branch covered: the declared Features compose to one pin plus the resolved
-// capability set.
-func TestResolveImages_LegacyRung2ComposesAndPins(t *testing.T) {
-	features := []any{"ghcr.io/example/feature-a:1", "ghcr.io/example/feature-b:1"}
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": features}})
-	var gotFeatures []string
-	fc := FeatureComposerFunc(func(_ context.Context, fs []string) (string, error) {
-		gotFeatures = fs
-		return fakeDigest, nil
-	})
-	pins, capSet, err := resolveImages(context.Background(), m, nil, fc, "")
-	if err != nil {
-		t.Fatalf("resolveImages: %v", err)
-	}
-	if strings.Join(gotFeatures, ",") != "ghcr.io/example/feature-a:1,ghcr.io/example/feature-b:1" {
-		t.Errorf("composer got features %v", gotFeatures)
-	}
-	if len(pins) != 1 || pins[0].Digest != fakeDigest {
-		t.Errorf("pins = %+v", pins)
-	}
-	if strings.Join(capSet, ",") != "ghcr.io/example/feature-a:1,ghcr.io/example/feature-b:1" {
-		t.Errorf("resolved capability set = %v", capSet)
-	}
-}
-
-// TestResolveImages_LegacyRung2NeedsComposer keeps the dormant nil-composer
-// guard covered.
-func TestResolveImages_LegacyRung2NeedsComposer(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{"f"}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
-		t.Error("a rung-2 manifest with no composer must error")
-	}
-}
-
-// TestResolveImages_LegacyRung2ComposerError keeps the composer failure path
-// covered on the dormant rung-2 branch.
-func TestResolveImages_LegacyRung2ComposerError(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{"f"}}})
-	fc := FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
-		return "", errors.New("compose failed")
-	})
-	if _, _, err := resolveImages(context.Background(), m, nil, fc, ""); err == nil {
-		t.Error("a failing rung-2 composer must error")
-	}
-}
-
-// TestResolveImages_LegacyRung2RejectsTagNotDigest keeps the pin-by-digest
-// guard covered on the dormant rung-2 branch.
-func TestResolveImages_LegacyRung2RejectsTagNotDigest(t *testing.T) {
-	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{"f"}}})
-	fc := FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
-		return "composed:latest", nil // a tag, not a digest
-	})
-	if _, _, err := resolveImages(context.Background(), m, nil, fc, ""); err == nil {
-		t.Error("a rung-2 composer returning a tag must be rejected")
-	}
-}
-
-// legacyRung3 builds a direct-construct rung-3 manifest from the given step
-// maps.
-func legacyRung3(steps ...map[string]any) *manifest.Manifest {
-	list := make([]any, len(steps))
-	for i, s := range steps {
-		list[i] = s
-	}
-	return mWithExecEnv(map[string]any{"rung3PerStepImages": map[string]any{"steps": list}})
-}
-
-// TestResolveImages_LegacyRung3ResolvesPerStepDigests keeps the dormant
-// rung-3 branch covered: each step's sibling image resolves to its own pin
-// carrying the declared step id, in declared order, with no capability set.
-func TestResolveImages_LegacyRung3ResolvesPerStepDigests(t *testing.T) {
-	m := legacyRung3(
-		map[string]any{"id": "extract", "image": "registry.example.com/tool-a:1"},
-		map[string]any{"id": "convert", "image": "registry.example.com/tool-b:2"},
-	)
-	digestFor := map[string]string{
-		"registry.example.com/tool-a:1": fakeDigest,
-		"registry.example.com/tool-b:2": fakeDigest2,
-	}
-	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
-		return digestFor[ref], nil
-	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err != nil {
-		t.Fatalf("rung-3 resolution must succeed: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("rung-3 must pin one image per step, got %+v", pins)
-	}
-	if pins[0].Ref != "registry.example.com/tool-a:1" || pins[0].Digest != fakeDigest || pins[0].StepID != "extract" {
-		t.Errorf("first step pin = %+v", pins[0])
-	}
-	if pins[1].Ref != "registry.example.com/tool-b:2" || pins[1].Digest != fakeDigest2 || pins[1].StepID != "convert" {
-		t.Errorf("second step pin = %+v", pins[1])
-	}
-	if len(capSet) != 0 {
-		t.Errorf("rung-3 must pin no capability set, got %v", capSet)
-	}
-}
-
-// TestResolveImages_LegacyRung3SharedTagPinsDistinctlyByID keeps the #1739
-// tag-collision regression covered on the dormant branch: two steps naming
-// the SAME image tag pin distinctly by their declared step ids.
-func TestResolveImages_LegacyRung3SharedTagPinsDistinctlyByID(t *testing.T) {
-	m := legacyRung3(
-		map[string]any{"id": "first", "image": "registry.example.com/shared-tool:1"},
-		map[string]any{"id": "second", "image": "registry.example.com/shared-tool:1"},
-	)
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return fakeDigest, nil
-	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err != nil {
-		t.Fatalf("shared-tag rung-3 resolution must succeed: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("two steps sharing a tag must still pin one image per step, got %+v", pins)
-	}
-	if pins[0].StepID != "first" || pins[1].StepID != "second" {
-		t.Errorf("pins must carry the declared step ids, got [%q, %q]", pins[0].StepID, pins[1].StepID)
-	}
-}
-
-// TestResolveImages_LegacyRung3PositionalIDFallback keeps the positional
-// fallback covered on the dormant branch: steps with no declared id still
-// get traceable, distinct positional ids stamped onto their pins.
-func TestResolveImages_LegacyRung3PositionalIDFallback(t *testing.T) {
-	m := legacyRung3(
-		map[string]any{"image": "registry.example.com/tool-a:1"},
-		map[string]any{"image": "registry.example.com/tool-b:2"},
-	)
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return fakeDigest, nil
-	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err != nil {
-		t.Fatalf("no-id rung-3 resolution must succeed: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("expected two pins, got %+v", pins)
-	}
-	if pins[0].StepID != "#0" || pins[1].StepID != "#1" {
-		t.Errorf("positional fallback ids must be #0/#1, got [%q, %q]", pins[0].StepID, pins[1].StepID)
-	}
-}
-
-// TestResolveImages_LegacyRung3SealsTrustContractHosts keeps the #1775
-// sealed-reach behavior covered on the dormant branch: a step declaring a
-// trustContract has its hosts sealed onto the pin; a step declaring none
-// pins with nil hosts, which the marshaled lock omits.
-func TestResolveImages_LegacyRung3SealsTrustContractHosts(t *testing.T) {
-	m := legacyRung3(
-		map[string]any{
-			"id":    "reach",
-			"image": "registry.example.com/tool-a:1",
-			"trustContract": map[string]any{
-				"hosts": []any{"api.upstream.example.com", "api.upstream.example.com:443"},
-			},
-		},
-		map[string]any{"id": "noreach", "image": "registry.example.com/tool-b:2"},
-	)
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return fakeDigest, nil
-	})
-	pins, _, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err != nil {
-		t.Fatalf("resolveImages: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("expected two pins, got %+v", pins)
-	}
-	if pins[0].StepID != "reach" {
-		t.Fatalf("first pin must be the reach step, got %+v", pins[0])
-	}
-	if strings.Join(pins[0].Hosts, ",") != "api.upstream.example.com,api.upstream.example.com:443" {
-		t.Errorf("reach pin must seal the declared hosts, got %v", pins[0].Hosts)
-	}
-	if pins[1].StepID != "noreach" || len(pins[1].Hosts) != 0 {
-		t.Errorf("a step with no trust contract must pin with nil hosts, got %+v", pins[1])
-	}
-
-	// The nil-hosts pin omits `hosts` from the marshaled lock (byte-stability).
-	lf, err := MarshalLockfile(Lockfile{ResolvedImages: pins[1:]})
-	if err != nil {
-		t.Fatalf("marshal lockfile: %v", err)
-	}
-	if strings.Contains(string(lf), "hosts") {
-		t.Errorf("a no-reach pin must omit hosts from the lock, got:\n%s", lf)
-	}
-}
-
-// TestResolveImages_LegacyRung3RejectsTagNotDigest keeps the pin-by-digest
-// guard covered on the dormant rung-3 branch.
-func TestResolveImages_LegacyRung3RejectsTagNotDigest(t *testing.T) {
-	m := legacyRung3(map[string]any{"image": "registry.example.com/per-step-tool:1"})
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return "registry.example.com/per-step-tool:1", nil // a tag, not a digest
-	})
-	_, _, err := resolveImages(context.Background(), m, dr, nil, "")
-	if err == nil {
-		t.Fatal("a rung-3 resolver returning a tag must be rejected")
-	}
-	if !strings.Contains(err.Error(), "digest") {
-		t.Errorf("error should explain the pin-by-digest rule, got: %v", err)
-	}
-}
-
-// TestResolveImages_LegacyRung3ResolverError keeps the per-step resolver
-// failure path covered on the dormant branch.
-func TestResolveImages_LegacyRung3ResolverError(t *testing.T) {
-	m := legacyRung3(map[string]any{"image": "registry.example.com/per-step-tool:1"})
-	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
-		return "", errors.New("image not found")
-	})
-	if _, _, err := resolveImages(context.Background(), m, dr, nil, ""); err == nil {
-		t.Error("an unresolvable rung-3 image must error")
-	}
-}
-
-// TestResolveImages_LegacyRung3NeedsResolver keeps the dormant rung-3
-// nil-resolver guard covered.
-func TestResolveImages_LegacyRung3NeedsResolver(t *testing.T) {
-	m := legacyRung3(map[string]any{"image": "registry.example.com/per-step-tool:1"})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil, ""); err == nil {
-		t.Error("a rung-3 manifest with no resolver must error")
 	}
 }

--- a/internal/flightplan/freeze/launch.go
+++ b/internal/flightplan/freeze/launch.go
@@ -29,6 +29,14 @@ type VerifiedFrozen struct {
 	// populated on the verified path: a tampered digest changes the recomputed
 	// content hash and refuses before this field is read.
 	ResolvedImages []ImagePin
+	// StepTrust is the step-keyed sealed trust section carried by the
+	// verified manifest lock block: for each tool step that declared a trust
+	// contract, the network reach freeze sealed from it, keyed by step id.
+	// Launch/runtime read the sealed reach only from here (the verified
+	// path): a tampered section changes the recomputed content hash and
+	// refuses before this field is read. Nil when the frozen unit seals no
+	// tool-step reach.
+	StepTrust map[string]StepReach
 	// SignerFingerprint is the `sha256:<hex>` fingerprint of the verified
 	// author public-key PEM (the same `pubPEM` the ed25519 signature verified
 	// against). It is the honest signer identity the audit trail carries:
@@ -143,10 +151,22 @@ func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, 
 	if len(manifestLock.ResolvedImages) > 0 {
 		pins = append([]ImagePin(nil), manifestLock.ResolvedImages...)
 	}
+	// The step-keyed sealed reach is copied from the manifest's own verified
+	// lock block exactly like the pins, with the hosts slices defensively
+	// copied so a later mutation of manifestLock can never change what a
+	// caller reads off the verified path.
+	var stepTrust map[string]StepReach
+	if len(manifestLock.StepTrust) > 0 {
+		stepTrust = make(map[string]StepReach, len(manifestLock.StepTrust))
+		for id, reach := range manifestLock.StepTrust {
+			stepTrust[id] = StepReach{Hosts: append([]string(nil), reach.Hosts...)}
+		}
+	}
 	return VerifiedFrozen{
 		SkillMD:           verified,
 		ContentHash:       recorded,
 		ResolvedImages:    pins,
+		StepTrust:         stepTrust,
 		SignerFingerprint: signerFingerprint(pubPEM),
 	}, nil
 }

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -17,10 +17,29 @@ func freezeExample(t *testing.T) Result {
 	res, err := Run(context.Background(), exampleSkillMD(t), Options{
 		Version:        "1.0.0",
 		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
 		Composer:       fakeComposer(fakeDigest),
 	})
 	if err != nil {
 		t.Fatalf("freeze.Run: %v", err)
+	}
+	return res
+}
+
+// freezeToolSteps freezes the tool-steps fixture (two contracted tool steps)
+// with a fresh signing key, the shared fixture for the verified stepTrust
+// exposure tests.
+func freezeToolSteps(t *testing.T) Result {
+	t.Helper()
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), []byte(toolStepsMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
+		Composer:       fakeComposer(fakeDigest2),
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run tool steps: %v", err)
 	}
 	return res
 }
@@ -132,6 +151,63 @@ func TestVerifyFrozen_ExposesResolvedImagesForEnvironmentImage(t *testing.T) {
 	}
 	if v.ResolvedImages[0].Ref != "registry.example.com/runner:1.4" {
 		t.Errorf("ResolvedImages[0].Ref = %q, want the environment.image ref", v.ResolvedImages[0].Ref)
+	}
+}
+
+// TestVerifyFrozen_ExposesStepTrust proves launch/runtime read the sealed
+// reach off the verified path: a successful verification surfaces the
+// step-keyed trust section exactly as the manifest's verified lock block
+// recorded it, defensively copied.
+func TestVerifyFrozen_ExposesStepTrust(t *testing.T) {
+	res := freezeToolSteps(t)
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen: %v", err)
+	}
+	if len(v.StepTrust) != 2 {
+		t.Fatalf("StepTrust = %+v, want the two contracted steps", v.StepTrust)
+	}
+	if strings.Join(v.StepTrust["fetch"].Hosts, ",") != "s3.amazonaws.com,s3.amazonaws.com:443" {
+		t.Errorf("fetch reach = %v", v.StepTrust["fetch"].Hosts)
+	}
+	if strings.Join(v.StepTrust["file"].Hosts, ",") != "api.github.com" {
+		t.Errorf("file reach = %v", v.StepTrust["file"].Hosts)
+	}
+	// A skill sealing no reach exposes a nil section.
+	plain := freezeExample(t)
+	vp, err := VerifyFrozen(plain.FrozenManifest, plain.Lockfile, plain.Signature, plain.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen (no tool steps): %v", err)
+	}
+	if vp.StepTrust != nil {
+		t.Errorf("a unit sealing no reach must expose nil StepTrust, got %+v", vp.StepTrust)
+	}
+}
+
+// TestVerifyFrozen_TamperedStepTrustRefuses is the sign-coverage regression
+// for the step-keyed section: widening a sealed host inside the frozen
+// manifest's lock block after signing changes the recomputed content hash,
+// so verification refuses before any reach is exposed.
+func TestVerifyFrozen_TamperedStepTrustRefuses(t *testing.T) {
+	res := freezeToolSteps(t)
+	// The lock block is injected at the end of the aileron mapping, so the
+	// LAST occurrence of the sealed host is the lock's stepTrust entry (the
+	// earlier occurrences are the step's declared contract in the signed
+	// frontmatter). Tamper only that sealed entry.
+	target := []byte("api.github.com")
+	idx := bytes.LastIndex(res.FrozenManifest, target)
+	if idx < 0 {
+		t.Fatal("test setup: sealed host not found in the frozen manifest")
+	}
+	tampered := append([]byte(nil), res.FrozenManifest[:idx]...)
+	tampered = append(tampered, []byte("api.evil-example.com")...)
+	tampered = append(tampered, res.FrozenManifest[idx+len(target):]...)
+	v, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey)
+	if err == nil {
+		t.Fatal("a tampered stepTrust section must refuse to verify")
+	}
+	if len(v.StepTrust) != 0 {
+		t.Errorf("a refused verification must expose no sealed reach, got %+v", v.StepTrust)
 	}
 }
 

--- a/internal/flightplan/freeze/lint.go
+++ b/internal/flightplan/freeze/lint.go
@@ -9,12 +9,14 @@ import (
 
 // validStepKinds is the closed set of step kinds the schema permits. The
 // no-LLM guarantee is structural: only `llm-seam` reaches an LLM, and every
-// other kind is deterministic by construction. A step whose kind is absent
-// or outside this set could smuggle a non-deterministic call past the seam,
-// so the lint rejects it.
+// other kind (action-call, transform, and the deterministic-subprocess tool
+// step) is deterministic by construction. A step whose kind is absent or
+// outside this set could smuggle a non-deterministic call past the seam, so
+// the lint rejects it.
 var validStepKinds = map[string]bool{
 	"action-call": true,
 	"transform":   true,
+	"tool":        true,
 	"llm-seam":    true,
 }
 
@@ -44,7 +46,7 @@ func (e *LintError) Error() string {
 //
 //   - every step must declare a `kind`;
 //   - that kind must be one of the schema's closed set (action-call,
-//     transform, llm-seam); an unknown kind is a smuggling vector;
+//     transform, tool, llm-seam); an unknown kind is a smuggling vector;
 //   - a non-seam step must not carry an LLM marker (a key whose name marks
 //     a model/prompt/llm call). Only `llm-seam` may.
 //
@@ -71,7 +73,7 @@ func Lint(m *manifest.Manifest) error {
 		if !validStepKinds[kind] {
 			return &LintError{
 				StepID: id,
-				Reason: fmt.Sprintf("unknown step kind %q (only action-call, transform, and the marked llm-seam may appear)", kind),
+				Reason: fmt.Sprintf("unknown step kind %q (only action-call, transform, tool, and the marked llm-seam may appear)", kind),
 			}
 		}
 		if kind == llmSeamKind {

--- a/internal/flightplan/freeze/lint_test.go
+++ b/internal/flightplan/freeze/lint_test.go
@@ -122,6 +122,36 @@ func TestLint_RejectsModelMarkerOnTransform(t *testing.T) {
 	}
 }
 
+// TestLint_AcceptsCleanToolStep proves `kind: tool` is a deterministic step
+// the lint admits — without it, no tools-declaring plan could freeze. The
+// parsed fixture also proves the acceptance end-to-end through
+// manifest.Parse.
+func TestLint_AcceptsCleanToolStep(t *testing.T) {
+	m, err := manifest.Parse([]byte(toolStepsMD))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := Lint(m); err != nil {
+		t.Errorf("clean tool steps must lint clean: %v", err)
+	}
+}
+
+// TestLint_RejectsLLMMarkerOnToolStep proves the LLM-marker check applies to
+// the tool kind automatically: a tool step is deterministic by construction
+// and must never smuggle an LLM call.
+func TestLint_RejectsLLMMarkerOnToolStep(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "sneaky", "kind": "tool", "command": []any{"aws"}, "prompt": "summarize"},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("a tool step carrying an LLM marker must fail lint")
+	}
+	if !strings.Contains(err.Error(), "sneaky") || !strings.Contains(err.Error(), "prompt") {
+		t.Errorf("error should name the step and the marker, got: %v", err)
+	}
+}
+
 func TestLint_NilManifestClean(t *testing.T) {
 	if err := Lint(nil); err != nil {
 		t.Errorf("Lint(nil) must be clean: %v", err)

--- a/internal/flightplan/freeze/lock.go
+++ b/internal/flightplan/freeze/lock.go
@@ -8,29 +8,29 @@ import (
 )
 
 // ImagePin pairs a pre-freeze image reference with the content-addressed
-// digest freeze resolved it to. It mirrors the schema
-// `$defs.lock.resolvedImages[]` item exactly.
-//
-// StepID links a rung-3 per-step pin to the step that dispatches to it, so the
-// runtime associates a step to its pin by id rather than by the mutable image
-// tag (which two steps may share). It is empty for rung-1/rung-2 pins, which
-// boot a single whole-plan image and carry no step linkage; `omitempty` keeps
-// those pins' lock bytes byte-identical to the pre-StepID format.
+// digest freeze resolved it to. The schema `$defs.lock.resolvedImages[]` item
+// admits exactly {ref, digest}: the plan runs in one container, so freeze
+// emits at most one pin and no per-pin step linkage.
 type ImagePin struct {
 	Ref    string `yaml:"ref" json:"ref"`
 	Digest string `yaml:"digest" json:"digest"`
-	// StepID is the rung-3 declaring step's id (its declared `id`, or a
-	// positional index like "#0" when the step declares none). Empty for
-	// rung-1/rung-2 pins.
+	// StepID is DORMANT: the schema no longer admits a per-pin `id`, so
+	// freeze never emits it. It is retained only so the not-yet-rewritten
+	// runtime tool-dispatch decode (#1829) keeps compiling with its
+	// direct-construct tests; it is slated for deletion with that rewire.
 	StepID string `yaml:"id,omitempty" json:"id,omitempty"`
-	// Hosts is the network reach freeze sealed from the rung-3 step's declared
-	// trust contract (its `hosts`). Freeze stamps it here so the content hash
-	// and signature cover it: a resolved, signed assertion of the step's reach
-	// that cannot be re-supplied at launch. It is the single canonical signed
-	// source #1769 stamps onto the launch host allow-list. `omitempty` keeps
-	// rung-1/rung-2 pins and rung-3 pins with no declared contract byte-identical
-	// to the pre-reach lock format.
+	// Hosts is DORMANT: the per-pin sealed reach moved to the step-keyed
+	// `lock.stepTrust` section (see Lockfile.StepTrust), so freeze never
+	// emits it. Retained only for the #1829 runtime rewire, same as StepID.
 	Hosts []string `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+}
+
+// StepReach is the sealed network reach for one tool step: the `hosts` from
+// its declared trust contract, resolved at freeze time. It mirrors a schema
+// `$defs.lock.stepTrust` entry exactly. Hosts only: the full contract stays
+// in the signed frontmatter bytes.
+type StepReach struct {
+	Hosts []string `yaml:"hosts" json:"hosts"`
 }
 
 // Lockfile is the resolved lock-and-digest record freeze produces. Its
@@ -41,8 +41,17 @@ type Lockfile struct {
 	// ResolvedImages are the resolved image digest pins. Empty for an
 	// instruction-only or no-execution-environment skill.
 	ResolvedImages []ImagePin `yaml:"resolvedImages,omitempty" json:"resolvedImages,omitempty"`
-	// ResolvedCapabilitySet is the capability set freeze pinned (rung-2).
+	// ResolvedCapabilitySet is the capability set freeze pinned: the declared
+	// environment tools, verbatim. Empty when no tools are declared.
 	ResolvedCapabilitySet []string `yaml:"resolvedCapabilitySet,omitempty" json:"resolvedCapabilitySet,omitempty"`
+	// StepTrust is the step-keyed sealed trust section: for each tool step
+	// that declares a trust contract, the resolved network reach freeze
+	// sealed from it, keyed by step id. Covered by the content hash and
+	// signature, so the reach cannot be re-supplied at launch. Nil when no
+	// tool step declares a contract (omitempty keeps those locks
+	// byte-identical to the pre-stepTrust format). yaml.v3 marshals map keys
+	// sorted, so the emitted section is byte-deterministic across freezes.
+	StepTrust map[string]StepReach `yaml:"stepTrust,omitempty" json:"stepTrust,omitempty"`
 	// ContentHash identifies the exact frozen manifest bytes
 	// (`sha256:<hex>`). It is computed last and excluded from the bytes it
 	// hashes, so a Lockfile passed to the content hasher must have it empty.

--- a/internal/flightplan/freeze/lock_test.go
+++ b/internal/flightplan/freeze/lock_test.go
@@ -14,9 +14,13 @@ func sampleLock() Lockfile {
 		ResolvedImages: []ImagePin{
 			{Ref: "registry.example.com/runner:1.4", Digest: fakeDigest},
 		},
-		ResolvedCapabilitySet: []string{"ghcr.io/example/feature:1"},
-		ContentHash:           fakeDigest2,
-		Version:               "1.2.3",
+		ResolvedCapabilitySet: []string{"aws-cli@2.x"},
+		StepTrust: map[string]StepReach{
+			"fetch": {Hosts: []string{"s3.amazonaws.com"}},
+			"file":  {Hosts: []string{"tracker.example.com", "tracker.example.com:443"}},
+		},
+		ContentHash: fakeDigest2,
+		Version:     "1.2.3",
 	}
 }
 
@@ -43,10 +47,40 @@ func TestMarshalLockfile_UsesSchemaFieldNames(t *testing.T) {
 		t.Fatalf("MarshalLockfile: %v", err)
 	}
 	s := string(b)
-	for _, key := range []string{"resolvedImages:", "resolvedCapabilitySet:", "contentHash:", "version:", "ref:", "digest:"} {
+	for _, key := range []string{"resolvedImages:", "resolvedCapabilitySet:", "stepTrust:", "contentHash:", "version:", "ref:", "digest:", "hosts:"} {
 		if !strings.Contains(s, key) {
 			t.Errorf("lockfile missing schema field %q:\n%s", key, s)
 		}
+	}
+}
+
+// TestMarshalLockfile_StepTrustDeterministic proves the step-keyed map
+// marshals byte-identically regardless of insertion order: yaml.v3 sorts map
+// keys, and the freeze determinism contract (two freezes of the same input
+// produce byte-identical lockfiles) rides on it.
+func TestMarshalLockfile_StepTrustDeterministic(t *testing.T) {
+	ab := Lockfile{StepTrust: map[string]StepReach{}}
+	ab.StepTrust["alpha"] = StepReach{Hosts: []string{"a.example.com"}}
+	ab.StepTrust["beta"] = StepReach{Hosts: []string{"b.example.com"}}
+	ba := Lockfile{StepTrust: map[string]StepReach{}}
+	ba.StepTrust["beta"] = StepReach{Hosts: []string{"b.example.com"}}
+	ba.StepTrust["alpha"] = StepReach{Hosts: []string{"a.example.com"}}
+
+	first, err := MarshalLockfile(ab)
+	if err != nil {
+		t.Fatalf("marshal ab: %v", err)
+	}
+	second, err := MarshalLockfile(ba)
+	if err != nil {
+		t.Fatalf("marshal ba: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("stepTrust marshal is insertion-order dependent:\n%s\nvs\n%s", first, second)
+	}
+	idxAlpha := strings.Index(string(first), "alpha:")
+	idxBeta := strings.Index(string(first), "beta:")
+	if idxAlpha < 0 || idxBeta < 0 || idxAlpha > idxBeta {
+		t.Errorf("stepTrust keys must emit sorted:\n%s", first)
 	}
 }
 

--- a/internal/flightplan/freeze/steptrust.go
+++ b/internal/flightplan/freeze/steptrust.go
@@ -1,0 +1,96 @@
+package freeze
+
+import (
+	"fmt"
+	"strings"
+)
+
+// sealStepTrust walks the manifest's step graph and seals each tool step's
+// declared trust-contract reach into the step-keyed lock section
+// (`lock.stepTrust`). Hosts only: the full contract stays in the signed
+// frontmatter bytes; this section is the resolved reach launch/runtime
+// consume, covered by the content hash and signature so it cannot be
+// re-supplied at launch.
+//
+// Selection is fail-closed:
+//
+//   - only `kind: tool` steps participate; a tool step with no declared
+//     trustContract is omitted (it declares no reach);
+//   - a declared trustContract that is not a mapping, or whose hosts are
+//     missing, empty, or carry a non-string/empty entry, is a hard error —
+//     never a partial seal (the schema rejects these shapes before freeze
+//     runs; this is the freeze-time defensive backstop);
+//   - a contracted tool step with a missing/empty id, or two contracted tool
+//     steps sharing an id, is a hard error: the id is the lock key the
+//     runtime dispatches on, so an ambiguous key must never be sealed.
+//
+// An empty result returns nil so the lock section is omitted entirely
+// (omitempty) and a no-tool-steps plan's lock bytes are unchanged.
+func sealStepTrust(steps []any) (map[string]StepReach, error) {
+	var out map[string]StepReach
+	for i, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			// Lint (which runs before sealing) already rejects non-mapping
+			// steps; keep the backstop for direct constructs.
+			return nil, fmt.Errorf("freeze: step %d is not a mapping", i)
+		}
+		if kind, _ := step["kind"].(string); kind != "tool" {
+			continue
+		}
+		hosts, declared, err := toolStepHosts(step, i)
+		if err != nil {
+			return nil, err
+		}
+		if !declared {
+			continue
+		}
+		id, _ := step["id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, fmt.Errorf("freeze: tool step %d declares a trustContract but no id (the id keys the sealed reach)", i)
+		}
+		if _, dup := out[id]; dup {
+			return nil, fmt.Errorf("freeze: duplicate tool step id %q (each sealed reach needs a unique key)", id)
+		}
+		if out == nil {
+			out = make(map[string]StepReach)
+		}
+		out[id] = StepReach{Hosts: hosts}
+	}
+	return out, nil
+}
+
+// toolStepHosts extracts the declared trust-contract hosts from a tool step's
+// untyped map. declared is false when the step carries no trustContract (an
+// optional block: absent means the step declares no reach). A declared
+// trustContract whose hosts are missing, empty, or carry a non-string/empty
+// entry is rejected rather than sealing a partial reach, so a malformed reach
+// never silently produces a wrong seal.
+func toolStepHosts(step map[string]any, index int) (hosts []string, declared bool, err error) {
+	raw, ok := step["trustContract"]
+	if !ok || raw == nil {
+		return nil, false, nil
+	}
+	tc, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("freeze: tool step %d has a trustContract that is not a mapping", index)
+	}
+	hostsRaw, ok := tc["hosts"]
+	if !ok || hostsRaw == nil {
+		return nil, false, fmt.Errorf("freeze: tool step %d declares a trustContract with no hosts (access scope is the boundary)", index)
+	}
+	list, ok := hostsRaw.([]any)
+	if !ok || len(list) == 0 {
+		return nil, false, fmt.Errorf("freeze: tool step %d declares a trustContract with an empty or non-array hosts", index)
+	}
+	hosts = make([]string, 0, len(list))
+	for _, h := range list {
+		s, ok := h.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			return nil, false, fmt.Errorf("freeze: tool step %d declares a trustContract host that is empty or not a string", index)
+		}
+		hosts = append(hosts, strings.TrimSpace(s))
+	}
+	return hosts, true, nil
+}

--- a/internal/flightplan/freeze/steptrust_test.go
+++ b/internal/flightplan/freeze/steptrust_test.go
@@ -1,0 +1,135 @@
+package freeze
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSealStepTrust_SealsContractedToolSteps proves the selection contract
+// over the parsed fixture: each tool step with a declared trust contract gets
+// an entry keyed by its id carrying exactly its declared hosts, and a tool
+// step with no contract is omitted.
+func TestSealStepTrust_SealsContractedToolSteps(t *testing.T) {
+	m := parseM(t, []byte(toolStepsMD))
+	got, err := sealStepTrust(m.Aileron.Steps)
+	if err != nil {
+		t.Fatalf("sealStepTrust: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("stepTrust = %+v, want exactly the two contracted steps", got)
+	}
+	if strings.Join(got["fetch"].Hosts, ",") != "s3.amazonaws.com,s3.amazonaws.com:443" {
+		t.Errorf("fetch reach = %v", got["fetch"].Hosts)
+	}
+	if strings.Join(got["file"].Hosts, ",") != "api.github.com" {
+		t.Errorf("file reach = %v", got["file"].Hosts)
+	}
+	if _, ok := got["version"]; ok {
+		t.Error("a tool step with no trust contract must be omitted from stepTrust")
+	}
+}
+
+// TestSealStepTrust_NonToolStepsIgnored proves only tool steps participate:
+// an action-call carrying a trustContract-shaped key is not sealed (its reach
+// lives in requires.actions, not the step-keyed section).
+func TestSealStepTrust_NonToolStepsIgnored(t *testing.T) {
+	steps := []any{
+		map[string]any{"id": "call", "kind": "action-call", "actionRef": "aileron:x.y",
+			"trustContract": map[string]any{"hosts": []any{"api.example.com"}}},
+		map[string]any{"id": "reshape", "kind": "transform", "outputs": []any{"out"}},
+	}
+	got, err := sealStepTrust(steps)
+	if err != nil {
+		t.Fatalf("sealStepTrust: %v", err)
+	}
+	if got != nil {
+		t.Errorf("non-tool steps must seal nothing, got %+v", got)
+	}
+}
+
+// TestSealStepTrust_EmptyResultIsNil proves a plan with no contracted tool
+// steps yields nil, so the marshaled lock omits the section entirely
+// (byte-stability with the pre-stepTrust format).
+func TestSealStepTrust_EmptyResultIsNil(t *testing.T) {
+	got, err := sealStepTrust(nil)
+	if err != nil {
+		t.Fatalf("sealStepTrust(nil): %v", err)
+	}
+	if got != nil {
+		t.Errorf("no steps must seal nil, got %+v", got)
+	}
+	lf, err := MarshalLockfile(Lockfile{StepTrust: got})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(lf), "stepTrust") {
+		t.Errorf("an empty stepTrust must be omitted from the lock, got:\n%s", lf)
+	}
+}
+
+// TestSealStepTrust_MalformedRefused enumerates the fail-closed guards: a
+// malformed declared reach is a hard error, never a partial seal. These
+// shapes are schema-rejected on any parsed manifest; sealStepTrust is the
+// freeze-time defensive backstop for direct constructs.
+func TestSealStepTrust_MalformedRefused(t *testing.T) {
+	toolStep := func(overrides map[string]any) map[string]any {
+		s := map[string]any{"id": "fetch", "kind": "tool", "command": []any{"aws"}}
+		for k, v := range overrides {
+			s[k] = v
+		}
+		return s
+	}
+	cases := map[string][]any{
+		"non-mapping step": {"scalar"},
+		"trustContract not a mapping": {
+			toolStep(map[string]any{"trustContract": "scalar"}),
+		},
+		"trustContract with no hosts": {
+			toolStep(map[string]any{"trustContract": map[string]any{"effect": "read"}}),
+		},
+		"empty hosts": {
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": []any{}}}),
+		},
+		"non-array hosts": {
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": "api.example.com"}}),
+		},
+		"non-string host": {
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": []any{42}}}),
+		},
+		"empty host entry": {
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": []any{" "}}}),
+		},
+		"contracted step with no id": {
+			map[string]any{"kind": "tool", "command": []any{"aws"},
+				"trustContract": map[string]any{"hosts": []any{"api.example.com"}}},
+		},
+		"duplicate contracted step id": {
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": []any{"a.example.com"}}}),
+			toolStep(map[string]any{"trustContract": map[string]any{"hosts": []any{"b.example.com"}}}),
+		},
+	}
+	for name, steps := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := sealStepTrust(steps); err == nil {
+				t.Errorf("%s must be refused", name)
+			}
+		})
+	}
+}
+
+// TestSealStepTrust_TrimsHosts proves declared hosts are trimmed exactly like
+// the rest of freeze's string extraction, so a stray-whitespace host never
+// seals a reach the runtime cannot match.
+func TestSealStepTrust_TrimsHosts(t *testing.T) {
+	steps := []any{
+		map[string]any{"id": "fetch", "kind": "tool", "command": []any{"aws"},
+			"trustContract": map[string]any{"hosts": []any{"  api.example.com "}}},
+	}
+	got, err := sealStepTrust(steps)
+	if err != nil {
+		t.Fatalf("sealStepTrust: %v", err)
+	}
+	if strings.Join(got["fetch"].Hosts, ",") != "api.example.com" {
+		t.Errorf("hosts must be trimmed, got %v", got["fetch"].Hosts)
+	}
+}

--- a/internal/flightplan/freeze/testdata_test.go
+++ b/internal/flightplan/freeze/testdata_test.go
@@ -112,6 +112,86 @@ aileron:
 # No Environment
 `
 
+// toolStepsMD is a valid manifest declaring environment tools and three tool
+// steps: two with a trust contract (declared reach freeze seals into
+// lock.stepTrust) and one without (omitted from the sealed section).
+const toolStepsMD = `---
+name: tool-steps-skill
+description: A skill running declared environment tools with sealed reach.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  environment:
+    tools:
+      - aws-cli@2.x
+      - gh@2
+  inputs: []
+  outputs: []
+  steps:
+    - id: fetch
+      kind: tool
+      command:
+        - aws
+        - s3
+        - ls
+      outputs:
+        - listing
+      trustContract:
+        credential:
+          kind: none
+        hosts:
+          - s3.amazonaws.com
+          - s3.amazonaws.com:443
+        effect: read
+        idempotency:
+          safeToRetry: true
+        audit:
+          fields:
+            - result
+    - id: version
+      kind: tool
+      command:
+        - aws
+        - --version
+      outputs:
+        - version
+    - id: file
+      kind: tool
+      command:
+        - gh
+        - issue
+        - create
+      outputs:
+        - issue
+      trustContract:
+        credential:
+          kind: none
+        hosts:
+          - api.github.com
+        effect: write
+        idempotency:
+          safeToRetry: false
+        audit:
+          fields:
+            - result
+---
+
+# Tool Steps Skill
+`
+
 // genSigningKey returns a fresh ed25519 private key and writes its PKCS#8
 // PEM form to a temp file, returning the path. Mirrors the keyring PEM
 // conventions; used to exercise LoadSigningKey + Sign.

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -611,12 +611,12 @@
     },
     "lock": {
       "type": "object",
-      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved image digests and the resolved capability set, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
+      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved environment image digest, records the resolved capability set and the step-keyed sealed trust reach, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
       "additionalProperties": false,
       "properties": {
         "resolvedImages": {
           "type": "array",
-          "description": "The resolved image digest pins. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest.",
+          "description": "The resolved image digest pins. The plan runs in one container, so a plan with a declared environment pins exactly one image: the digest-resolved custom base, or the image composed from the runtime base plus the declared tools. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest and carries no per-step linkage; the step-keyed sealed reach lives in the sibling stepTrust section.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -627,20 +627,6 @@
                 "type": "string",
                 "description": "The resolved content-addressed digest.",
                 "pattern": "^sha256:[a-f0-9]{64}$"
-              },
-              "id": {
-                "type": "string",
-                "description": "For a per-step pin, the id of the step that dispatches to this image (its declared `id`, or a positional fallback). Links the pin to its step so association does not key on the mutable image reference. Absent for whole-plan environment pins, which boot a single image with no per-step linkage.",
-                "minLength": 1
-              },
-              "hosts": {
-                "type": "array",
-                "description": "For a per-step pin, the network reach freeze sealed from the step's declared trust contract. Each entry is a host with an optional port, no scheme, no path, reusing the trustContract `hosts` vocabulary. Freeze stamps the declared reach here so it is covered by the content hash and signature: a resolved, signed assertion of the step's reach that cannot be re-supplied at launch. Absent for whole-plan environment pins and for a step that declares no trust contract.",
-                "items": {
-                  "type": "string",
-                  "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
-                  "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
-                }
               }
             }
           }
@@ -649,6 +635,30 @@
           "type": "array",
           "description": "The resolved capability set the freeze pinned.",
           "items": { "type": "string", "minLength": 1 }
+        },
+        "stepTrust": {
+          "type": "object",
+          "description": "The step-keyed sealed trust section. Keyed by tool-step id; each entry carries the network reach freeze sealed from that step's declared trust contract. Hosts only: the full contract stays in the signed frontmatter, and this section is the resolved reach launch and runtime consume. Freeze stamps it here so the reach is covered by the content hash and signature and cannot be re-supplied at launch. A tool step that declares no trust contract has no entry.",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["hosts"],
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "description": "The sealed network reach from the step's declared trust contract. Each entry is a host with an optional port, no scheme, no path, reusing the trustContract `hosts` vocabulary.",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
+                  "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
+                }
+              }
+            }
+          }
         },
         "contentHash": {
           "type": "string",

--- a/internal/flightplan/manifest/manifest.go
+++ b/internal/flightplan/manifest/manifest.go
@@ -73,10 +73,10 @@ type Requires struct {
 
 	// ExecutionEnvironment is DORMANT: the schema no longer admits a
 	// `requires.executionEnvironment` key, so Parse can never populate this
-	// field. It is retained only so the not-yet-rewritten freeze rung
-	// branches (#1827) and runtime tool-dispatch decode (#1829) keep
-	// compiling with their direct-construct tests until their owners delete
-	// them. It is slated for deletion with its last consumer.
+	// field. It is retained only so the not-yet-rewritten runtime
+	// tool-dispatch decode (#1829, its sole remaining consumer) keeps
+	// compiling until that owner deletes it. It is slated for deletion with
+	// that consumer.
 	ExecutionEnvironment map[string]any `yaml:"executionEnvironment"`
 }
 

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -115,14 +115,12 @@ func TestStrippedTopLevelStillValid(t *testing.T) {
 	}
 }
 
-// TestLockResolvedImagesID locks the per-step pin association substrate at the
-// schema boundary: a lock whose resolvedImages[] item carries the optional
-// `id` is valid (the step→pin link), a lock item with only ref+digest stays
-// valid (whole-plan environment pins carry no id), and an unknown key on the
-// item is still rejected (additionalProperties:false is preserved).
-func TestLockResolvedImagesID(t *testing.T) {
-	lockFrontmatter := func(item string) []byte {
-		return []byte(`name: s
+// lockFrontmatter wraps a lock block body into a complete, otherwise-valid
+// aileron frontmatter so a test exercises only the lock validity rules.
+// lockBlock is the YAML for the lock value's keys, indented to sit under
+// `lock:` (4 spaces for its keys).
+func lockFrontmatter(lockBlock string) []byte {
+	return []byte(`name: s
 description: d
 aileron:
   schemaVersion: aileron.flightplan.v1
@@ -143,86 +141,111 @@ aileron:
   inputs: []
   outputs: []
   lock:
-    resolvedImages:
-` + item + `
+` + lockBlock + `
 `)
-	}
-	const digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
 
-	t.Run("valid/with id", func(t *testing.T) {
-		item := "      - ref: registry.example.com/tool-a:1\n        digest: " + digest + "\n        id: extract"
-		if err := validateFrontmatter(lockFrontmatter(item)); err != nil {
-			t.Fatalf("a resolvedImages item with id must validate, got: %v", err)
+const lockTestDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// TestLockResolvedImagesSinglePinShape locks the one-pin model at the schema
+// boundary (#1827): a resolvedImages item is exactly {ref, digest}. The
+// retired per-pin `id` and `hosts` keys (the rung-3 stepId-on-pin linkage) are
+// rejected outright; the step-keyed sealed reach lives in the sibling
+// stepTrust section instead.
+func TestLockResolvedImagesSinglePinShape(t *testing.T) {
+	item := func(extra string) string {
+		return "    resolvedImages:\n      - ref: registry.example.com/runner:1.4\n        digest: " + lockTestDigest + extra
+	}
+
+	t.Run("valid/ref and digest only", func(t *testing.T) {
+		if err := validateFrontmatter(lockFrontmatter(item(""))); err != nil {
+			t.Fatalf("a ref+digest pin must validate, got: %v", err)
 		}
 	})
-	t.Run("valid/without id", func(t *testing.T) {
-		item := "      - ref: registry.example.com/runner:1.4\n        digest: " + digest
-		if err := validateFrontmatter(lockFrontmatter(item)); err != nil {
-			t.Fatalf("a resolvedImages item without id must validate, got: %v", err)
+	t.Run("invalid/per-pin id rejected", func(t *testing.T) {
+		if err := validateFrontmatter(lockFrontmatter(item("\n        id: extract"))); err == nil {
+			t.Fatal("the retired per-pin id key must be rejected")
+		}
+	})
+	t.Run("invalid/per-pin hosts rejected", func(t *testing.T) {
+		if err := validateFrontmatter(lockFrontmatter(item("\n        hosts:\n          - api.example.com"))); err == nil {
+			t.Fatal("the retired per-pin hosts key must be rejected")
 		}
 	})
 	t.Run("invalid/unknown key", func(t *testing.T) {
-		item := "      - ref: registry.example.com/tool-a:1\n        digest: " + digest + "\n        stepId: extract"
-		if err := validateFrontmatter(lockFrontmatter(item)); err == nil {
+		if err := validateFrontmatter(lockFrontmatter(item("\n        stepId: extract"))); err == nil {
 			t.Fatal("an unknown key on a resolvedImages item must be rejected")
-		}
-	})
-	t.Run("invalid/empty id", func(t *testing.T) {
-		item := "      - ref: registry.example.com/tool-a:1\n        digest: " + digest + "\n        id: \"\""
-		if err := validateFrontmatter(lockFrontmatter(item)); err == nil {
-			t.Fatal("an empty id (minLength:1) must be rejected")
 		}
 	})
 }
 
-// TestLockResolvedImagesHosts locks the per-pin sealed reach at the schema
-// boundary: a lock resolvedImages[] item may carry the optional `hosts` array
-// (freeze's sealed reach), a malformed host (a scheme-prefixed entry) is
-// rejected by the host pattern, and the item stays
-// additionalProperties:false.
-func TestLockResolvedImagesHosts(t *testing.T) {
-	lockFrontmatter := func(item string) []byte {
-		return []byte(`name: s
-description: d
-aileron:
-  schemaVersion: aileron.flightplan.v1
-  requires:
-    actions:
-      - ref: aileron:metrics.query_series
-        trustContract:
-          credential:
-            kind: none
-          hosts:
-            - api.example.com
-          effect: read
-          idempotency:
-            safeToRetry: true
-          audit:
-            fields:
-              - result
-  inputs: []
-  outputs: []
-  lock:
-    resolvedImages:
-` + item + `
-`)
+// TestLockStepTrust locks the step-keyed sealed trust section at the schema
+// boundary (#1827): stepTrust is keyed by tool-step id, each entry requires a
+// non-empty hosts array using the trust-contract host pattern, and the entry
+// object is closed.
+func TestLockStepTrust(t *testing.T) {
+	valid := map[string]string{
+		"single step": `    stepTrust:
+      fetch:
+        hosts:
+          - s3.amazonaws.com`,
+		"multiple steps with ports": `    stepTrust:
+      fetch:
+        hosts:
+          - s3.amazonaws.com
+          - s3.amazonaws.com:443
+      file:
+        hosts:
+          - tracker.example.com`,
+		"alongside a pin": `    resolvedImages:
+      - ref: registry.example.com/runner:1.4
+        digest: ` + lockTestDigest + `
+    stepTrust:
+      fetch:
+        hosts:
+          - api.example.com`,
 	}
-	const digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	for name, lock := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := validateFrontmatter(lockFrontmatter(lock)); err != nil {
+				t.Fatalf("expected valid, got: %v", err)
+			}
+		})
+	}
 
-	t.Run("valid/with hosts", func(t *testing.T) {
-		item := "      - ref: registry.example.com/tool-a:1\n        digest: " + digest +
-			"\n        id: reach\n        hosts:\n          - api.example.com\n          - api.example.com:443"
-		if err := validateFrontmatter(lockFrontmatter(item)); err != nil {
-			t.Fatalf("a resolvedImages item with hosts must validate, got: %v", err)
-		}
-	})
-	t.Run("invalid/scheme-prefixed host", func(t *testing.T) {
-		item := "      - ref: registry.example.com/tool-a:1\n        digest: " + digest +
-			"\n        hosts:\n          - https://api.example.com"
-		if err := validateFrontmatter(lockFrontmatter(item)); err == nil {
-			t.Fatal("a scheme-prefixed host must be rejected by the host pattern")
-		}
-	})
+	invalid := map[string]string{
+		"empty hosts": `    stepTrust:
+      fetch:
+        hosts: []`,
+		"missing hosts": `    stepTrust:
+      fetch: {}`,
+		"scheme-prefixed host": `    stepTrust:
+      fetch:
+        hosts:
+          - https://api.example.com`,
+		"unknown key on entry": `    stepTrust:
+      fetch:
+        hosts:
+          - api.example.com
+        effect: read`,
+		"non-object entry": `    stepTrust:
+      fetch: s3.amazonaws.com`,
+		"key not a step id": `    stepTrust:
+      "not a step id":
+        hosts:
+          - api.example.com`,
+	}
+	for name, lock := range invalid {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			err := validateFrontmatter(lockFrontmatter(lock))
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "schema validation") {
+				t.Errorf("error should cite schema validation, got: %v", err)
+			}
+		})
+	}
 }
 
 // environmentFrontmatter wraps an `environment` block body into a complete,

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -42,7 +42,10 @@ func frozenExample(t *testing.T) store.FrozenVersion {
 	res, err := freeze.Run(context.Background(), raw, freeze.Options{
 		Version:        "1.0.0",
 		SigningKeyPath: keyPath,
-		Composer: freeze.FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+		Resolver: freeze.DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+			return "sha256:" + strings.Repeat("b", 64), nil
+		}),
+		Composer: freeze.FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
 			return "sha256:" + strings.Repeat("a", 64), nil
 		}),
 	})

--- a/internal/sandbox/composition/tools.go
+++ b/internal/sandbox/composition/tools.go
@@ -1,0 +1,126 @@
+package composition
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// curatedTools is the closed set of curated-catalog tool names an
+// `environment.tools` entry may reference. It mirrors the manifest schema's
+// closed tool-name pattern (`^(aws-cli|gh)@...` in
+// docs/schema/flight-plan-manifest.schema.json) and the Feature recipes
+// authored under images/sandbox-features/<name>/. Adding a catalog tool means
+// adding its Feature recipe, widening the schema pattern, and adding it here.
+var curatedTools = map[string]bool{
+	"aws-cli": true,
+	"gh":      true,
+}
+
+// ResolveToolFeatureRef resolves a declared environment tool reference
+// (`<name>@<version>`, for example "aws-cli@2.x") to the published
+// devcontainer Feature reference for its curated-catalog recipe (see
+// FeatureReference). The name vocabulary is closed to the curated catalog; an
+// unknown name or a malformed reference is rejected. The version constraint
+// is validated for shape only: the v1 catalog carries one recipe per tool, so
+// reproducibility comes from the composed image's digest pin, not from
+// resolving the version to a distinct Feature tag.
+func ResolveToolFeatureRef(ref string) (string, error) {
+	i := strings.LastIndex(ref, "@")
+	if i < 0 {
+		return "", fmt.Errorf("tool reference %q is not <name>@<version>", ref)
+	}
+	name, version := ref[:i], ref[i+1:]
+	if name == "" || version == "" {
+		return "", fmt.Errorf("tool reference %q is not <name>@<version> (both parts must be non-empty)", ref)
+	}
+	if !curatedTools[name] {
+		return "", fmt.Errorf("tool %q is not in the curated catalog (known tools: %s)", name, strings.Join(curatedToolNames(), ", "))
+	}
+	return FeatureReference(name), nil
+}
+
+// curatedToolNames returns the curated tool names sorted for stable error
+// messages.
+func curatedToolNames() []string {
+	names := make([]string, 0, len(curatedTools))
+	for name := range curatedTools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ToolsPlan returns the composition Plan that composes the given devcontainer
+// Feature references onto base (an image reference, typically digest-pinned
+// by the caller so the compose input cannot drift). The plan mirrors the
+// synthesized local agent build (#1451): TierDevcontainer with a synthesized
+// devcontainer.json materialized into a managed temp workspace folder by the
+// container builder, never written into the user's workDir. Image is a
+// deterministic local-daemon tag derived from base plus the sorted Feature
+// set, so identical compositions share a tag and distinct ones never collide.
+func ToolsPlan(base string, featureRefs []string) Plan {
+	sorted := sortedRefs(featureRefs)
+	features := make(map[string]json.RawMessage, len(sorted))
+	for _, ref := range sorted {
+		features[ref] = json.RawMessage("{}")
+	}
+	return Plan{
+		Tier:                    TierDevcontainer,
+		BaseImage:               base,
+		Image:                   LocalToolsImageTag(base, sorted),
+		Features:                features,
+		SynthesizedDevcontainer: synthesizedToolsDevcontainer(base, sorted),
+	}
+}
+
+// LocalToolsImageTag returns the local-only image tag for an image composed
+// from base plus the given Feature references. The tag is deterministic per
+// (base, sorted Feature set): a short content hash keys it, so the `auto`
+// build policy can skip a rebuild for an identical composition while distinct
+// compositions get distinct tags. The "aileron/" prefix (no registry host)
+// keeps it a local-daemon tag, mirroring LocalAgentImageTag's convention; it
+// is never pushed to a registry.
+func LocalToolsImageTag(base string, featureRefs []string) string {
+	sorted := sortedRefs(featureRefs)
+	h := sha256.New()
+	h.Write([]byte(base))
+	for _, ref := range sorted {
+		h.Write([]byte{0})
+		h.Write([]byte(ref))
+	}
+	return "aileron/sandbox-tools:" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// sortedRefs returns a sorted copy of refs so plan content and tags are
+// deterministic regardless of declaration order.
+func sortedRefs(refs []string) []string {
+	sorted := append([]string(nil), refs...)
+	sort.Strings(sorted)
+	return sorted
+}
+
+// synthesizedToolsDevcontainer renders the devcontainer.json that composes
+// the given Feature references onto base. It is the multi-Feature sibling of
+// synthesizedAgentDevcontainer: a build-only artifact with no customizations
+// block, materialized into a managed temp workspace folder by the container
+// builder (#1451). Feature order is the caller's (sorted) order, so the
+// rendered bytes are deterministic for a given composition.
+func synthesizedToolsDevcontainer(base string, sortedFeatureRefs []string) string {
+	var sb strings.Builder
+	sb.WriteString("{\n  \"name\": \"Aileron sandbox\",\n")
+	fmt.Fprintf(&sb, "  \"image\": %q,\n", base)
+	sb.WriteString("  \"features\": {\n")
+	for i, ref := range sortedFeatureRefs {
+		sep := ","
+		if i == len(sortedFeatureRefs)-1 {
+			sep = ""
+		}
+		fmt.Fprintf(&sb, "    %q: {}%s\n", ref, sep)
+	}
+	sb.WriteString("  }\n}\n")
+	return sb.String()
+}

--- a/internal/sandbox/composition/tools_test.go
+++ b/internal/sandbox/composition/tools_test.go
@@ -1,0 +1,131 @@
+package composition
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestResolveToolFeatureRef_CuratedTools proves every curated-catalog tool
+// resolves to its published Feature reference, whatever (loose) version
+// constraint the manifest declares.
+func TestResolveToolFeatureRef_CuratedTools(t *testing.T) {
+	cases := map[string]string{
+		"aws-cli@2.x": "ghcr.io/alrubinger/aileron-features/aws-cli:0",
+		"aws-cli@2":   "ghcr.io/alrubinger/aileron-features/aws-cli:0",
+		"gh@2.19.1":   "ghcr.io/alrubinger/aileron-features/gh:0",
+		"gh@2":        "ghcr.io/alrubinger/aileron-features/gh:0",
+	}
+	for ref, want := range cases {
+		got, err := ResolveToolFeatureRef(ref)
+		if err != nil {
+			t.Errorf("ResolveToolFeatureRef(%q): %v", ref, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ResolveToolFeatureRef(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
+// TestResolveToolFeatureRef_UnknownToolRejected proves the name vocabulary is
+// closed to the curated catalog: an unknown tool name is rejected with an
+// error naming the known tools.
+func TestResolveToolFeatureRef_UnknownToolRejected(t *testing.T) {
+	_, err := ResolveToolFeatureRef("nmap@7.1")
+	if err == nil {
+		t.Fatal("an unknown tool name must be rejected")
+	}
+	if !strings.Contains(err.Error(), "curated catalog") {
+		t.Errorf("error should cite the curated catalog, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "aws-cli") || !strings.Contains(err.Error(), "gh") {
+		t.Errorf("error should name the known tools, got: %v", err)
+	}
+}
+
+// TestResolveToolFeatureRef_MalformedRejected proves the <name>@<version>
+// shape is enforced: a missing separator, empty name, or empty version is a
+// hard error rather than a coerced lookup.
+func TestResolveToolFeatureRef_MalformedRejected(t *testing.T) {
+	for _, ref := range []string{"", "aws-cli", "@2.x", "aws-cli@", "@"} {
+		if _, err := ResolveToolFeatureRef(ref); err == nil {
+			t.Errorf("malformed tool reference %q must be rejected", ref)
+		}
+	}
+}
+
+// TestToolsPlan_SynthesizesDevcontainer proves the plan the composer builds
+// from: TierDevcontainer, the Features map keyed by the given references, and
+// a synthesized devcontainer.json (valid JSON) whose image is the base and
+// whose features are exactly the given references.
+func TestToolsPlan_SynthesizesDevcontainer(t *testing.T) {
+	base := "ghcr.io/alrubinger/aileron-sandbox-base:latest@sha256:" + strings.Repeat("a", 64)
+	refs := []string{
+		"ghcr.io/alrubinger/aileron-features/gh:0",
+		"ghcr.io/alrubinger/aileron-features/aws-cli:0",
+	}
+	plan := ToolsPlan(base, refs)
+	if plan.Tier != TierDevcontainer {
+		t.Errorf("Tier = %q, want %q", plan.Tier, TierDevcontainer)
+	}
+	if plan.BaseImage != base {
+		t.Errorf("BaseImage = %q, want %q", plan.BaseImage, base)
+	}
+	if len(plan.Features) != 2 {
+		t.Fatalf("Features = %v, want both references", plan.Features)
+	}
+	for _, ref := range refs {
+		if string(plan.Features[ref]) != "{}" {
+			t.Errorf("Features[%q] = %q, want {}", ref, plan.Features[ref])
+		}
+	}
+	if plan.SynthesizedDevcontainer == "" {
+		t.Fatal("SynthesizedDevcontainer must be set (no .devcontainer on disk)")
+	}
+	var cfg struct {
+		Image    string                     `json:"image"`
+		Features map[string]json.RawMessage `json:"features"`
+	}
+	if err := json.Unmarshal([]byte(plan.SynthesizedDevcontainer), &cfg); err != nil {
+		t.Fatalf("synthesized devcontainer is not valid JSON: %v\n%s", err, plan.SynthesizedDevcontainer)
+	}
+	if cfg.Image != base {
+		t.Errorf("synthesized image = %q, want %q", cfg.Image, base)
+	}
+	if len(cfg.Features) != 2 {
+		t.Errorf("synthesized features = %v, want both references", cfg.Features)
+	}
+	for _, ref := range refs {
+		if _, ok := cfg.Features[ref]; !ok {
+			t.Errorf("synthesized features missing %q", ref)
+		}
+	}
+}
+
+// TestToolsPlan_DeterministicTag proves the local image tag is deterministic
+// for the same composition (declaration order does not matter) and distinct
+// for distinct compositions.
+func TestToolsPlan_DeterministicTag(t *testing.T) {
+	base := "ghcr.io/alrubinger/aileron-sandbox-base:latest@sha256:" + strings.Repeat("a", 64)
+	a := ToolsPlan(base, []string{"ghcr.io/x/aws-cli:0", "ghcr.io/x/gh:0"})
+	b := ToolsPlan(base, []string{"ghcr.io/x/gh:0", "ghcr.io/x/aws-cli:0"})
+	if a.Image != b.Image {
+		t.Errorf("declaration order must not change the tag: %q vs %q", a.Image, b.Image)
+	}
+	if a.SynthesizedDevcontainer != b.SynthesizedDevcontainer {
+		t.Error("declaration order must not change the synthesized devcontainer bytes")
+	}
+	if !strings.HasPrefix(a.Image, "aileron/") {
+		t.Errorf("the composed tag must be a local-daemon aileron/ tag, got %q", a.Image)
+	}
+
+	c := ToolsPlan(base, []string{"ghcr.io/x/aws-cli:0"})
+	if c.Image == a.Image {
+		t.Errorf("distinct feature sets must produce distinct tags, both %q", c.Image)
+	}
+	d := ToolsPlan("other-base@sha256:"+strings.Repeat("b", 64), []string{"ghcr.io/x/aws-cli:0", "ghcr.io/x/gh:0"})
+	if d.Image == a.Image {
+		t.Errorf("distinct bases must produce distinct tags, both %q", d.Image)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the #1827 freeze contract: one composition path over the `environment` block, replacing the interim bridge and the three dormant legacy rung branches.

- **Single composition path** (`internal/flightplan/freeze/images.go`): no environment → empty pins; `environment.image` only → one digest pin; `environment.tools` (with the default runner base or a declared custom base) → resolve the base digest first, resolve each tool against the curated catalog, compose the Feature references onto the digest-pinned base, and pin exactly ONE composed digest. The `rung1Image`/`rung2CapabilityUnits`/`rung3PerStepImages` branches, the "more than one image rung" error, and the INTERIM both-declared refusal are deleted, not deprecated.
- **Catalog tool resolution** (`internal/sandbox/composition/tools.go`): `ResolveToolFeatureRef("aws-cli@2.x")` validates the `<name>@<version>` shape against the curated set (`aws-cli`, `gh`, mirroring the schema's closed pattern) and returns the published Feature reference. `ToolsPlan(base, refs)` builds the synthesized-devcontainer composition plan with a deterministic local image tag.
- **`FeatureComposer` gains the base parameter**: `ComposeDigest(ctx, base, features)`. The CLI composer (`cmd/aileron/skill_freeze.go`) routes through `composition.ToolsPlan` + the container Builder; `rung2Plan` is deleted.
- **Step-keyed sealed trust**: the lock schema drops per-pin `id`/`hosts` (the rung-3 stepId-on-pin linkage) and gains `stepTrust`, keyed by tool-step id, each entry sealing the step's declared trust-contract `hosts`. Freeze walks the step graph fail-closed (`steptrust.go`); the section is covered by the content hash and signature. `VerifyFrozen` exposes the verified `StepTrust` for launch/runtime (#1828/#1829).
- **Lint accepts `kind: tool`** as a deterministic step; the LLM-marker check applies to it automatically. Without this, no tools-declaring plan could freeze.
- **Dormancy hand-off**: `ImagePin.StepID`/`.Hosts` and `manifest.Requires.ExecutionEnvironment` stay as documented DORMANT fields for the #1829 runtime rewire to delete (the precedent #1835 set).

Both schema copies (normative `docs/schema/` + embedded twin) updated byte-identically; the drift guard stays green. No OpenAPI change. Docs prose belongs to the umbrella's docs sub-issue.

## Test plan

- `internal/flightplan/manifest`: per-pin `id`/`hosts` now REJECTED at the schema boundary; `stepTrust` valid/invalid matrix (empty hosts, scheme-prefixed host, unknown entry key, non-object entry, non-step-id key).
- `internal/sandbox/composition`: resolver happy path for both catalog tools, unknown-name and malformed-ref rejection; `ToolsPlan` synthesized devcontainer content and deterministic/distinct tags.
- `internal/flightplan/freeze`: tools compose onto the default base (composer receives the digest-pinned base + catalog-resolved refs) and onto a custom image; image-only unchanged; error paths at both seams (resolver error, composer error, tag-not-digest from either, nil resolver/composer, unknown tool); `sealStepTrust` selection + fail-closed malformed-reach matrix; multi-entry `stepTrust` byte-determinism (extended `TestRun_Reproducible` + insertion-order-independent marshal); lint accepts a clean tool step and rejects an LLM marker on it; `VerifyFrozen` exposes `StepTrust` and REFUSES a post-signing tamper of the sealed section (sign-coverage regression).
- `cmd/aileron`: CLI-level tools+custom-base freeze asserting the composer received the digest-pinned base and catalog-resolved features; `TestRunSkillFreeze_EnvironmentImagePinsDigest` stays green.
- Full suite: `task test:go` green. New code paths (`resolveImages`, `sealStepTrust`, `toolStepHosts`) at 100% statement coverage; freeze package 88%, composition 95.5%.
- Grep gate: `git grep 'rung1Image\|rung2CapabilityUnits\|rung3PerStepImages\|more than one image rung' internal/flightplan/freeze/` returns nothing.
- Out of scope (per plan): runtime dispatch rewire (#1829), launch env injection (#1828), docs prose (umbrella docs sub-issue).
- Review pass: a thorough manual self-review of the full diff was done (single-pin invariant, fail-closed trust extraction, sign-coverage tamper test, runtime boot-string parity with main's interim behavior). The CodeRabbit CLI was rate-limited for the whole window (free-tier quota, ~47 min wait) and could not complete; flagging honestly rather than skipping silently.

Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBZ22ZY66qjou7gUTVfcBR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Freezing now preserves per-step trust settings and resolved tool environments in the saved manifest.
  * Tool steps can be composed onto a chosen base image, with curated tools pinned deterministically.

* **Bug Fixes**
  * Improved validation to reject malformed image pins, invalid tool references, and unsafe trust settings before freezing.
  * Verification now detects tampered trust data and refuses invalid frozen outputs.

* **Tests**
  * Added end-to-end coverage for custom-base tool composition, step trust sealing, and manifest/schema consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->