### PR TITLE
fix(proxybinding): reject placeholder values, warn on suspect sigv4 keys

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -269,16 +269,23 @@ var daemonUnitLayers = func(ctx context.Context) ([]capture.CaptureDescriptor, [
 // and preserves today's defaults-only table. A present-but-malformed unit, or
 // a malformed descriptor in any layer, fails construction loudly rather than
 // silently shipping an empty (passthrough) table.
-func assembleHostBindings(ctx context.Context) (binding.HostBindings, error) {
+func assembleHostBindings(ctx context.Context, log *slog.Logger) (binding.HostBindings, error) {
 	_, sealingLayer, err := daemonUnitLayers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("assemble host bindings: load image unit layer: %w", err)
 	}
 	opts := proxybinding.DefaultLoadOptions()
 	opts.ExtraEntries = sealingLayer
-	table, err := proxybinding.LoadHostBindings(opts)
+	table, warnings, err := proxybinding.LoadHostBindingsWithWarnings(opts)
 	if err != nil {
 		return nil, fmt.Errorf("assemble host bindings: %w", err)
+	}
+	// Warnings are non-fatal: a well-formed-but-suspect binding (e.g. a
+	// sigv4-resign access_key_id that does not match the AWS shape) is logged
+	// at startup so an operator sees the likely mistake before it fails at
+	// launch, without blocking daemon boot.
+	for _, w := range warnings {
+		log.Warn("host binding descriptor warning", "detail", w)
 	}
 	return table, nil
 }
@@ -544,7 +551,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// bindings now that #1323 removed the central github.yaml; its projection
 	// is byte-identical to that former default (pinned by internal/app's
 	// TestGHUnitDriftGuard).
-	server.hostBindings, err = assembleHostBindings(ctx)
+	server.hostBindings, err = assembleHostBindings(ctx, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/host_bindings_unit_layer_test.go
+++ b/internal/app/host_bindings_unit_layer_test.go
@@ -1,14 +1,24 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/auth/capture"
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/proxybinding"
 )
+
+// discardLogger is a no-op slog.Logger for tests that do not assert on log
+// output but must satisfy assembleHostBindings's logger parameter.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 // swapDaemonUnitLayers substitutes the image-derived unit-layer seam for the
 // duration of a test, restoring the production resolver afterward.
@@ -28,7 +38,7 @@ func TestAssembleHostBindings_NoUnitLayerEqualsDefaults(t *testing.T) {
 		return nil, nil, nil
 	})
 
-	table, err := assembleHostBindings(context.Background())
+	table, err := assembleHostBindings(context.Background(), discardLogger())
 	if err != nil {
 		t.Fatalf("assembleHostBindings: %v", err)
 	}
@@ -53,7 +63,7 @@ func TestAssembleHostBindings_UnitLayerIsAdditive(t *testing.T) {
 		return nil, sealing, nil
 	})
 
-	table, err := assembleHostBindings(context.Background())
+	table, err := assembleHostBindings(context.Background(), discardLogger())
 	if err != nil {
 		t.Fatalf("assembleHostBindings: %v", err)
 	}
@@ -69,6 +79,39 @@ func TestAssembleHostBindings_UnitLayerIsAdditive(t *testing.T) {
 	}
 }
 
+// TestAssembleHostBindings_SuspectSigV4KeyWarnsButLoads proves a well-formed
+// sigv4-resign entry whose access_key_id does not match the AWS shape loads
+// successfully (does not block boot) and is surfaced as a startup warning
+// naming the field, per the warn-only contract.
+func TestAssembleHostBindings_SuspectSigV4KeyWarnsButLoads(t *testing.T) {
+	swapDaemonUnitLayers(t, func(context.Context) ([]capture.CaptureDescriptor, []proxybinding.Entry, error) {
+		sealing := []proxybinding.Entry{{
+			Host:          "example.execute-api.us-east-1.amazonaws.com",
+			CredentialRef: "user/aws",
+			Scheme:        binding.SchemeSigV4Resign,
+			AccessKeyID:   "not-a-valid-shape",
+			Region:        "us-east-1",
+			Service:       "execute-api",
+		}}
+		return nil, sealing, nil
+	})
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+
+	table, err := assembleHostBindings(context.Background(), log)
+	if err != nil {
+		t.Fatalf("assembleHostBindings: suspect key must not block boot: %v", err)
+	}
+	if _, ok := table.Match("example.execute-api.us-east-1.amazonaws.com"); !ok {
+		t.Error("suspect-key binding must still be present in the table")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "access_key_id") || !strings.Contains(out, "not-a-valid-shape") {
+		t.Errorf("expected a startup warning naming access_key_id and the value; got: %q", out)
+	}
+}
+
 // TestAssembleHostBindings_MalformedUnitFailsLoudly proves a present-but-broken
 // unit (a seam error) fails table construction loudly rather than degrading to
 // a defaults-only or empty table.
@@ -78,7 +121,7 @@ func TestAssembleHostBindings_MalformedUnitFailsLoudly(t *testing.T) {
 		return nil, nil, wantErr
 	})
 
-	_, err := assembleHostBindings(context.Background())
+	_, err := assembleHostBindings(context.Background(), discardLogger())
 	if err == nil {
 		t.Fatal("assembleHostBindings = nil error, want the unit-layer error surfaced")
 	}

--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -66,11 +66,31 @@ func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
 // than swallowed so a malformed descriptor fails construction loudly
 // instead of silently shipping an empty (passthrough) table.
 func LoadHostBindings(opts LoadOptions) (binding.HostBindings, error) {
+	table, _, err := LoadHostBindingsWithWarnings(opts)
+	return table, err
+}
+
+// LoadHostBindingsWithWarnings is LoadHostBindings plus the non-fatal
+// startup warnings aggregated from the merged entries (see [Entry.Warnings]).
+// Warnings never block construction; the caller (the daemon boot path) logs
+// them so an operator sees a suspect-but-well-formed binding before it fails
+// at launch. Warnings are collected from the post-merge entry set, so a
+// warning reflects the entry that actually reaches the table (a user override
+// is warned on, the shadowed built-in is not).
+func LoadHostBindingsWithWarnings(opts LoadOptions) (binding.HostBindings, []string, error) {
 	entries, err := Load(opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return ToHostBindings(entries)
+	var warnings []string
+	for i := range entries {
+		warnings = append(warnings, entries[i].Warnings()...)
+	}
+	table, err := ToHostBindings(entries)
+	if err != nil {
+		return nil, nil, err
+	}
+	return table, warnings, nil
 }
 
 // ToHostBindings adapts a slice of validated entries into a

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -39,12 +39,38 @@ package proxybinding
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/credential/inject"
 )
+
+// placeholderPattern matches an angle-bracket span (e.g. "<AccessKeyId>",
+// "<token>", "<your-region>"). A descriptor author who copies a template
+// verbatim and leaves an un-substituted placeholder in a parsed value ships
+// a binding that authenticates nothing: at launch time the credential-sealing
+// path emits the literal placeholder upstream and the request fails with an
+// opaque provider error (the reported case was a sigv4-resign entry with
+// access_key_id "<AccessKeyId>" surfacing as UnrecognizedClientException).
+// Any string field carrying such a span is a load-time error so the daemon
+// fails loudly at boot rather than at launch. Descriptor comments are not
+// parsed values, so a "<...>" in a YAML comment is never scanned; the
+// header-template "{token}" slot uses braces, not angle brackets, so it is
+// unaffected.
+var placeholderPattern = regexp.MustCompile(`<[^>]+>`)
+
+// sigv4AccessKeyIDPattern is the canonical shape of an AWS access key ID used
+// by the sigv4-resign scheme: an "AKIA" (long-term) or "ASIA" (temporary/STS)
+// prefix followed by 16 uppercase-alphanumeric characters. A well-formed
+// descriptor whose access_key_id does not match this shape still loads (the
+// value is non-secret and AWS may evolve the format), but it is surfaced as a
+// non-fatal startup warning so a typo'd or placeholder-shaped key is visible
+// before it fails at launch. This is intentionally warn-only: the repository's
+// own SigV4 test vector uses the documented "AKIDEXAMPLE" key, which must keep
+// loading clean.
+var sigv4AccessKeyIDPattern = regexp.MustCompile(`^(AKIA|ASIA)[A-Z0-9]{16}$`)
 
 // SchemaVersion is the only descriptor schema version this loader
 // understands. The format is versioned so it can evolve under 0.0.x
@@ -259,6 +285,15 @@ func Parse(data []byte) (Descriptor, error) {
 // credential-ref legality: there is exactly one matcher and one name
 // contract, not two.
 func (e *Entry) Validate() error {
+	// Reject un-substituted template placeholders before any other check.
+	// An angle-bracket span in a parsed value (e.g. access_key_id
+	// "<AccessKeyId>") is never legitimate: it means an author left a
+	// copy-paste placeholder in place, so fail closed at boot naming the
+	// field rather than shipping a binding that authenticates nothing.
+	if err := e.rejectPlaceholders(); err != nil {
+		return err
+	}
+
 	if e.Host == "" {
 		return fmt.Errorf("missing required field: host")
 	}
@@ -338,6 +373,72 @@ func (e *Entry) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// rejectPlaceholders scans every string field of the Entry for an
+// angle-bracket span and returns a field-named error on the first match. It
+// is the load-time guard against un-substituted template placeholders. Parse
+// wraps the returned error with the binding index and host, and
+// Load/parseLayerFile wrap it with the user file path, so the operator sees
+// file + entry + field. Slice fields (allowed_hosts) are scanned per element
+// with the index named.
+func (e *Entry) rejectPlaceholders() error {
+	type namedField struct {
+		name  string
+		value string
+	}
+	fields := []namedField{
+		{"host", e.Host},
+		{"credential_ref", e.CredentialRef},
+		{"scheme", e.Scheme},
+		{"emit_mechanism", e.EmitMechanism},
+		{"username", e.Username},
+		{"header", e.Header},
+		{"template", e.Template},
+		{"query_param", e.QueryParam},
+		{"access_key_id", e.AccessKeyID},
+		{"region", e.Region},
+		{"service", e.Service},
+		{"effect", e.Effect},
+	}
+	if e.Sentinel != nil {
+		fields = append(fields,
+			namedField{"sentinel.value", e.Sentinel.Value},
+			namedField{"sentinel.env", e.Sentinel.Env},
+		)
+	}
+	for i, h := range e.AllowedHosts {
+		fields = append(fields, namedField{fmt.Sprintf("allowed_hosts[%d]", i), h})
+	}
+	for _, f := range fields {
+		if match := placeholderPattern.FindString(f.value); match != "" {
+			return fmt.Errorf("field %s contains an un-substituted template placeholder %q; replace it with a real value", f.name, match)
+		}
+	}
+	return nil
+}
+
+// Warnings returns non-fatal advisories about a well-formed Entry that loads
+// successfully but is suspect. Unlike [Entry.Validate], a warning never blocks
+// boot: it is logged at daemon startup so an operator sees a likely mistake
+// before it fails at launch. The strings name the offending field and value so
+// the aggregating caller can prefix them with the file and entry context.
+//
+// Today the only warning is a sigv4-resign access_key_id that does not match
+// the canonical AWS shape ([sigv4AccessKeyIDPattern]). This is warn-only by
+// design: the value is non-secret, the AWS format may evolve, and the
+// documented "AKIDEXAMPLE" test vector must keep loading clean, so a
+// shape mismatch is surfaced without failing construction.
+func (e *Entry) Warnings() []string {
+	var out []string
+	if e.Scheme == string(inject.SchemeSigV4Resign) &&
+		e.AccessKeyID != "" &&
+		!sigv4AccessKeyIDPattern.MatchString(e.AccessKeyID) {
+		out = append(out, fmt.Sprintf(
+			"binding %q: sigv4-resign access_key_id %q does not match the expected AWS access key ID shape (AKIA/ASIA + 16 uppercase alphanumerics); verify it is correct",
+			e.Host, e.AccessKeyID))
+	}
+	return out
 }
 
 // schemeNames returns the closed scheme set as plain strings, for error

--- a/internal/proxybinding/placeholder_test.go
+++ b/internal/proxybinding/placeholder_test.go
@@ -1,0 +1,199 @@
+package proxybinding
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// TestLoad_RejectsPlaceholderAccessKeyID is the regression for feedback #1872:
+// a user descriptor that leaves the sigv4-resign access_key_id as the
+// copy-paste placeholder "<AccessKeyId>" must fail Load at daemon boot with a
+// field-named error, instead of loading and failing at launch with an opaque
+// UnrecognizedClientException. The error must name the file (Load wraps with
+// the user path), the entry (Parse wraps with the binding index+host), and the
+// field.
+func TestLoad_RejectsPlaceholderAccessKeyID(t *testing.T) {
+	dir := t.TempDir()
+	body := "version: v1\n" +
+		"bindings:\n" +
+		"  - host: s3.amazonaws.com\n" +
+		"    credential_ref: user/aws\n" +
+		"    scheme: sigv4-resign\n" +
+		"    access_key_id: <AccessKeyId>\n" +
+		"    region: us-east-1\n" +
+		"    service: s3\n"
+	path := writeDescriptor(t, dir, "user.yaml", body)
+
+	_, err := Load(LoadOptions{UserPath: path})
+	if err == nil {
+		t.Fatal("Load = nil error, want a load-time rejection of the placeholder access_key_id")
+	}
+	msg := err.Error()
+	for _, want := range []string{"access_key_id", "<AccessKeyId>", "s3.amazonaws.com", path} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q (want file+entry+field naming)", msg, want)
+		}
+	}
+}
+
+// TestValidate_RejectsPlaceholderInEveryStringField proves the placeholder
+// guard covers every scanned string field, not just access_key_id. Each case
+// injects a "<...>" span into one field of an otherwise-valid entry and
+// expects a field-named error.
+func TestValidate_RejectsPlaceholderInEveryStringField(t *testing.T) {
+	cases := []struct {
+		field string
+		mut   func(e *Entry)
+	}{
+		{"host", func(e *Entry) { e.Host = "<host>" }},
+		{"credential_ref", func(e *Entry) { e.CredentialRef = "user/<svc>" }},
+		{"scheme", func(e *Entry) { e.Scheme = "<scheme>" }},
+		{"emit_mechanism", func(e *Entry) { e.EmitMechanism = "<mech>" }},
+		{"username", func(e *Entry) { e.Scheme = binding.SchemeBasic; e.Username = "<user>" }},
+		{"header", func(e *Entry) { e.Scheme = binding.SchemeHeaderTemplate; e.Header = "<hdr>"; e.Template = "{token}" }},
+		{"template", func(e *Entry) {
+			e.Scheme = binding.SchemeHeaderTemplate
+			e.Header = "Authorization"
+			e.Template = "<tpl>"
+		}},
+		{"query_param", func(e *Entry) { e.Scheme = binding.SchemeQueryParam; e.QueryParam = "<qp>" }},
+		{"access_key_id", func(e *Entry) {
+			e.Scheme = binding.SchemeSigV4Resign
+			e.AccessKeyID = "<AccessKeyId>"
+			e.Region = "us-east-1"
+			e.Service = "s3"
+		}},
+		{"region", func(e *Entry) {
+			e.Scheme = binding.SchemeSigV4Resign
+			e.AccessKeyID = "AKIAIOSFODNN7EXAMPLE"
+			e.Region = "<region>"
+			e.Service = "s3"
+		}},
+		{"service", func(e *Entry) {
+			e.Scheme = binding.SchemeSigV4Resign
+			e.AccessKeyID = "AKIAIOSFODNN7EXAMPLE"
+			e.Region = "us-east-1"
+			e.Service = "<service>"
+		}},
+		{"effect", func(e *Entry) { e.Effect = "<effect>" }},
+		{"allowed_hosts[0]", func(e *Entry) { e.AllowedHosts = []string{"<host>"} }},
+		{"sentinel.value", func(e *Entry) {
+			e.EmitMechanism = string(binding.EmitMechanismSentinelSwap)
+			e.Sentinel = &Sentinel{Value: "<value>", Env: "GH_TOKEN"}
+		}},
+		{"sentinel.env", func(e *Entry) {
+			e.EmitMechanism = string(binding.EmitMechanismSentinelSwap)
+			e.Sentinel = &Sentinel{Value: "ghp_placeholder", Env: "<ENV>"}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			e := &Entry{
+				Host:          "api.example.com",
+				CredentialRef: "user/example",
+				Scheme:        binding.SchemeBearer,
+			}
+			tc.mut(e)
+			err := e.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want placeholder rejection for %s", tc.field)
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error %q does not name field %q", err.Error(), tc.field)
+			}
+		})
+	}
+}
+
+// TestLoad_AKIDEXAMPLEAndBuiltinsLoadClean proves the placeholder guard and the
+// warn-only sigv4 shape check produce no false positives: the repository's own
+// documented SigV4 test vector "AKIDEXAMPLE" loads and produces no warning that
+// would block boot, and the embedded built-in defaults (Linear) load clean.
+func TestLoad_AKIDEXAMPLEAndBuiltinsLoadClean(t *testing.T) {
+	// Built-in defaults must load without error.
+	if _, err := Load(LoadOptions{}); err != nil {
+		t.Fatalf("built-in defaults must load clean: %v", err)
+	}
+
+	dir := t.TempDir()
+	body := "version: v1\n" +
+		"bindings:\n" +
+		"  - host: s3.amazonaws.com\n" +
+		"    credential_ref: user/aws\n" +
+		"    scheme: sigv4-resign\n" +
+		"    access_key_id: AKIDEXAMPLE\n" +
+		"    region: us-east-1\n" +
+		"    service: s3\n"
+	path := writeDescriptor(t, dir, filepath.Base("aws-user.yaml"), body)
+
+	table, warnings, err := LoadHostBindingsWithWarnings(LoadOptions{UserPath: path})
+	if err != nil {
+		t.Fatalf("AKIDEXAMPLE vector must load clean, not error: %v", err)
+	}
+	if _, ok := table.Match("s3.amazonaws.com"); !ok {
+		t.Error("AKIDEXAMPLE binding must be present in the table")
+	}
+	// AKIDEXAMPLE does not match the AKIA/ASIA shape, so warn-only surfaces a
+	// warning; the load must still succeed (it did above). The contract is:
+	// warn, do not block. We only assert it loaded; a warning here is allowed.
+	_ = warnings
+}
+
+// TestLoadWithWarnings_SuspectSigV4KeyWarns proves a well-formed sigv4-resign
+// entry with a wrong-shaped access_key_id loads successfully but is surfaced as
+// a non-fatal warning naming the field and value.
+func TestLoadWithWarnings_SuspectSigV4KeyWarns(t *testing.T) {
+	dir := t.TempDir()
+	body := "version: v1\n" +
+		"bindings:\n" +
+		"  - host: s3.amazonaws.com\n" +
+		"    credential_ref: user/aws\n" +
+		"    scheme: sigv4-resign\n" +
+		"    access_key_id: totally-wrong-shape\n" +
+		"    region: us-east-1\n" +
+		"    service: s3\n"
+	path := writeDescriptor(t, dir, "user.yaml", body)
+
+	table, warnings, err := LoadHostBindingsWithWarnings(LoadOptions{UserPath: path})
+	if err != nil {
+		t.Fatalf("suspect-shape key must not block load: %v", err)
+	}
+	if _, ok := table.Match("s3.amazonaws.com"); !ok {
+		t.Error("suspect-key binding must still be present in the table")
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for the wrong-shaped access_key_id, got none")
+	}
+	joined := strings.Join(warnings, "\n")
+	for _, want := range []string{"access_key_id", "totally-wrong-shape"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warning %q missing %q", joined, want)
+		}
+	}
+}
+
+// TestWarnings_WellShapedSigV4KeyIsSilent proves a canonical AKIA/ASIA-prefixed
+// access_key_id produces no warning, so the warn path does not cry wolf on
+// legitimate keys.
+func TestWarnings_WellShapedSigV4KeyIsSilent(t *testing.T) {
+	for _, key := range []string{"AKIAIOSFODNN7EXAMPLE", "ASIAY34FZKBOKMUTVV7A"} {
+		e := &Entry{
+			Host:          "s3.amazonaws.com",
+			CredentialRef: "user/aws",
+			Scheme:        binding.SchemeSigV4Resign,
+			AccessKeyID:   key,
+			Region:        "us-east-1",
+			Service:       "s3",
+		}
+		if err := e.Validate(); err != nil {
+			t.Fatalf("well-shaped key %q must validate: %v", key, err)
+		}
+		if w := e.Warnings(); len(w) != 0 {
+			t.Errorf("well-shaped key %q produced warnings: %v", key, w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds load-time validation to `Entry.Validate()` in `internal/proxybinding/descriptor.go`, addressing the reported incident where a binding descriptor with `access_key_id: <AccessKeyId>` loaded successfully and only failed at launch time with an opaque `UnrecognizedClientException`.

1. **Hard-reject un-substituted placeholders.** Every string field of an `Entry` (`host`, `credential_ref`, `scheme`, `emit_mechanism`, `username`, `header`, `template`, `query_param`, `access_key_id`, `region`, `service`, `allowed_hosts[]`, `effect`, `sentinel.value`, `sentinel.env`) is scanned for an angle-bracket span (`<[^>]+>`). Any match is a load-time error naming the field. `Parse` already wraps with the binding index+host and `Load`/`parseLayerFile` wrap with the user file path, so the resulting error names file + entry + field. Descriptor comments are not parsed values, and the header-template `{token}` slot uses braces, so there are no legitimate false positives.

2. **Warn-only on a suspect sigv4-resign `access_key_id`.** When `scheme == sigv4-resign` and the `access_key_id` does not match `^(AKIA|ASIA)[A-Z0-9]{16}$`, a non-fatal warning naming the field/value is aggregated through the load path (`LoadHostBindingsWithWarnings`) and logged at daemon startup via the `*slog.Logger` in scope at `NewHandlerWithConfig`. Boot is not blocked, and `AKIDEXAMPLE` is not special-cased, so the repo's own SigV4 test vector still loads.

The empty-region/empty-service hard reject on sigv4-resign entries (already present, stricter than a warn) is kept as-is.

Deferred to a follow-up per the triage Q2 answer: the `aileron status` host-bindings section and the launch preflight re-validation (additive surfaces, not required to convert the launch failure into a fast boot-time failure).

## Test plan

- `go build github.com/ALRubinger/aileron/internal/...` — clean.
- `go test .../internal/proxybinding/... .../internal/app/...` — green; proxybinding coverage 95.2%.
- New tests:
  - `TestLoad_RejectsPlaceholderAccessKeyID` — regression: `<AccessKeyId>` fails `Load` with a file+entry+field-named error (fails before the fix, passes after).
  - `TestValidate_RejectsPlaceholderInEveryStringField` — every scanned field rejects a placeholder and names the field.
  - `TestLoad_AKIDEXAMPLEAndBuiltinsLoadClean` — the `AKIDEXAMPLE` vector and the built-in defaults load without error.
  - `TestLoadWithWarnings_SuspectSigV4KeyWarns` — a wrong-shaped key loads but warns.
  - `TestWarnings_WellShapedSigV4KeyIsSilent` — canonical `AKIA`/`ASIA` keys stay silent.
  - `TestAssembleHostBindings_SuspectSigV4KeyWarnsButLoads` — the daemon wiring logs the warning without blocking boot.

Closes #1872

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup now surfaces non-fatal warnings for host-binding issues while still loading valid bindings.
  * Invalid placeholder values are now rejected during loading, preventing them from reaching runtime configuration.

* **Bug Fixes**
  * Improved handling of SigV4 access key values: malformed entries can still load with warnings, while well-formed values remain quiet.
  * Error messages now point more clearly to the specific field causing a problem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->