### PR TITLE
docs(audit): correct reach.enforced comments to truthful per-record boolean

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -345,10 +345,14 @@ func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) st
 			payload = map[string]any{}
 		}
 	case runtime.RecordKindReach:
-		// A declared-reach record (#1784) carries the same flat `aileron.*`
-		// payload treatment as an output record: the reach attributes surface as
-		// top-level keys (including `aileron.reach.enforced: false`), not nested
-		// under `fields`. It is audit-only and enforces nothing.
+		// A reach record (#1784, enforcement truth from #1829) carries the same
+		// flat `aileron.*` payload treatment as an output record: the reach
+		// attributes surface as top-level keys (including the truthful per-record
+		// `aileron.reach.enforced` boolean), not nested under `fields`. That
+		// boolean is true when the step ran under a step-scoped proxy credential
+		// restricted to the verified sealed reach and false otherwise; its
+		// semantics are single-sourced to buildReachRecord in
+		// internal/flightplan/runtime/audit.go.
 		eventType = string(model.EventTypeFlightPlanLaunchReach)
 		payload = rec.Fields
 		if payload == nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -410,15 +410,18 @@ const (
 	EventTypeFlightPlanLaunchAction EventType = "flightplan.launch.action"
 	EventTypeFlightPlanLaunch       EventType = "flightplan.launch"
 
-	// EventTypeFlightPlanLaunchReach is one per-tool-dispatch declared-reach
-	// event (#1784). The in-process launch runtime emits one such record for each
-	// tool-dispatch step whose per-step trust contract declares a network
-	// reach (its Effect and Hosts). The flat `aileron.*` payload carries the
-	// dispatching step id, the declared effect, the declared hosts, and the
-	// literal `aileron.reach.enforced: false` marker. The record is audit-only:
-	// the declared reach is surfaced for observability and is NOT enforced (egress
-	// stays passthrough; the credential is injected per host binding). Actor is
-	// {type: service, id: "flightplan-launch"}.
+	// EventTypeFlightPlanLaunchReach is one per-tool-dispatch reach event
+	// (#1784, enforcement truth from #1829). The in-process launch runtime emits
+	// one such record for each tool-dispatch step whose per-step trust contract
+	// declares a network reach (its Effect and Hosts). The flat `aileron.*`
+	// payload carries the dispatching step id, the declared effect, the hosts the
+	// step ran under, and the truthful per-record `aileron.reach.enforced`
+	// boolean. That boolean is true when the step ran under a step-scoped proxy
+	// credential restricted to the verified lock's sealed reach, and false when
+	// the step declared a contract with no sealed entry. The single source of
+	// truth for the marker's semantics is buildReachRecord in
+	// internal/flightplan/runtime/audit.go. Actor is {type: service, id:
+	// "flightplan-launch"}.
 	EventTypeFlightPlanLaunchReach EventType = "flightplan.launch.reach"
 
 	// EventTypeOutputMaterialized is one per-output-per-step provenance event


### PR DESCRIPTION
## Summary

Two godoc/comment blocks still described `aileron.reach.enforced` as a hardcoded `false` marker that "enforces nothing", contradicting the real behavior since #1829. `buildReachRecord` in `internal/flightplan/runtime/audit.go` emits a truthful per-record boolean: `true` when the step ran under a step-scoped proxy credential restricted to the verified lock's sealed reach, `false` when the step declared a contract with no sealed entry.

This PR rewrites the two stale comment blocks so they state the truthful semantics and single-source them to `buildReachRecord`:

- `internal/model/model.go` — `EventTypeFlightPlanLaunchReach` godoc. Removed the "literal `aileron.reach.enforced: false` marker" / "NOT enforced (egress stays passthrough)" falsehoods.
- `cmd/aileron/skill_launch.go` — `RecordKindReach` case. Removed "It is audit-only and enforces nothing".

Comment-only change; no behavior change.

## Test plan

- `go build ./internal/model/... ./cmd/aileron/...` passes.
- `go vet ./internal/model/...` clean.
- Documentation-only change with no behavior change, so no test additions apply.

Closes #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
