### PR TITLE
fix(vault): add user-scope vault put with hidden-input prompt

### DIFF
--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -26,6 +26,7 @@ const envVaultPassphrase = "AILERON_VAULT_PASSPHRASE"
 const vaultUsage = `usage:
   aileron vault init [--passphrase-file <path>]
   aileron vault put agents/<name>/<purpose> --from-file <path>
+  aileron vault put user/<service> [--from-file <path>]
   aileron vault delete <path-as-listed> [--yes]
   aileron vault list [--scope agent|user|all] [--prefix agents/] [--include-control-plane] [--json]
 
@@ -43,18 +44,26 @@ are removed from the local vault (where secret set writes them).
 Control-plane entries (connected-accounts/, llm-config/) are managed by
 the control plane, not this CLI.
 
-vault put remains agents-only: you create a binding with ` + "`binding setup`" + `,
-not ` + "`vault put`" + `.`
+vault put targets the agent namespace (agents/<name>/<purpose>, from a
+file) or the user namespace (user/<service>). For a user credential the
+value is entered at a hidden prompt by default, or read verbatim from
+--from-file. Routing user credentials through this verb base64-encodes
+them correctly on the wire; a hand-crafted curl PUT that passes a raw
+secret (a 40-char AWS secret key is itself valid base64) silently decodes
+to garbage. You still create a binding with ` + "`binding setup`" + `, not
+` + "`vault put`" + `.`
 
 // runVault dispatches `aileron vault <subcommand>`.
 //
 // init opens the local vault file directly (first-run flow); the
 // put/delete/list verbs are thin daemon-backed HTTP clients that never
-// open the vault file themselves. put is namespace-locked to
-// `agents/<name>/<purpose>` (you create a binding with `binding setup`,
-// not `vault put`); delete classifies the path and dispatches to the
-// matching namespace-scoped daemon endpoint (agents/, user/, or a
-// binding), so anything `vault list` prints is deletable.
+// open the vault file themselves. put targets the agent namespace
+// (agents/<name>/<purpose>, from a file) or the user namespace
+// (user/<service>, from a hidden prompt or a file) — you still create a
+// binding with `binding setup`, not `vault put`; delete classifies the
+// path and dispatches to the matching namespace-scoped daemon endpoint
+// (agents/, user/, or a binding), so anything `vault list` prints is
+// deletable.
 func runVault(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, vaultUsage)
@@ -159,57 +168,145 @@ type userSummary struct {
 	Metadata *vaultSummaryMetadata `json:"metadata,omitempty"`
 }
 
-// runVaultPut stores a credential envelope read verbatim from a file
-// at agents/<name>/<purpose> via the daemon. The file bytes are stored
-// as-is (whole-file read, no trailing-newline munging) since agent
-// credential files (Claude's .credentials.json, Codex's auth.json) are
-// exact-byte artifacts.
+// runVaultPut stores a credential envelope via the daemon. It dispatches
+// on the target namespace:
+//
+//   - agents/<name>/<purpose> — file-only. Agent credential files (Claude's
+//     .credentials.json, Codex's auth.json) are exact-byte JSON artifacts,
+//     so the bytes are read verbatim from --from-file (no trailing-newline
+//     munging) and there is no interactive entry.
+//   - user/<service> — the value may be entered at a hidden prompt (the
+//     default) or read from --from-file. User credentials are frequently
+//     raw secrets an operator holds in hand (an AWS secret key, an API
+//     token); typing one at a no-echo prompt keeps it out of argv and shell
+//     history, and — crucially — routing it through this verb base64-encodes
+//     it correctly on the wire. Hand-crafting the PUT with a raw
+//     already-"looks-like-base64" secret (a 40-char AWS secret key is valid
+//     base64) silently decodes to garbage server-side and later surfaces as
+//     AWS SignatureDoesNotMatch (#1822).
+//
+// Any other namespace is rejected before any HTTP call: you create a binding
+// with `binding setup`, not `vault put`.
 func runVaultPut(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("vault put", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	fromFile := flags.String("from-file", "", "Read the credential bytes verbatim from the named file")
-	flags.Bool("yes", false, "Accepted for symmetry with delete; put never prompts")
+	fromFile := flags.String("from-file", "", "Read the credential bytes verbatim from the named file (required for agents/, optional for user/)")
+	flags.Bool("yes", false, "Accepted for symmetry with delete; put never prompts for confirmation")
 	positionals, err := parseInterspersedFlags(flags, args)
 	if err != nil {
 		return 1
 	}
 	if len(positionals) != 1 {
 		fmt.Fprintln(stderr, "usage: aileron vault put agents/<name>/<purpose> --from-file <path>")
+		fmt.Fprintln(stderr, "       aileron vault put user/<service> [--from-file <path>]")
 		return 1
 	}
-	name, purpose, err := agentPathNameAndPurpose(positionals[0])
+	arg := positionals[0]
+	scope, _ := vaultscope.Classify(arg)
+	switch scope {
+	case vaultscope.ScopeAgent:
+		return runVaultPutAgent(arg, *fromFile, stdout, stderr)
+	case vaultscope.ScopeUser:
+		return runVaultPutUser(arg, *fromFile, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "error: vault put accepts agents/<name>/<purpose> or user/<service> (got %q)\n", arg)
+		fmt.Fprintln(stderr, "create a binding with `binding setup`, not `vault put`.")
+		return 1
+	}
+}
+
+// runVaultPutAgent stores an agent credential envelope read verbatim from a
+// file at agents/<name>/<purpose>. The file bytes are stored as-is
+// (whole-file read, no trailing-newline munging) since agent credential
+// files are exact-byte artifacts; interactive entry is deliberately not
+// offered for this namespace.
+func runVaultPutAgent(arg, fromFile string, stdout, stderr io.Writer) int {
+	// Classify already confirmed the agents/<name>/<purpose> shape, so this
+	// wrapper cannot error; the check is defensive.
+	name, purpose, err := agentPathNameAndPurpose(arg)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	if *fromFile == "" {
-		fmt.Fprintln(stderr, "error: --from-file <path> is required")
+	if fromFile == "" {
+		fmt.Fprintln(stderr, "error: --from-file <path> is required for agent credentials")
 		return 1
 	}
-	data, err := os.ReadFile(*fromFile)
+	data, err := os.ReadFile(fromFile)
 	if err != nil {
-		fmt.Fprintf(stderr, "error reading %q: %v\n", *fromFile, err)
+		fmt.Fprintf(stderr, "error reading %q: %v\n", fromFile, err)
 		return 1
 	}
 	if len(data) == 0 {
-		fmt.Fprintf(stderr, "error: %q is empty\n", *fromFile)
+		fmt.Fprintf(stderr, "error: %q is empty\n", fromFile)
+		return 1
+	}
+	return vaultPutCredential(agentCredentialPath(name, purpose), data,
+		"agents/"+name+"/"+purpose, stdout, stderr)
+}
+
+// runVaultPutUser stores a user-level credential envelope at user/<service>.
+// The value comes from --from-file (read verbatim) or, when that flag is
+// absent, an interactive hidden prompt on the controlling terminal so the
+// secret never reaches argv or shell history. Either way the bytes are
+// base64-encoded on the wire by agentCredentialsBody, which is the whole
+// point: it is the correct encoding the raw curl PUT footgun gets wrong
+// (#1822).
+func runVaultPutUser(arg, fromFile string, stdout, stderr io.Writer) int {
+	// Classify already confirmed the user/<service> shape and that <service>
+	// passes the allow-list; the check is defensive.
+	service, ok := vaultscope.UserServiceFromVaultPath(arg)
+	if !ok {
+		fmt.Fprintf(stderr, "error: invalid user service path %q\n", arg)
 		return 1
 	}
 
+	var data []byte
+	if fromFile != "" {
+		b, err := os.ReadFile(fromFile)
+		if err != nil {
+			fmt.Fprintf(stderr, "error reading %q: %v\n", fromFile, err)
+			return 1
+		}
+		data = b
+	} else {
+		// Hidden, no-echo entry mirrors `secret set`: print the prompt to
+		// stderr, then read with no additional prompt (promptPassphrase is an
+		// overridable var so tests can inject the typed value).
+		fmt.Fprintf(stderr, "Value for user/%s: ", service)
+		value, err := promptPassphrase("", nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stderr) // newline after hidden input
+		data = []byte(value)
+	}
+	if len(data) == 0 {
+		fmt.Fprintln(stderr, "error: value cannot be empty")
+		return 1
+	}
+	return vaultPutCredential(userCredentialDaemonPath(service), data,
+		"user/"+service, stdout, stderr)
+}
+
+// vaultPutCredential base64-encodes data into the shared AgentCredentials
+// wire shape, PUTs it to httpPath via the daemon, and maps the response to a
+// CLI exit code. label is the namespaced identifier echoed on success.
+func vaultPutCredential(httpPath string, data []byte, label string, stdout, stderr io.Writer) int {
 	body, err := json.Marshal(agentCredentialsBody{Value: data})
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	status, respBody, err := vaultDoRequest(http.MethodPut,
-		agentCredentialPath(name, purpose), body)
+	status, respBody, err := vaultDoRequest(http.MethodPut, httpPath, body)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
 	switch status {
 	case http.StatusNoContent:
-		fmt.Fprintf(stdout, "Stored agents/%s/%s\n", name, purpose)
+		fmt.Fprintf(stdout, "Stored %s\n", label)
 		return 0
 	case http.StatusLocked:
 		fmt.Fprintln(stderr, "error: vault is locked; unlock it first")
@@ -221,6 +318,15 @@ func runVaultPut(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(respBody))
 		return 1
 	}
+}
+
+// userCredentialDaemonPath builds the daemon path for a user-level
+// credential. The service segment is path-escaped defensively; callers pass
+// values already constrained by vaultscope.UserServiceFromVaultPath, but
+// escaping keeps a stray special character from corrupting the request. It
+// is the write-side twin of the DELETE path vaultDeleteTargetFor builds.
+func userCredentialDaemonPath(service string) string {
+	return "/vault/user/" + url.PathEscape(service) + "/credentials"
 }
 
 // vaultDeleteTarget describes a classified, CLI-deletable vault path: the
@@ -270,7 +376,7 @@ func vaultDeleteTargetFor(arg string) (vaultDeleteTarget, bool) {
 		service, _ := vaultscope.UserServiceFromVaultPath(arg)
 		label := "user/" + service
 		return vaultDeleteTarget{
-			httpPath:   "/vault/user/" + url.PathEscape(service) + "/credentials",
+			httpPath:   userCredentialDaemonPath(service),
 			label:      label,
 			successMsg: "Deleted " + label,
 			notFound:   "error: no credential entry for " + label,

--- a/cmd/aileron/vault_put_user_test.go
+++ b/cmd/aileron/vault_put_user_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// vault put user/<service> contract (#1822): the CLI verb replaces the raw
+// curl PUT that base64-mis-decoded secrets. These tests pin:
+//
+//   - an interactive (no --from-file) user put reads the value at a hidden
+//     prompt and base64-encodes it on the wire, so a raw secret that is
+//     itself valid base64 round-trips to the exact bytes typed;
+//   - --from-file stores file bytes verbatim to /vault/user/<service>/credentials;
+//   - a malformed <service> is rejected before any HTTP call;
+//   - an empty value (typed or from an empty file) is rejected before HTTP;
+//   - locked / no-vault daemon statuses map to non-zero exits.
+//
+// fakeVaultServer and scriptPrompt live in the sibling vault test files.
+
+// TestRunVaultPutUser_InteractiveRoundTripsBytesVerbatim is the core
+// regression: a 40-char AWS secret access key is every-byte valid base64, so
+// a raw write (the old curl PUT footgun) silently decodes it to garbage and
+// later surfaces as AWS SignatureDoesNotMatch. Routing it through
+// `vault put user/<service>` must base64-ENCODE it, so the daemon decodes
+// back to the exact bytes the operator typed.
+func TestRunVaultPutUser_InteractiveRoundTripsBytesVerbatim(t *testing.T) {
+	const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	defer scriptPrompt(secret)()
+
+	var wireValue, gotMethod, gotPath string
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		var raw struct {
+			Value string `json:"value"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		wireValue = raw.Value
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"put", "user/athena"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if gotMethod != http.MethodPut || gotPath != "/vault/user/athena/credentials" {
+		t.Errorf("request = %s %s, want PUT /vault/user/athena/credentials", gotMethod, gotPath)
+	}
+	// The wire value must be base64 of the typed secret, NOT the raw secret.
+	if wireValue == secret {
+		t.Fatalf("wire value is the raw secret %q; it must be base64-encoded", secret)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(wireValue)
+	if err != nil {
+		t.Fatalf("wire value %q is not valid base64: %v", wireValue, err)
+	}
+	if string(decoded) != secret {
+		t.Errorf("decoded wire value = %q, want the exact typed bytes %q", decoded, secret)
+	}
+	if wireValue != base64.StdEncoding.EncodeToString([]byte(secret)) {
+		t.Errorf("wire value = %q, want base64(%q)", wireValue, secret)
+	}
+	if !strings.Contains(stdout.String(), "Stored user/athena") {
+		t.Errorf("stdout = %q, want it to confirm the store", stdout.String())
+	}
+}
+
+// --from-file stores the file bytes verbatim (base64-encoded on the wire) at
+// the user endpoint, the same daemon path vault delete/list use.
+func TestRunVaultPutUser_FromFileRoundTrips(t *testing.T) {
+	fileBytes := []byte("gho_rawtokenbytes")
+	var received []byte
+	var gotPath string
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var body agentCredentialsBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		received = body.Value
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "tok")
+	if err := os.WriteFile(f, fileBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"put", "user/github", "--from-file", f}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if gotPath != "/vault/user/github/credentials" {
+		t.Errorf("path = %q, want /vault/user/github/credentials", gotPath)
+	}
+	if !bytes.Equal(received, fileBytes) {
+		t.Errorf("server received %q, want %q (verbatim)", received, fileBytes)
+	}
+	if !strings.Contains(stdout.String(), "Stored user/github") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+// A malformed <service> (uppercase, whitespace, empty, leading dash, or an
+// extra path segment) is rejected client-side before any HTTP call and
+// before any prompt, so a typo never reaches the daemon or blocks on stdin.
+func TestRunVaultPut_RejectsMalformedUserService(t *testing.T) {
+	for _, arg := range []string{"user/BAD", "user/has space", "user/", "user/-leading", "user/foo/bar"} {
+		called := false
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		})
+		var stdout, stderr bytes.Buffer
+		code := runVault([]string{"put", arg}, strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("arg %q: exit = 0, want non-zero for malformed service", arg)
+		}
+		if called {
+			t.Errorf("arg %q: HTTP issued for a rejected service", arg)
+		}
+	}
+}
+
+// An empty value — whether typed at the prompt or read from an empty file —
+// is rejected before any HTTP call.
+func TestRunVaultPutUser_EmptyValueRejectedNoHTTP(t *testing.T) {
+	t.Run("interactive", func(t *testing.T) {
+		defer scriptPrompt("")()
+		called := false
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		})
+		var stdout, stderr bytes.Buffer
+		code := runVault([]string{"put", "user/github"}, strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero for empty typed value")
+		}
+		if called {
+			t.Errorf("HTTP issued for empty typed value")
+		}
+		if !strings.Contains(stderr.String(), "empty") {
+			t.Errorf("stderr = %q, want an empty-value message", stderr.String())
+		}
+	})
+	t.Run("empty-file", func(t *testing.T) {
+		called := false
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		})
+		dir := t.TempDir()
+		f := filepath.Join(dir, "empty")
+		if err := os.WriteFile(f, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		code := runVault([]string{"put", "user/github", "--from-file", f}, strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("exit = 0, want non-zero for empty file")
+		}
+		if called {
+			t.Errorf("HTTP issued for empty file")
+		}
+	})
+}
+
+// Locked and no-vault daemon statuses map to a non-zero exit, mirroring the
+// agent branch.
+func TestRunVaultPutUser_LockedAndNoVault(t *testing.T) {
+	restore := scriptPrompt("a-secret", "a-secret")
+	defer restore()
+	for _, status := range []int{http.StatusLocked, http.StatusServiceUnavailable} {
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		})
+		var stdout, stderr bytes.Buffer
+		code := runVault([]string{"put", "user/github"}, strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("status %d: exit = 0, want non-zero", status)
+		}
+	}
+}
+
+// The user-put daemon path is the write-side twin of the delete path, so a
+// value typed at the prompt round-trips to the same endpoint vault delete
+// targets. This pins the escaping helper directly.
+func TestUserCredentialDaemonPath(t *testing.T) {
+	if got := userCredentialDaemonPath("github"); got != "/vault/user/github/credentials" {
+		t.Errorf("userCredentialDaemonPath(github) = %q, want /vault/user/github/credentials", got)
+	}
+}

--- a/cmd/aileron/vault_put_user_test.go
+++ b/cmd/aileron/vault_put_user_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -199,5 +200,89 @@ func TestRunVaultPutUser_LockedAndNoVault(t *testing.T) {
 func TestUserCredentialDaemonPath(t *testing.T) {
 	if got := userCredentialDaemonPath("github"); got != "/vault/user/github/credentials" {
 		t.Errorf("userCredentialDaemonPath(github) = %q, want /vault/user/github/credentials", got)
+	}
+}
+
+// vault put with the wrong number of positionals prints usage and makes no
+// HTTP call — the dispatcher never reaches a namespace branch.
+func TestRunVaultPut_WrongPositionalCount(t *testing.T) {
+	for _, args := range [][]string{{"put"}, {"put", "user/a", "user/b"}} {
+		called := false
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})
+		var stdout, stderr bytes.Buffer
+		code := runVault(args, strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("args %v: exit = 0, want non-zero", args)
+		}
+		if called {
+			t.Errorf("args %v: HTTP issued", args)
+		}
+		if !strings.Contains(stderr.String(), "usage:") {
+			t.Errorf("args %v: stderr = %q, want usage", args, stderr.String())
+		}
+	}
+}
+
+// A hidden-prompt read failure (e.g. no controlling terminal) surfaces a
+// non-zero exit and makes no HTTP call, so a failed read never stores an
+// empty or partial credential.
+func TestRunVaultPutUser_PromptError(t *testing.T) {
+	prev := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prev })
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		return "", io.ErrUnexpectedEOF
+	}
+	called := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"put", "user/github"}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("exit = 0, want non-zero on prompt error")
+	}
+	if called {
+		t.Errorf("HTTP issued despite prompt error")
+	}
+}
+
+// An unexpected daemon status surfaces the server code and body so the
+// operator sees what actually went wrong.
+func TestRunVaultPutUser_UnexpectedStatus(t *testing.T) {
+	defer scriptPrompt("a-secret")()
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	})
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"put", "user/github"}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("exit = 0, want non-zero for 500")
+	}
+	if !strings.Contains(stderr.String(), "server returned 500") {
+		t.Errorf("stderr = %q, want it to surface the 500", stderr.String())
+	}
+}
+
+// --from-file pointing at a missing file surfaces a read error before any
+// HTTP call.
+func TestRunVaultPutUser_FromFileMissing(t *testing.T) {
+	called := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"put", "user/github", "--from-file", filepath.Join(t.TempDir(), "nope")},
+		strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("exit = 0, want non-zero for missing file")
+	}
+	if called {
+		t.Errorf("HTTP issued for missing file")
+	}
+	if !strings.Contains(stderr.String(), "error reading") {
+		t.Errorf("stderr = %q, want a read error", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Operators storing user-level credentials had to hand-craft a `curl` PUT to `/v1/vault/user/{service}/credentials` with a base64-encoded secret. That endpoint takes `api.AgentCredentials.Value []byte`, which JSON-marshals as base64, so a raw 40-char AWS secret key (itself valid base64) silently decoded to garbage on the server and later surfaced as `AWS SignatureDoesNotMatch`.

This extends the existing daemon-backed `vault put` to the user namespace so operators stop hand-crafting curl PUTs:

- `aileron vault put user/<service>` prompts for the value at a **hidden, no-echo terminal prompt** (keeping the secret out of argv and shell history), or reads `--from-file`.
- It PUTs to `/vault/user/<service>/credentials`, base64-encoding the value correctly on the wire via the existing `agentCredentialsBody` — the whole point of routing through the verb instead of curl.
- `runVaultPut` now classifies the path with `vaultscope.Classify` and dispatches: `agents/<name>/<purpose>` stays **file-only** (exact-byte credential artifacts, unchanged behavior), `user/<service>` accepts a prompt or a file.
- `vault put`/`delete`/`list` are now a consistent namespace-general family; a malformed `<service>` is rejected client-side before any HTTP call or prompt.

Command spelling follows convention: `secret set` writes the LOCAL file vault (`secret/<name>`), a different backend from daemon-managed user credentials, so `vault put user/<service>` is the consistent choice rather than overloading `secret set --scope user`.

Scope is intentionally limited to the CLI verb. The OpenAPI spec and a `value_string` wire field are **not** touched — the operator flagged the CLI verb as the real fix and the wire kindness as optional.

## Test plan

New tests in `cmd/aileron/vault_put_user_test.go`:

- **Regression** (`TestRunVaultPutUser_InteractiveRoundTripsBytesVerbatim`): a hidden-prompt put of a 40-char AWS-secret-shaped string (every byte valid base64) is base64-**encoded** on the wire and decodes back to the exact typed bytes — proving the round-trip the raw curl PUT got wrong.
- `--from-file` round-trips file bytes verbatim to `/vault/user/<service>/credentials`.
- Malformed `<service>` (uppercase, whitespace, empty, leading dash, extra segment) rejected before any HTTP/prompt.
- Empty value (typed or empty file) rejected before HTTP.
- Locked / no-vault daemon statuses map to non-zero exits.

`go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and `go test ./cmd/aileron/ ./internal/app/ ./internal/vaultscope/` all pass.

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXrrs4h93XwcA52ayCe9UY
