### PR TITLE
fix(runtime): boot composed tools image by local-daemon tag

### DIFF
--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -437,6 +437,13 @@ aileron:
 	if !strings.Contains(string(v.Lockfile), "aws-cli@2.x") {
 		t.Errorf("the lockfile must record the declared tools:\n%s", v.Lockfile)
 	}
+	// The composed pin records the bootable local-daemon tag (#1856), computed
+	// from the same digest-pinned base and catalog-resolved feature refs the
+	// composer received, so the runtime boots the composed image.
+	wantTag := composition.LocalToolsImageTag(composeBase, composeFeatures)
+	if !strings.Contains(string(v.Lockfile), "localTag: "+wantTag) {
+		t.Errorf("the lockfile must record the composed pin's bootable localTag %q:\n%s", wantTag, v.Lockfile)
+	}
 }
 
 func TestRunSkillFreeze_FromPath(t *testing.T) {

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -170,10 +170,11 @@ func stripEnvironmentBlock(t *testing.T, md string) string {
 
 // TestRunSkillLaunch_BootsPinnedEnvironmentImage proves the acceptance
 // property: the worked example declares environment tools, so its verified
-// lock pins a composed image digest.
-// Launch boots that exact ref@sha256:<digest-from-lock> through the image runner
-// and exits 0. The recorded image is the load-bearing assertion that the lock's
-// signed-image claim corresponds to the image actually entered.
+// lock pins a composed image carrying a bootable local-daemon tag (#1856).
+// Launch boots that local tag through the image runner and exits 0. The
+// recorded image is the load-bearing assertion that the lock's signed
+// composed-tools claim corresponds to the daemon-resolvable image actually
+// entered, not the unbootable descriptive ref@digest join.
 func TestRunSkillLaunch_BootsPinnedEnvironmentImage(t *testing.T) {
 	storeDir := withTempStore(t)
 	freezeExampleForLaunch(t, storeDir)
@@ -195,8 +196,11 @@ func TestRunSkillLaunch_BootsPinnedEnvironmentImage(t *testing.T) {
 	if !runner.called {
 		t.Fatal("launch did not boot the pinned image for an environment unit")
 	}
-	if !strings.HasSuffix(runner.spec.Image, "@"+fakeFreezeDigest) {
-		t.Errorf("booted image = %q, want it to end with @%s (the verified lock digest)", runner.spec.Image, fakeFreezeDigest)
+	if !strings.HasPrefix(runner.spec.Image, "aileron/sandbox-tools:") {
+		t.Errorf("booted image = %q, want the composed pin's bootable local-daemon tag", runner.spec.Image)
+	}
+	if strings.Contains(runner.spec.Image, "@"+fakeFreezeDigest) || strings.Contains(runner.spec.Image, "+tools(") {
+		t.Errorf("booted the unbootable descriptive ref@digest join %q, want the local tag", runner.spec.Image)
 	}
 	if runner.spec.Name != "weekly-metrics-digest" {
 		t.Errorf("spec.Name = %q, want the launched skill name", runner.spec.Name)

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -627,6 +627,11 @@
                 "type": "string",
                 "description": "The resolved content-addressed digest.",
                 "pattern": "^sha256:[a-f0-9]{64}$"
+              },
+              "localTag": {
+                "type": "string",
+                "description": "The bootable local-daemon tag the runtime boots for a composed-tools pin (aileron/sandbox-tools:<hex>). Present only on a composed-tools pin; absent for a directly-pinned base, which boots ref@digest.",
+                "minLength": 1
               }
             }
           }

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -37,6 +37,13 @@ func TestRun_EnvironmentToolsHappyPath(t *testing.T) {
 	if len(res.Lock.ResolvedImages) != 1 || res.Lock.ResolvedImages[0].Digest != fakeDigest {
 		t.Errorf("resolvedImages = %+v", res.Lock.ResolvedImages)
 	}
+	// The composed-tools pin carries the bootable local-daemon tag (#1856), so
+	// the runtime can boot the composed image rather than the unbootable
+	// ref@digest join. The tag is sealed inside the signed lock (content hash +
+	// signature cover it), verified by the round-trip below.
+	if tag := res.Lock.ResolvedImages[0].LocalTag; !strings.HasPrefix(tag, "aileron/sandbox-tools:") {
+		t.Errorf("composed pin must carry an aileron/sandbox-tools: LocalTag, got %q", tag)
+	}
 	if len(res.Lock.ResolvedCapabilitySet) != 1 || res.Lock.ResolvedCapabilitySet[0] != "aws-cli@2.x" {
 		t.Errorf("resolvedCapabilitySet = %v", res.Lock.ResolvedCapabilitySet)
 	}
@@ -64,6 +71,58 @@ func TestRun_EnvironmentToolsHappyPath(t *testing.T) {
 	}
 	if fm.Aileron.Lock["contentHash"] != res.ContentHash {
 		t.Errorf("frozen manifest lock.contentHash = %v, want %v", fm.Aileron.Lock["contentHash"], res.ContentHash)
+	}
+}
+
+// TestRun_ComposedLocalTagIsSigned proves the composed pin's bootable LocalTag
+// is security-relevant boot input covered by the signature: a lock whose
+// localTag is mutated after freeze no longer verifies against the stored
+// signature. The tag is now the runtime's boot target (#1856), so it must be
+// sealed like the digest, not re-suppliable at launch.
+func TestRun_ComposedLocalTagIsSigned(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), exampleSkillMD(t), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Resolver:       dummyResolver(),
+		Composer:       fakeComposer(fakeDigest),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Lock.ResolvedImages[0].LocalTag == "" {
+		t.Fatal("precondition: the composed pin must carry a LocalTag to tamper with")
+	}
+
+	// The honest lock verifies over its canonical content bytes.
+	honest := res.Lock.withoutContentHash()
+	mHonest, err := injectLock(exampleSkillMD(t), honest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lfHonest, err := MarshalLockfile(honest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(canonicalContent(mHonest, lfHonest), res.Signature, res.PublicKey); err != nil {
+		t.Fatalf("the honest lock must verify: %v", err)
+	}
+
+	// Mutating the localTag changes the canonical content bytes, so the stored
+	// signature no longer verifies: the tag is sealed inside the lock.
+	tampered := res.Lock.withoutContentHash()
+	tampered.ResolvedImages = append([]ImagePin(nil), tampered.ResolvedImages...)
+	tampered.ResolvedImages[0].LocalTag = "aileron/sandbox-tools:deadbeefdeadbeef"
+	mTampered, err := injectLock(exampleSkillMD(t), tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lfTampered, err := MarshalLockfile(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(canonicalContent(mTampered, lfTampered), res.Signature, res.PublicKey); err == nil {
+		t.Error("a mutated localTag must fail signature verification; the tag is sealed boot input")
 	}
 }
 

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -152,7 +152,19 @@ func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver,
 	if err := requireDigest("environment:"+strings.Join(tools, ","), digest); err != nil {
 		return nil, nil, err
 	}
-	return []ImagePin{{Ref: composedToolsRef(pinnedBase, tools), Digest: digest}}, tools, nil
+	// The composed pin carries three identities: the descriptive Ref (what was
+	// composed onto which pinned base, for errors/audit), the attesting Digest
+	// (the composed image's content address), and the bootable LocalTag (the
+	// local-daemon tag the composed image actually carries, so the runtime can
+	// boot it). LocalTag is computed from the SAME pinnedBase and
+	// catalog-resolved featureRefs the composer received, so it is byte-identical
+	// to composition.ToolsPlan(pinnedBase, featureRefs).Image; LocalToolsImageTag
+	// sorts internally, so declaration order does not matter.
+	return []ImagePin{{
+		Ref:      composedToolsRef(pinnedBase, tools),
+		Digest:   digest,
+		LocalTag: composition.LocalToolsImageTag(pinnedBase, featureRefs),
+	}}, tools, nil
 }
 
 // requireDigest enforces the pin-by-digest invariant: a resolved value that
@@ -166,7 +178,9 @@ func requireDigest(ref, digest string) error {
 
 // composedToolsRef renders a stable, descriptive pre-freeze reference for an
 // image composed from declared environment tools, so the lock entry records
-// what was composed and onto which digest-pinned base.
+// what was composed and onto which digest-pinned base. This Ref is descriptive
+// and not itself bootable: the composed pin carries a separate LocalTag with
+// the daemon-resolvable local-daemon tag the runtime boots.
 func composedToolsRef(pinnedBase string, tools []string) string {
 	return pinnedBase + "+tools(" + strings.Join(tools, ",") + ")"
 }

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 )
 
 func parseM(t *testing.T, raw []byte) *manifest.Manifest {
@@ -61,6 +62,10 @@ func TestResolveImages_EnvironmentImageResolvesToDigest(t *testing.T) {
 	if len(pins) != 1 || pins[0].Digest != fakeDigest || pins[0].Ref != "registry.example.com/runner:1.4" {
 		t.Errorf("pins = %+v", pins)
 	}
+	// An image-only pin has no composed local tag: it boots ref@digest.
+	if pins[0].LocalTag != "" {
+		t.Errorf("an image-only pin must carry no LocalTag, got %q", pins[0].LocalTag)
+	}
 	if capSet != nil {
 		t.Errorf("an image-only environment must have no capability set, got %v", capSet)
 	}
@@ -105,6 +110,16 @@ func TestResolveImages_ToolsComposeOntoDefaultBase(t *testing.T) {
 	}
 	if !strings.Contains(pins[0].Ref, wantBase+"@"+fakeDigest) || !strings.Contains(pins[0].Ref, "aws-cli@2.x") {
 		t.Errorf("the pin ref must record the pinned base and the composed tools, got %q", pins[0].Ref)
+	}
+	// The composed pin carries the bootable local-daemon tag the composed image
+	// carries in the daemon: byte-identical to LocalToolsImageTag over the same
+	// pinnedBase and catalog-resolved feature refs the composer received.
+	wantTag := composition.LocalToolsImageTag(wantBase+"@"+fakeDigest, gotFeatures)
+	if !strings.HasPrefix(wantTag, "aileron/sandbox-tools:") {
+		t.Fatalf("expected an aileron/sandbox-tools: tag, got %q", wantTag)
+	}
+	if pins[0].LocalTag != wantTag {
+		t.Errorf("composed pin LocalTag = %q, want %q", pins[0].LocalTag, wantTag)
 	}
 	if strings.Join(capSet, ",") != "aws-cli@2.x" {
 		t.Errorf("resolved capability set must record the declared tools verbatim, got %v", capSet)
@@ -157,6 +172,13 @@ func TestResolveImages_ToolsComposeOntoCustomImage(t *testing.T) {
 	}
 	if len(pins) != 1 || pins[0].Digest != fakeDigest2 {
 		t.Fatalf("tools onto a custom base must pin exactly one image, got %+v", pins)
+	}
+	wantTag := composition.LocalToolsImageTag("registry.example.com/base:1@"+fakeDigest, gotFeatures)
+	if !strings.HasPrefix(wantTag, "aileron/sandbox-tools:") {
+		t.Fatalf("expected an aileron/sandbox-tools: tag, got %q", wantTag)
+	}
+	if pins[0].LocalTag != wantTag {
+		t.Errorf("composed pin LocalTag = %q, want %q", pins[0].LocalTag, wantTag)
 	}
 	if strings.Join(capSet, ",") != "gh@2,aws-cli@2.x" {
 		t.Errorf("resolved capability set = %v, want the declared tools verbatim", capSet)
@@ -374,6 +396,14 @@ func TestResolveImages_DistinctToolSetsDistinctPins(t *testing.T) {
 	if pinsA[0].Digest == pinsB[0].Digest {
 		t.Errorf("distinct tool sets must produce distinct pinned digests, both pinned %q", pinsA[0].Digest)
 	}
+	// Tag collision-freedom carries through freeze: distinct tool sets get
+	// distinct bootable local tags.
+	if pinsA[0].LocalTag == "" || pinsB[0].LocalTag == "" {
+		t.Fatalf("each composed pin must carry a LocalTag, got A=%q B=%q", pinsA[0].LocalTag, pinsB[0].LocalTag)
+	}
+	if pinsA[0].LocalTag == pinsB[0].LocalTag {
+		t.Errorf("distinct tool sets must produce distinct LocalTags, both %q", pinsA[0].LocalTag)
+	}
 	if strings.Join(capA, ",") != "aws-cli@2.x" {
 		t.Errorf("resolved capability set must record the declared tools, got %v", capA)
 	}
@@ -384,5 +414,8 @@ func TestResolveImages_DistinctToolSetsDistinctPins(t *testing.T) {
 	}
 	if pinsA2[0].Digest != pinsA[0].Digest {
 		t.Errorf("the same tool set must reproduce the same pin: %q vs %q", pinsA2[0].Digest, pinsA[0].Digest)
+	}
+	if pinsA2[0].LocalTag != pinsA[0].LocalTag {
+		t.Errorf("the same tool set must reproduce the same LocalTag: %q vs %q", pinsA2[0].LocalTag, pinsA[0].LocalTag)
 	}
 }

--- a/internal/flightplan/freeze/lock.go
+++ b/internal/flightplan/freeze/lock.go
@@ -9,11 +9,19 @@ import (
 
 // ImagePin pairs a pre-freeze image reference with the content-addressed
 // digest freeze resolved it to. The schema `$defs.lock.resolvedImages[]` item
-// admits exactly {ref, digest}: the plan runs in one container, so freeze
+// admits {ref, digest, localTag?}: the plan runs in one container, so freeze
 // emits at most one pin and no per-pin step linkage.
 type ImagePin struct {
 	Ref    string `yaml:"ref" json:"ref"`
 	Digest string `yaml:"digest" json:"digest"`
+	// LocalTag is the bootable local-daemon tag for a composed-tools pin
+	// (`aileron/sandbox-tools:<hex>`), the identity the composed image carries
+	// in the local daemon. It is set only on the composed-tools pin: an
+	// image-only or custom-base pin leaves it empty and boots `ref@digest`.
+	// omitempty keeps those non-composed locks byte-identical to the
+	// pre-localTag format. Sealed inside the signed lock (covered by the
+	// content hash and signature), so it cannot be re-supplied at launch.
+	LocalTag string `yaml:"localTag,omitempty" json:"localTag,omitempty"`
 }
 
 // StepReach is the sealed network reach for one tool step: the `hosts` from

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -627,6 +627,11 @@
                 "type": "string",
                 "description": "The resolved content-addressed digest.",
                 "pattern": "^sha256:[a-f0-9]{64}$"
+              },
+              "localTag": {
+                "type": "string",
+                "description": "The bootable local-daemon tag the runtime boots for a composed-tools pin (aileron/sandbox-tools:<hex>). Present only on a composed-tools pin; absent for a directly-pinned base, which boots ref@digest.",
+                "minLength": 1
               }
             }
           }

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -177,6 +177,16 @@ func TestLockResolvedImagesSinglePinShape(t *testing.T) {
 			t.Fatal("an unknown key on a resolvedImages item must be rejected")
 		}
 	})
+	t.Run("valid/composed pin carries localTag", func(t *testing.T) {
+		if err := validateFrontmatter(lockFrontmatter(item("\n        localTag: aileron/sandbox-tools:0123456789abcdef"))); err != nil {
+			t.Fatalf("a pin carrying a bootable localTag must validate, got: %v", err)
+		}
+	})
+	t.Run("invalid/empty localTag rejected", func(t *testing.T) {
+		if err := validateFrontmatter(lockFrontmatter(item("\n        localTag: \"\""))); err == nil {
+			t.Fatal("an empty-string localTag must be rejected by minLength: 1")
+		}
+	})
 }
 
 // TestLockStepTrust locks the step-keyed sealed trust section at the schema

--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -38,7 +38,7 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 			"flightplan: frozen unit pins image %q but no image runner is configured", pin.Ref)
 	}
 	spec := ImageRunSpec{
-		Image:   imageRef(pin.Ref, pin.Digest),
+		Image:   imageRef(pin.Ref, pin.Digest, pin.LocalTag),
 		Name:    opts.Name,
 		Version: opts.Version,
 		Inputs:  opts.Inputs,
@@ -57,13 +57,26 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 	}, nil
 }
 
-// imageRef composes the `ref@digest` string the runner boots. Freeze records
-// the digest as a bare `sha256:<hex>`, so the ref and digest are joined with
-// `@`. An empty digest degrades to the bare ref rather than a dangling `@`. The
-// digest is the content-addressed identity, so a runner handed this string
-// boots the exact image the signature attested rather than resolving the
-// mutable tag.
-func imageRef(ref, digest string) string {
+// imageRef composes the image identity the runner boots, reading only from the
+// verified lock pin so the boot target is never a re-parse of untrusted bytes.
+//
+// A composed-tools pin carries a localTag: the local-daemon tag
+// (`aileron/sandbox-tools:<hex>`) the composed image actually carries in the
+// daemon. That image was built locally, so its recorded digest is the image Id
+// rather than a registry digest; `tag@digest` would not resolve. imageRef
+// therefore boots the localTag verbatim when present. The tag is a value from
+// the signed lock (covered by the content hash and signature), so booting it
+// preserves the boot-straight-from-the-verified-lock property.
+//
+// Otherwise (an image-only or custom-base pin) the ref is a real registry ref
+// and the digest a real registry digest, so `ref@digest` is a correct
+// content-addressed boot reference: the runner boots the exact image the
+// signature attested rather than resolving the mutable tag. An empty digest
+// degrades to the bare ref rather than a dangling `@`.
+func imageRef(ref, digest, localTag string) string {
+	if localTag != "" {
+		return localTag
+	}
 	if digest == "" {
 		return ref
 	}

--- a/internal/flightplan/runtime/image_test.go
+++ b/internal/flightplan/runtime/image_test.go
@@ -57,6 +57,42 @@ func TestRunInImage_BootsExactPinnedImage(t *testing.T) {
 	}
 }
 
+func TestRunInImage_BootsComposedLocalTag(t *testing.T) {
+	// A composed-tools pin carries a descriptive, unbootable Ref and an image-Id
+	// Digest, plus the bootable local-daemon tag in LocalTag. The runtime must
+	// boot the LocalTag verbatim (the daemon-resolvable identity), never the
+	// `ref@digest` join, which names no image the daemon can resolve. This is the
+	// #1856 regression: before the fix imageRef produced the unbootable join and
+	// the boot failed closed.
+	localTag := "aileron/sandbox-tools:0123456789abcdef"
+	descriptiveRef := "ghcr.io/alrubinger/aileron-sandbox-base:edge@sha256:" +
+		strings.Repeat("a", 64) + "+tools(gh@2.x)"
+	imageID := "sha256:" + strings.Repeat("b", 64)
+	lp := LoadedPlan{
+		ContentHash: "sha256:content",
+		ResolvedImages: []freeze.ImagePin{
+			{Ref: descriptiveRef, Digest: imageID, LocalTag: localTag},
+		},
+	}
+	fake := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+	if _, err := runInImage(context.Background(), lp, Options{
+		Name:        "tools-plan",
+		Version:     "1.0.0",
+		ImageRunner: fake,
+	}); err != nil {
+		t.Fatalf("runInImage: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("the image runner was never called")
+	}
+	if fake.spec.Image != localTag {
+		t.Errorf("booted image = %q, want the bootable local tag %q", fake.spec.Image, localTag)
+	}
+	if strings.Contains(fake.spec.Image, "@"+imageID) || strings.Contains(fake.spec.Image, "+tools(") {
+		t.Errorf("booted the unbootable ref@digest join %q, want the local tag", fake.spec.Image)
+	}
+}
+
 func TestRunInImage_PinnedButNoRunnerErrors(t *testing.T) {
 	// A plan that declares and pins an environment image but supplies no ImageRunner is
 	// an explicit error, never a silent in-process fallback: ignoring the pin
@@ -141,12 +177,17 @@ func TestHasWholePlanImage(t *testing.T) {
 }
 
 func TestImageRef_JoinsRefAndDigest(t *testing.T) {
-	got := imageRef("registry.example.com/runner:1.4", "sha256:abc")
+	got := imageRef("registry.example.com/runner:1.4", "sha256:abc", "")
 	if got != "registry.example.com/runner:1.4@sha256:abc" {
 		t.Errorf("imageRef = %q", got)
 	}
 	// An empty digest degrades to the bare ref rather than a dangling `@`.
-	if got := imageRef("r", ""); got != "r" {
+	if got := imageRef("r", "", ""); got != "r" {
 		t.Errorf("imageRef with empty digest = %q, want the bare ref", got)
+	}
+	// A non-empty local tag wins over the ref@digest join: it is the
+	// daemon-resolvable identity of a locally-built composed image.
+	if got := imageRef("registry.example.com/runner:1.4", "sha256:abc", "aileron/sandbox-tools:x"); got != "aileron/sandbox-tools:x" {
+		t.Errorf("imageRef with local tag = %q, want the local tag", got)
 	}
 }

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -122,8 +122,9 @@ func TestRun_DeniedApprovalAbortsAndAudits(t *testing.T) {
 }
 
 // TestRun_BootsPinnedImageWhenLockPinsEnvironment proves the boot branch end to end:
-// the worked example declares an environment, so a store-backed Run delegates to the wired
-// ImageRunner with the exact ref@digest from the verified lock and never walks
+// the worked example declares tools, so freeze records a composed pin carrying a
+// bootable local-daemon tag. A store-backed Run delegates to the wired
+// ImageRunner with that local tag from the verified lock (#1856) and never walks
 // the in-process pipeline.
 func TestRun_BootsPinnedImageWhenLockPinsEnvironment(t *testing.T) {
 	fv := frozenExample(t)
@@ -131,7 +132,16 @@ func TestRun_BootsPinnedImageWhenLockPinsEnvironment(t *testing.T) {
 	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
 		t.Fatalf("WriteFrozen: %v", err)
 	}
-	wantDigest := "sha256:" + strings.Repeat("a", 64)
+	// The verified lock's composed pin carries the bootable local tag; the boot
+	// must hand that verbatim to the runner, not the unbootable ref@digest join.
+	lp, err := verifyAndDecode(fv)
+	if err != nil {
+		t.Fatalf("verifyAndDecode: %v", err)
+	}
+	wantTag := lp.ResolvedImages[0].LocalTag
+	if wantTag == "" || !strings.HasPrefix(wantTag, "aileron/sandbox-tools:") {
+		t.Fatalf("expected a composed pin with an aileron/sandbox-tools: local tag, got %q", wantTag)
+	}
 	fake := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:booted"}}
 	res, err := Run(context.Background(), Options{
 		Store:       s,
@@ -147,8 +157,8 @@ func TestRun_BootsPinnedImageWhenLockPinsEnvironment(t *testing.T) {
 	if !fake.called {
 		t.Fatal("Run did not delegate to the ImageRunner for an environment-pinned unit")
 	}
-	if !strings.HasSuffix(fake.spec.Image, "@"+wantDigest) {
-		t.Errorf("booted image = %q, want it to end with @%s", fake.spec.Image, wantDigest)
+	if fake.spec.Image != wantTag {
+		t.Errorf("booted image = %q, want the composed pin's local tag %q", fake.spec.Image, wantTag)
 	}
 	if res.ContentHash != "sha256:booted" {
 		t.Errorf("RunResult.ContentHash = %q, want the runner's result", res.ContentHash)


### PR DESCRIPTION
## Summary

A tools-declaring frozen plan failed closed at launch (P1). Freeze composes the declared tools onto the digest-pinned base and tags the built image in the local daemon as `composition.LocalToolsImageTag(base, features)` (`aileron/sandbox-tools:<hex>`), but recorded the composed pin with a **descriptive, unbootable** `Ref` (`<base>@sha256:...+tools(...)`) whose local image `Id` was joined as `ref@digest`. No such reference exists in the daemon, so boot failed even though the image was present under the local tag.

This adds a `LocalTag` field to the signed `ImagePin` lock struct carrying the bootable local-daemon tag for a composed-tools pin:

- **Freeze** populates `LocalTag = composition.LocalToolsImageTag(pinnedBase, featureRefs)`, computed from the *same* `pinnedBase` and catalog-resolved `featureRefs` the composer received, so it is byte-identical to the tag the built image carries (`LocalToolsImageTag` sorts internally, so declaration order does not matter). Image-only / custom-base pins leave it empty.
- **Runtime** (`imageRef`) boots the `LocalTag` verbatim when present, reading only from the verified lock (preserving "boot straight from the verified lock, never a re-parse"). Otherwise it falls back to the existing `ref@digest` join for registry pins.
- **`Ref`** stays the human-readable descriptive record (useful in errors/audit, keeps `ref` `minLength: 1` satisfied). **`Digest`** stays the composed image's content address (still attesting the composition).
- The tag is **sealed inside the signed lock** (covered by content hash + signature), so it cannot be re-supplied at launch.

Both schema copies (doc `docs/schema/...` + embedded `internal/flightplan/manifest/...`) gain an optional `localTag` (`type: string`, `minLength: 1`); `omitempty` keeps non-composed locks byte-identical to the pre-`localTag` format. No compat shim (pre-release).

### Scope

No change to the composition package, the production composer in `cmd/aileron/skill_freeze.go`, `container.Builder`, approval gating, or OpenAPI. Independent of #1857.

## Test plan

- `internal/flightplan/manifest`: schema drift guard (`TestEmbeddedSchemaMatchesDoc`) passes after the embedded-copy refresh; added validation cases asserting a `localTag` validates and an empty-string `localTag` is rejected by `minLength: 1`.
- `internal/flightplan/freeze`: extended tools-compose tests assert the composed pin's `LocalTag == LocalToolsImageTag(pinnedBase, featureRefs)`; image-only pin asserts `LocalTag == ""`; distinct tool sets yield distinct/deterministic `LocalTag`s. New `TestRun_ComposedLocalTagIsSigned` proves the tag is sealed: a mutated `localTag` fails signature verification.
- `internal/flightplan/runtime`: new regression test `TestRunInImage_BootsComposedLocalTag` boots the local tag (asserts it is **not** the unbootable `ref@digest` string); `TestRunInImage_BootsExactPinnedImage` still boots `ref@digest` for a registry pin (non-composed path unregressed); `TestImageRef_JoinsRefAndDigest` updated for the new signature (local tag wins).
- `cmd/aileron`: launch + freeze CLI tests over the tools worked example now assert the bootable local tag / `localTag:` in the emitted lock.
- Full `internal` and `cmd/aileron` module test suites green; `go build ./...` and `go vet` clean.

Closes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
