### PR TITLE
test(launch): assert composed-image devcontainer.metadata carries both credential conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,9 +857,12 @@ jobs:
       # @devcontainers/cli and asserts `command -v claude` / `command -v codex`,
       # and (#1083) composes the Codex Feature plus a second Feature through
       # Aileron's composition.Discover -> Builder.Build path and asserts both
-      # tools resolve on PATH. The ubuntu runner has Docker; this is the
-      # fail-fast acceptance environment.
-      - name: Build sandbox Features and verify CLIs on PATH (#1082, #1083)
+      # tools resolve on PATH; and (#1857) composes the aws-cli + gh Features
+      # and asserts the composed image's devcontainer.metadata label parses into
+      # both credential conventions (sigv4-resign + bearer) via the production
+      # read path. The ubuntu runner has Docker; this is the fail-fast
+      # acceptance environment.
+      - name: Build sandbox Features and verify CLIs on PATH (#1082, #1083, #1857)
         run: task test:integration:sandbox-features
 
   integration-sandbox-managed:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -474,10 +474,10 @@ tasks:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
 
   test:integration:sandbox-features:
-    desc: "Build the per-agent sandbox Features (claude/codex) and assert each agent CLI is on PATH in the composed image: directly via @devcontainers/cli (#1082) and through Aileron's own composition.Discover -> Builder.Build path with a second Feature (#1083); fail-fast — requires Docker + Node + @devcontainers/cli (no self-skip). Excludes the managed-toolchain build (TestSandboxFeaturesManaged*), which has its own target/job."
+    desc: "Build the per-agent sandbox Features (claude/codex) and assert each agent CLI is on PATH in the composed image: directly via @devcontainers/cli (#1082) and through Aileron's own composition.Discover -> Builder.Build path with a second Feature (#1083); plus the credential-metadata end-to-end assertion (#1857) that composes the aws-cli + gh Features and asserts the composed image's devcontainer.metadata parses into both credential conventions (sigv4-resign + bearer). Fail-fast — requires Docker + Node + @devcontainers/cli (no self-skip). Excludes the managed-toolchain build (TestSandboxFeaturesManaged*), which has its own target/job."
     dir: internal
     cmds:
-      - go test -tags=integration_sandbox -run 'TestSandboxFeatures$|TestSandboxFeaturesComposeViaAileron$|TestGHFeatureComposesViaAileron$' ./launch/...
+      - go test -tags=integration_sandbox -run 'TestSandboxFeatures$|TestSandboxFeaturesComposeViaAileron$|TestGHFeatureComposesViaAileron$|TestComposedImageCredentialMetadata$' ./launch/...
     env:
       AILERON_SANDBOX_BASE_CONTEXT:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd

--- a/internal/launch/sandbox_features_credential_metadata_integration_test.go
+++ b/internal/launch/sandbox_features_credential_metadata_integration_test.go
@@ -1,0 +1,231 @@
+//go:build integration_sandbox
+
+// Composed-image credential-convention e2e test (#1857).
+//
+// Where the sibling composition tests (TestSandboxFeaturesComposeViaAileron /
+// TestGHFeatureComposesViaAileron, #1083) prove declared tools resolve on PATH,
+// this test closes the credential-convention coverage gap left by seam-level
+// fakes: it composes a REAL image (Aileron sandbox base + the aws-cli Feature +
+// the gh Feature) through Aileron's own composition.Discover ->
+// container.Builder.Build path, reads the composed image's devcontainer.metadata
+// OCI label through the exact production read path the launcher uses
+// (container.ImageMetadataLabel, called at boot by
+// cmd/aileron/skill_launch_proxy.go), and asserts it parses via
+// composition.ConventionsFromMetadata into BOTH credential conventions:
+// aws-cli's sigv4-resign and gh's bearer.
+//
+// This exercises the real contract (composed image -> devcontainer.metadata ->
+// both conventions parse), not internals. If a Feature ever drops its
+// credential block from the merged metadata, this test fails loudly — that is a
+// real regression, so there is no t.Skip.
+//
+// Per the umbrella's two-layer test posture this test is FAIL-FAST: there is no
+// t.Skip. If Go, Node, npx/@devcontainers/cli, Docker, or the base image is
+// absent, the test FAILS. CI provisions the toolchain (see the
+// integration-sandbox-features job).
+//
+// Run with:
+//
+//	task test:integration:sandbox-features
+//
+// or directly (from internal/, with AILERON_SANDBOX_BASE_CONTEXT +
+// AILERON_SANDBOX_FEATURES_CONTEXT set as the task does):
+//
+//	go test -tags=integration_sandbox -run TestComposedImageCredentialMetadata ./launch/...
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// TestComposedImageCredentialMetadata composes the aws-cli Feature plus the gh
+// Feature through Aileron's Discover -> Build path, reads the composed image's
+// devcontainer.metadata label via the production read path, and asserts both
+// credential conventions (aws-cli's sigv4-resign and gh's bearer) parse out of
+// the merged metadata with the expected placeholder env sets. The two
+// credential-carrying Features are themselves the >=2-Feature composition, so
+// no probe Feature is needed and len(plan.Features) == 2 is exact.
+func TestComposedImageCredentialMetadata(t *testing.T) {
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		// Fail-fast: CI provisions Docker; absence is a job failure, not a skip.
+		t.Fatalf("no docker runtime on PATH (required, not skipped): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	// The composed image FROMs a freshly built sandbox-base under a known tag so
+	// the build does not depend on a registry-published base.
+	buildSandboxFeaturesBaseImage(ctx, t, rt)
+
+	featuresRoot := sandboxFeaturesContext(t)
+	awsFeatureDir := filepath.Join(featuresRoot, "aws-cli")
+	if _, err := os.Stat(filepath.Join(awsFeatureDir, "devcontainer-feature.json")); err != nil {
+		t.Fatalf("aws-cli feature not found at %s: %v", awsFeatureDir, err)
+	}
+	ghFeatureDir := filepath.Join(featuresRoot, "gh")
+	if _, err := os.Stat(filepath.Join(ghFeatureDir, "devcontainer-feature.json")); err != nil {
+		t.Fatalf("gh feature not found at %s: %v", ghFeatureDir, err)
+	}
+
+	workspace := t.TempDir()
+	devDir := filepath.Join(workspace, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir .devcontainer: %v", err)
+	}
+
+	// Copy both Features into .devcontainer/<name>: the only path form
+	// @devcontainers/cli accepts for a local Feature is relative to .devcontainer.
+	copyFeatureDir(t, awsFeatureDir, filepath.Join(devDir, "aws-cli"))
+	copyFeatureDir(t, ghFeatureDir, filepath.Join(devDir, "gh"))
+
+	dc := map[string]any{
+		"name":  "aileron-credential-metadata-composition",
+		"image": sandboxFeaturesBaseImage,
+		"features": map[string]any{
+			"./aws-cli": map[string]any{},
+			"./gh":      map[string]any{},
+		},
+	}
+	raw, err := json.MarshalIndent(dc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal devcontainer.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), raw, 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+
+	// Drive Aileron's own composition + build plumbing.
+	plan, err := sandboxcomposition.Discover(workspace, "test", "")
+	if err != nil {
+		t.Fatalf("composition.Discover: %v", err)
+	}
+	if plan.Tier != sandboxcomposition.TierDevcontainer {
+		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierDevcontainer)
+	}
+	if len(plan.Features) != 2 {
+		t.Fatalf("plan.Features = %#v, want 2 (aws-cli + gh)", plan.Features)
+	}
+
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	result, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		WorkDir: workspace,
+		Plan:    plan,
+		Policy:  sandboxcontainer.BuildPolicyAlways,
+		// This test exercises Feature composition + metadata merging, not
+		// toolchain provisioning; pin host-npx so it keeps its pre-#1530
+		// behavior now that the default is managed. The managed path has its
+		// own coverage in the Sandbox Managed integration matrix.
+		ToolchainMode: sandboxcontainer.ToolchainModeHostNPX,
+	})
+	if err != nil {
+		t.Fatalf("Builder.Build via @devcontainers/cli: %v", err)
+	}
+	if !result.Built {
+		t.Fatalf("result.Built = false, want true (features require a build)")
+	}
+	if result.Image == "" {
+		t.Fatalf("result.Image is empty")
+	}
+
+	// Read the merged devcontainer.metadata label through the EXACT production
+	// read path the launcher uses at boot (skill_launch_proxy.go). An empty
+	// label means the merged metadata never carried the credential blocks — a
+	// real regression, not a skip.
+	label := sandboxcontainer.ImageMetadataLabel(ctx, sandboxcontainer.DefaultRunner(), rt, result.Image)
+	if strings.TrimSpace(label) == "" {
+		t.Fatalf("composed image %s has an empty devcontainer.metadata label; expected merged aws-cli + gh credential blocks", result.Image)
+	}
+
+	// Parse the label into credential conventions via the contract the launcher
+	// depends on.
+	convs, err := sandboxcomposition.ConventionsFromMetadata([]byte(label))
+	if err != nil {
+		t.Fatalf("ConventionsFromMetadata(%q): %v", label, err)
+	}
+	if len(convs) != 2 {
+		t.Fatalf("ConventionsFromMetadata returned %d conventions, want 2 (aws-cli sigv4-resign + gh bearer); label=%s", len(convs), label)
+	}
+
+	// Assert the two conventions by scheme, unordered: metadata array/merge
+	// order is not part of the contract. Match each expected convention by its
+	// inject.Scheme, then assert its placeholder env-key set.
+	byScheme := map[inject.Scheme][]string{}
+	for _, conv := range convs {
+		if _, dup := byScheme[conv.Scheme]; dup {
+			t.Fatalf("duplicate convention for scheme %q; want exactly one aws-cli (%s) and one gh (%s); label=%s",
+				conv.Scheme, inject.SchemeSigV4Resign, inject.SchemeBearer, label)
+		}
+		envs := make([]string, 0, len(conv.Placeholders))
+		for _, p := range conv.Placeholders {
+			envs = append(envs, p.Env)
+		}
+		byScheme[conv.Scheme] = envs
+	}
+
+	assertEnvSet(t, byScheme, inject.SchemeSigV4Resign, []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}, label)
+	assertEnvSet(t, byScheme, inject.SchemeBearer, []string{"GH_TOKEN"}, label)
+}
+
+// assertEnvSet asserts that the conventions-by-scheme map carries the given
+// scheme and that its placeholder env keys equal want as an unordered set.
+func assertEnvSet(t *testing.T, byScheme map[inject.Scheme][]string, scheme inject.Scheme, want []string, label string) {
+	t.Helper()
+	got, ok := byScheme[scheme]
+	if !ok {
+		t.Fatalf("no credential convention with scheme %q found among %v; label=%s", scheme, keysOf(byScheme), label)
+	}
+	if !sameStringSet(got, want) {
+		t.Fatalf("scheme %q placeholder env keys = %v, want %v (unordered); label=%s", scheme, got, want, label)
+	}
+}
+
+// keysOf returns the schemes present in a conventions-by-scheme map, for error
+// messages.
+func keysOf(m map[inject.Scheme][]string) []inject.Scheme {
+	out := make([]inject.Scheme, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// sameStringSet reports whether a and b contain the same elements, ignoring
+// order and duplicates.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	want := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		want[s] = struct{}{}
+	}
+	if len(seen) != len(want) {
+		return false
+	}
+	for s := range want {
+		if _, ok := seen[s]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Closes the end-to-end coverage gap left by seam-level fakes for the credential-convention read path: adds a build-tagged (`integration_sandbox`) integration test that composes a **real** image (Aileron sandbox base + the `aws-cli` Feature + the `gh` Feature) through Aileron's own `composition.Discover` → `container.Builder.Build` path, reads the composed image's `devcontainer.metadata` OCI label through the **exact production read path** the launcher uses at boot (`sandboxcontainer.ImageMetadataLabel(ctx, sandboxcontainer.DefaultRunner(), rt, image)` — the same call `cmd/aileron/skill_launch_proxy.go` makes), and asserts it parses via `composition.ConventionsFromMetadata` into **both** credential conventions:

- aws-cli's `sigv4-resign` — placeholder env set `{AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY}`
- gh's `bearer` — placeholder env set `{GH_TOKEN}`

Conventions are matched by `inject.Scheme` **unordered** (metadata array/merge order is not part of the contract), with a duplicate-scheme guard so exactly one of each is required. This exercises the real contract (composed image → `devcontainer.metadata` → both conventions parse), not internals. If a Feature ever drops its credential block from the merged metadata, the test fails loudly.

### What changed
- **New file** `internal/launch/sandbox_features_credential_metadata_integration_test.go` — mirrors the sibling composition e2e (`TestGHFeatureComposesViaAileron`), reusing the already-present shared helpers (`buildSandboxFeaturesBaseImage`, `sandboxFeaturesContext`, `copyFeatureDir`, `sandboxFeaturesBaseImage`, `testLogWriter`) with zero new scaffolding helpers. No probe Feature: the two credential-carrying Features are themselves the ≥2-Feature composition, so `len(plan.Features) == 2` is exact.
- **`Taskfile.yml`** — appended `TestComposedImageCredentialMetadata$` to the anchored `-run` alternation in `test:integration:sandbox-features` and updated the `desc`.
- **`.github/workflows/ci.yml`** — extended the `integration-sandbox-features` job step name/comment to reference #1857. No structural CI change: the `gh` and `aws-cli` Features are already published/validated by `sandbox-features.yml`.

### Scope
Test-only. No production/source changes. No new CI job or Taskfile target. No OpenAPI/spec changes. Fail-fast posture (no `t.Skip`); Docker is provisioned by the CI integration job.

## Test plan
- `gofmt -l` clean; `go vet -tags=integration_sandbox ./launch/...` clean.
- Default unit suite green for affected packages: `go test ./launch/... ./sandbox/composition/...` (from `internal/`).
- `task --list` parses the updated Taskfile target.
- The new test runs only under `integration_sandbox` on a Docker host (CI `integration-sandbox-features` job) via `task test:integration:sandbox-features`; it is excluded from the default unit run by the build tag. It was not executed locally here (no Docker in this environment) — CI's integration job is the fail-fast acceptance environment.
- CodeRabbit review pass run on the diff; the single minor finding (harden `sameStringSet` length guard) was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for composed sandbox feature images so credential metadata is checked more thoroughly.
  * Added coverage to confirm images built with common features expose both supported credential formats correctly.
  * Expanded automated integration checks to catch metadata issues earlier in the sandbox workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->