### PR TITLE
fix(flightplan): detect step-id collisions across kinds at freeze lint

### DIFF
--- a/internal/flightplan/freeze/lint.go
+++ b/internal/flightplan/freeze/lint.go
@@ -56,6 +56,13 @@ func Lint(m *manifest.Manifest) error {
 	if m == nil || m.InstructionOnly {
 		return nil
 	}
+	// seenIDs enforces whole-graph unique step ids across ALL step kinds,
+	// mirroring runtime/decode.go's launch-time duplicate check. Freeze runs
+	// this before sealing stepTrust (steptrust.go) so a sealed reach can never
+	// be keyed onto an id that an ambiguous non-tool step also declares:
+	// steptrust.go only rejects duplicates among tool steps, leaving a
+	// tool/non-tool id collision undetected without this whole-graph pass.
+	seenIDs := map[string]bool{}
 	for i, raw := range m.Aileron.Steps {
 		step, ok := raw.(map[string]any)
 		if !ok {
@@ -65,6 +72,15 @@ func Lint(m *manifest.Manifest) error {
 			}
 		}
 		id := scalarString(step["id"])
+		if id != "" {
+			if seenIDs[id] {
+				return &LintError{
+					StepID: id,
+					Reason: "duplicate step id (every step id must be unique across the whole graph)",
+				}
+			}
+			seenIDs[id] = true
+		}
 		kindVal, hasKind := step["kind"]
 		if !hasKind {
 			return &LintError{StepID: id, Reason: "missing kind (every step must declare a kind)"}

--- a/internal/flightplan/freeze/lint_test.go
+++ b/internal/flightplan/freeze/lint_test.go
@@ -152,6 +152,32 @@ func TestLint_RejectsLLMMarkerOnToolStep(t *testing.T) {
 	}
 }
 
+// TestLint_RejectsDuplicateStepIDAcrossKinds proves the whole-graph
+// unique-step-id check spans ALL step kinds, not just tool steps. A tool step
+// and a non-tool step sharing an id would let freeze seal a stepTrust reach
+// onto an id an ambiguous non-tool step also declares; the lint must reject
+// the plan before sealing (steptrust.go only catches tool/tool collisions).
+func TestLint_RejectsDuplicateStepIDAcrossKinds(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "dup", "kind": "tool", "command": []any{"aws"}, "trustContract": map[string]any{"hosts": []any{"example.com"}}},
+		map[string]any{"id": "dup", "kind": "transform", "outputs": []any{"x"}},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("a tool step and a non-tool step sharing an id must fail lint")
+	}
+	var le *LintError
+	if !errors.As(err, &le) {
+		t.Fatalf("want *LintError, got %T", err)
+	}
+	if le.StepID != "dup" {
+		t.Errorf("error must name the colliding id, got %q", le.StepID)
+	}
+	if !strings.Contains(err.Error(), "duplicate step id") {
+		t.Errorf("error should describe the duplicate id, got: %v", err)
+	}
+}
+
 func TestLint_NilManifestClean(t *testing.T) {
 	if err := Lint(nil); err != nil {
 		t.Errorf("Lint(nil) must be clean: %v", err)


### PR DESCRIPTION
## Summary

Freeze lint had no whole-graph unique-step-id check. `freeze/steptrust.go` rejects duplicate ids only among `tool` steps, so a `tool` step and a non-tool step (`transform`, `action-call`, `llm-seam`) sharing an id slipped past freeze. Runtime decode (`runtime/decode.go`) catches graph-wide duplicates at launch, but freeze could still seal a stepTrust reach onto an id that an ambiguous non-tool step also declares.

This adds a whole-graph unique-step-id pass to `freeze.Lint`, mirroring the runtime decode check, that hard-errors on the first duplicate id across ALL step kinds via a `LintError` before stepTrust is sealed. The check is scoped to non-empty ids so it never spuriously fails on id-less steps that the existing lint rules already govern.

## Test plan

- `go test ./internal/flightplan/...` — all packages pass.
- New `TestLint_RejectsDuplicateStepIDAcrossKinds` asserts a plan with a `tool` step and a `transform` step sharing an id fails freeze lint with a `LintError` naming the colliding id. Verified it FAILS against `origin/main` (no check) and PASSES with the fix.
- `gofmt` and `go vet` clean on the changed files.

Relates to #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
