### PR TITLE
docs(launch): drop rung vocabulary from launch godoc comments

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -943,7 +943,7 @@ func firstAgentBinary(agent Agent) string {
 // inside a container can reach the host-bound daemon. Non-loopback and
 // unparseable URLs are returned unchanged. runtimeName is retained as the
 // runtime seam; v4 is Docker-only, so the loopback host always rewrites to
-// host.docker.internal. It is exported so the rung-3 tool-container proxy
+// host.docker.internal. It is exported so the tool-container proxy
 // bootstrap can compute the container-facing proxy URL without duplicating the
 // loopback-rewrite rule.
 func ContainerURLForRuntime(rawURL, runtimeName string) string {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -410,9 +410,9 @@ const (
 	EventTypeFlightPlanLaunchAction EventType = "flightplan.launch.action"
 	EventTypeFlightPlanLaunch       EventType = "flightplan.launch"
 
-	// EventTypeFlightPlanLaunchReach is one per-rung-3-dispatch declared-reach
+	// EventTypeFlightPlanLaunchReach is one per-tool-dispatch declared-reach
 	// event (#1784). The in-process launch runtime emits one such record for each
-	// rung-3 tool-dispatch step whose per-step trust contract declares a network
+	// tool-dispatch step whose per-step trust contract declares a network
 	// reach (its Effect and Hosts). The flat `aileron.*` payload carries the
 	// dispatching step id, the declared effect, the declared hosts, and the
 	// literal `aileron.reach.enforced: false` marker. The record is audit-only:


### PR DESCRIPTION
## Summary

Two godoc comments outside the tool-step rename PR's scoped file set still carried the retired "rung-3" dispatch vocabulary that was swept from the rest of the tree. This aligns them with the PR's own established replacements (rung-3 dispatch -> tool step / tool-dispatch step):

- `internal/launch/launcher.go:946` — dropped the `rung-3 ` prefix from "rung-3 tool-container proxy bootstrap".
- `internal/model/model.go:413-415` — replaced "per-rung-3-dispatch" with "per-tool-dispatch" and "rung-3 tool-dispatch step" with "tool-dispatch step".

Comment-only change; no behavior change.

## Test plan

- `git grep -n 'rung-3\|per-rung' -- '*.go'` (excluding tests) returns no hits across production Go.
- `go build ./internal/launch/... ./internal/model/...` and `go vet` pass.
- `go test ./internal/launch/... ./internal/model/...` passes.

Relates to #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
