### PR TITLE
docs(composition): note scheme implementability enforced at inject boundary

### DIFF
--- a/internal/sandbox/composition/convention.go
+++ b/internal/sandbox/composition/convention.go
@@ -48,7 +48,13 @@ type CredentialPlaceholder struct {
 // launcher plants. It is the parse result freeze/launch consumers depend on.
 type CredentialConvention struct {
 	// Scheme names how the resolved secret is bound onto the outbound request
-	// at the network boundary. It is always a valid [inject.Scheme].
+	// at the network boundary. It is always a valid [inject.Scheme]: catalog
+	// parse routes it through [inject.ParseScheme], which only checks closed-set
+	// membership (rejecting non-members with [inject.ErrUnknownScheme]). Parse
+	// does not check that the scheme is actually implemented; a member that is
+	// recognized but unwired parses clean here. Implementability is enforced
+	// later, at the injection boundary in internal/credential/inject, which
+	// rejects such a scheme with [inject.ErrSchemeNotImplemented].
 	Scheme inject.Scheme
 	// Placeholders are the non-secret env/value pairs the launcher plants. At
 	// least one is present, each has a non-empty env and value, and no two


### PR DESCRIPTION
## Summary

The `CredentialConvention.Scheme` doc comment claimed the value "is always a
valid `[inject.Scheme]`" but omitted an important caveat: catalog parse routes
the scheme through `inject.ParseScheme`, which only checks closed-set membership
(rejecting non-members with `inject.ErrUnknownScheme`). It does **not** check
that the scheme is actually implemented. A scheme that is a recognized member of
the ADR-0019 closed set but is not yet wired parses clean at the catalog
boundary; its implementability is enforced later, at the injection boundary in
`internal/credential/inject`, which rejects such a scheme with
`inject.ErrSchemeNotImplemented`.

This is a purely additive doc-comment change. No behavior changes.

## Test plan

- `go build ./internal/sandbox/composition/... ./internal/credential/inject/...` — passes
- `go vet ./internal/sandbox/composition/...` — clean
- `go test ./internal/sandbox/composition/...` — passes

Doc-only change; the documented behavior (parse-vs-inject split) is already
covered by existing `inject` tests for `ErrUnknownScheme` /
`ErrSchemeNotImplemented`, so no new test is added.

Relates to #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
