### PR TITLE
fix(cli): reject reserved boot-env keys in the image-boot bootstrap merge

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -79,6 +79,24 @@ func (r containerImageRunner) diagWriter() io.Writer {
 // recurse; the image carries no nested container runtime).
 const envSkillImageBooted = "AILERON_SKILL_IMAGE_BOOTED"
 
+// reservedBootEnvKeys are the authoritative boot-env keys that
+// containerImageRunner.Run sets ITSELF on opts.Env before merging the
+// proxy/placeholder bootstrap env: the host daemon coordinates (#1759) and the
+// image-boot sentinel. The bootstrap env is a union of the ADR-0019 proxy/CA
+// keys and the image-declared credential placeholders (from the pin's
+// devcontainer.metadata label). PlaceholderEnv only rejects convention-vs-
+// convention collisions and the proxy overlay only shadows its own keys, so a
+// placeholder that (mis)declares one of these reserved keys would otherwise
+// reach the merge below and clobber the authoritative daemon token/URL or the
+// boot sentinel silently. Guard the merge: reject any bootstrap key that is a
+// reserved boot key, failing closed with a loud, variable-naming error rather
+// than booting with a poisoned token/URL or a lost re-entry sentinel.
+var reservedBootEnvKeys = map[string]struct{}{
+	"AILERON_TOKEN":     {},
+	"AILERON_API_URL":   {},
+	envSkillImageBooted: {},
+}
+
 // containerRunFlightPlan boots the pinned image and runs the plan inside it. It
 // is a package variable purely for symmetry with sandboxRunContainer; the
 // production launch swaps the whole runtime.ImageRunner via newLaunchImageRunner
@@ -234,11 +252,13 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 	// fails closed: a boot that resolved daemon config but could not write its
 	// session CA (or whose declared conventions were malformed) must NOT silently
 	// egress un-proxied; it runs cleanup and fails the boot. The proxy env and
-	// the sentinel + daemon env are disjoint key sets
+	// the sentinel + daemon env are expected to be disjoint key sets
 	// (HTTPS_PROXY/CA/placeholders vs
-	// AILERON_SKILL_IMAGE_BOOTED/AILERON_API_URL/AILERON_TOKEN), so the merge
-	// never clobbers the sentinel or daemon coordinates. Cleanup is deferred so
-	// the session CA is removed after the (synchronous) run completes.
+	// AILERON_SKILL_IMAGE_BOOTED/AILERON_API_URL/AILERON_TOKEN); the
+	// reservedBootEnvKeys guard below ENFORCES that invariant, failing the boot if
+	// any bootstrap/placeholder key collides with a reserved boot key rather than
+	// letting the merge clobber the sentinel or daemon coordinates. Cleanup is
+	// deferred so the session CA is removed after the (synchronous) run completes.
 	if r.proxy != nil {
 		bootstrap, cleanup, ok, err := r.proxy.Prepare(ctx, runtimeName, spec.Image, spec.Name)
 		if err != nil {
@@ -250,6 +270,11 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		if ok {
 			if cleanup != nil {
 				defer cleanup()
+			}
+			for k := range bootstrap.Env {
+				if _, reserved := reservedBootEnvKeys[k]; reserved {
+					return runtime.ImageRunResult{}, fmt.Errorf("skill launch: bootstrap/placeholder env declares reserved boot key %q: refusing to boot rather than clobber the authoritative daemon coordinates or the image-boot sentinel", k)
+				}
 			}
 			opts.Volumes = append(opts.Volumes, bootstrap.Mount)
 			if opts.Env == nil {

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -565,6 +565,67 @@ func TestContainerImageRunner_ProxyPrepareErrorFailsClosed(t *testing.T) {
 	}
 }
 
+// TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap proves that a
+// bootstrap/placeholder env declaring one of the reserved boot keys (the daemon
+// coordinates AILERON_TOKEN / AILERON_API_URL or the AILERON_SKILL_IMAGE_BOOTED
+// sentinel) fails the boot closed with an error naming the offending variable,
+// rather than letting the merge clobber the authoritative daemon token/URL or
+// the re-entry sentinel (#1828). An image-declared credential placeholder is
+// the realistic source of such a key: PlaceholderEnv only rejects
+// convention-vs-convention collisions, so a placeholder that mis-declares a
+// reserved key would otherwise reach the merge site. The boot must NOT run.
+func TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap(t *testing.T) {
+	for _, reserved := range []string{"AILERON_TOKEN", "AILERON_API_URL", envSkillImageBooted} {
+		reserved := reserved
+		t.Run(reserved, func(t *testing.T) {
+			storeDir := t.TempDir()
+			origStore := skillStoreDir
+			skillStoreDir = storeDir
+			t.Cleanup(func() { skillStoreDir = origStore })
+
+			var got sandboxcontainer.RunOptions
+			booted := false
+			orig := containerRunFlightPlan
+			containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+				booted = true
+				got = opts
+				return sandboxcontainer.RunResult{}, nil
+			}
+			t.Cleanup(func() { containerRunFlightPlan = orig })
+
+			daemon := &fakeImageDaemonEnv{
+				env: map[string]string{
+					"AILERON_API_URL": "http://host.docker.internal:48123/v1",
+					"AILERON_TOKEN":   "daemon-token",
+				},
+				ok: true,
+			}
+			// A placeholder union that mis-declares a reserved boot key.
+			proxy := &fakePlanProxyBootstrapper{
+				ok: true,
+				env: map[string]string{
+					"HTTPS_PROXY": "http://sess:tok@host.docker.internal:48123",
+					reserved:      "poisoned-by-placeholder",
+				},
+			}
+			spec := runtime.ImageRunSpec{Image: "registry.example.com/runner@sha256:abc", Name: "weekly-metrics-digest"}
+			_, err := (containerImageRunner{daemonEnv: daemon, proxy: proxy}).Run(context.Background(), spec)
+			if err == nil {
+				t.Fatalf("a bootstrap env declaring reserved key %q must fail the boot closed", reserved)
+			}
+			if !strings.Contains(err.Error(), reserved) {
+				t.Errorf("error must name the offending variable %q, got %v", reserved, err)
+			}
+			if booted {
+				t.Errorf("the image must NOT boot when a reserved boot key is present, got %+v", got)
+			}
+			if !proxy.cleaned {
+				t.Error("the returned cleanup must run on the reserved-key rejection path so a partial CA never leaks")
+			}
+		})
+	}
+}
+
 // --- CLI-version skew preflight (#1809) ---
 
 // newSkewTestSpec returns a minimal spec with the store dir pointed at a temp


### PR DESCRIPTION
## Summary

The Flight Plan image-boot path (`containerImageRunner.Run` in `cmd/aileron/skill_launch_container.go`) sets the authoritative boot coordinates on `opts.Env` before merging the proxy/placeholder bootstrap env:

- the host daemon coordinates `AILERON_TOKEN` / `AILERON_API_URL` (#1759), and
- the `AILERON_SKILL_IMAGE_BOOTED` re-entry sentinel.

The subsequent bootstrap merge does `opts.Env[k] = v` for every bootstrap key. That bootstrap env is a union of the ADR-0019 proxy/CA keys and the image-declared credential placeholders derived from the pin's `devcontainer.metadata` label. `composition.PlaceholderEnv` only rejects convention-vs-convention collisions, and the proxy overlay only shadows its own keys, so a placeholder that (mis)declares one of the reserved boot keys would reach the merge and silently clobber the authoritative daemon token/URL or the boot sentinel (which would poison audit/action routing or break re-entry recursion detection).

This adds a `reservedBootEnvKeys` guard at the merge site that fails the boot closed with a loud error naming the offending variable, rather than letting a placeholder overwrite a reserved boot key.

## Test plan

- New table-driven regression test `TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap` covers all three reserved keys (`AILERON_TOKEN`, `AILERON_API_URL`, `AILERON_SKILL_IMAGE_BOOTED`): a bootstrap env declaring the key must fail the boot closed with an error that names the variable, the image must NOT boot, and the returned cleanup must still run.
- Verified the test fails before the guard and passes after (removed the guard locally: all three subtests failed with "must fail the boot closed"; restored: green).
- `go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and the full `go test ./cmd/aileron/` suite pass; `gofmt` clean.

Relates to #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
