### PR TITLE
fix(launch): stamp operator identity as human actor on launch audit records

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/user"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
@@ -23,7 +24,31 @@ import (
 // returns the daemon-backed implementation in production.
 var newLaunchDispatcher = func() runtime.ActionDispatcher { return daemonDispatcher{} }
 var newLaunchApprover = func() runtime.Approver { return daemonApprover{} }
-var newLaunchAuditSink = func(stderr io.Writer) runtime.AuditSink { return daemonAuditSink{stderr: stderr} }
+var newLaunchAuditSink = func(stderr io.Writer) runtime.AuditSink {
+	return daemonAuditSink{stderr: stderr, actorID: operatorActorID()}
+}
+
+// operatorActorID resolves the CLI operator's identity as "<user>@<host>" so
+// every launch-scoped audit record correlates back to the human who ran the
+// invocation rather than the runtime component that emitted it (#1875). It is a
+// package-level seam so tests can stamp a deterministic identity without
+// depending on the host's real user/hostname. Lookup errors degrade to
+// "unknown" for the missing half rather than failing the launch: audit
+// provenance is best-effort (see daemonAuditSink), and a partial identity is
+// still more useful than mislabeling the operator as the runtime service. This
+// is the cheap operator-identity floor; a vault-anchored configured identity is
+// a deliberate follow-up (#1875).
+var operatorActorID = func() string {
+	name := "unknown"
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		name = u.Username
+	}
+	host := "unknown"
+	if h, err := os.Hostname(); err == nil && h != "" {
+		host = h
+	}
+	return name + "@" + host
+}
 
 // newLaunchImageRunner returns the production image runner that boots the
 // verified pinned environment image and runs the plan inside it (#1731). It
@@ -344,6 +369,10 @@ func (daemonApprover) Approve(_ context.Context, _ runtime.ApprovalRequest) (run
 // the recorder's own best-effort append discipline (ADR-0010).
 type daemonAuditSink struct {
 	stderr io.Writer
+	// actorID is the operator identity ("<user>@<host>") stamped as the human
+	// Actor on every record this sink emits, resolved once at construction via
+	// operatorActorID (#1875).
+	actorID string
 }
 
 func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) string {
@@ -389,7 +418,7 @@ func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) st
 
 	body, err := json.Marshal(auditIngestRequest{
 		EventType: eventType,
-		Actor:     auditIngestActor{Type: string(model.ActorTypeService), ID: "flightplan-launch"},
+		Actor:     auditIngestActor{Type: string(model.ActorTypeHuman), ID: s.actorID},
 		Payload:   payload,
 	})
 	if err != nil {

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -669,10 +669,73 @@ func TestDaemonDispatcher_UnwrapsEnvelopeResult(t *testing.T) {
 	}
 }
 
+// TestOperatorActorID_ComposesUserAtHost proves the operator-identity helper
+// resolves a non-empty "<user>@<host>" string so launch records correlate to
+// the human operator (#1875). Both halves come from the host, so the test
+// asserts the shape (exactly one "@", non-empty parts) rather than a fixed
+// value.
+func TestOperatorActorID_ComposesUserAtHost(t *testing.T) {
+	got := operatorActorID()
+	user, host, ok := strings.Cut(got, "@")
+	if !ok {
+		t.Fatalf("operatorActorID() = %q, want a single \"@\"-joined user@host", got)
+	}
+	if user == "" || host == "" {
+		t.Errorf("operatorActorID() = %q, want non-empty user and host halves", got)
+	}
+	if strings.Contains(host, "@") {
+		t.Errorf("operatorActorID() = %q, want exactly one \"@\" separator", got)
+	}
+}
+
+// TestNewLaunchAuditSink_StampsOperatorHumanActor is the #1875 regression: the
+// production sink seam must stamp the operator identity as a {type: human,
+// id: "<user>@<host>"} Actor on every record kind it emits — the launch
+// summary, per-action, reach, and output records — rather than the old
+// {type: service, id: "flightplan-launch"} runtime component. It overrides the
+// operatorActorID seam so the assertion is deterministic and independent of the
+// host user/hostname.
+func TestNewLaunchAuditSink_StampsOperatorHumanActor(t *testing.T) {
+	origActor := operatorActorID
+	operatorActorID = func() string { return "bob@ci-runner" }
+	t.Cleanup(func() { operatorActorID = origActor })
+
+	var gotBody auditIngestRequest
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"audit_id":"audit-op"}`))
+	})
+
+	sink := newLaunchAuditSink(io.Discard)
+	for _, tc := range []struct {
+		name string
+		rec  runtime.AuditRecord
+	}{
+		{"launch-summary", runtime.AuditRecord{Kind: runtime.RecordKindLaunch, Fields: map[string]any{"artifacts": 1}}},
+		{"per-action", runtime.AuditRecord{Kind: runtime.RecordKindAction, ActionRef: "aileron:x.y"}},
+		{"reach", runtime.AuditRecord{Kind: runtime.RecordKindReach, Fields: map[string]any{"aileron.step.id": "s"}}},
+		{"output", runtime.AuditRecord{Kind: runtime.RecordKindOutput, Fields: map[string]any{"aileron.output.name": "o"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBody = auditIngestRequest{}
+			if id := sink.Record(context.Background(), tc.rec); id != "audit-op" {
+				t.Fatalf("Record returned %q, want audit-op", id)
+			}
+			if gotBody.Actor.Type != string(model.ActorTypeHuman) {
+				t.Errorf("actor.type = %q, want human", gotBody.Actor.Type)
+			}
+			if gotBody.Actor.ID != "bob@ci-runner" {
+				t.Errorf("actor.id = %q, want bob@ci-runner", gotBody.Actor.ID)
+			}
+		})
+	}
+}
+
 // TestDaemonAuditSink_PostsPerActionRecord proves a record with an ActionRef
-// posts a flightplan.launch.action event to /v1/audit carrying the service
-// actor and the actionRef/fields/sink payload, and threads the 201's minted
-// audit_id back as the Record return value.
+// posts a flightplan.launch.action event to /v1/audit carrying the human
+// operator actor and the actionRef/fields/sink payload, and threads the 201's
+// minted audit_id back as the Record return value.
 func TestDaemonAuditSink_PostsPerActionRecord(t *testing.T) {
 	var gotPath string
 	var gotBody auditIngestRequest
@@ -685,7 +748,7 @@ func TestDaemonAuditSink_PostsPerActionRecord(t *testing.T) {
 		_, _ = w.Write([]byte(`{"audit_id":"audit-per-action"}`))
 	})
 
-	id := daemonAuditSink{stderr: io.Discard}.Record(context.Background(), runtime.AuditRecord{
+	id := daemonAuditSink{stderr: io.Discard, actorID: "alice@dev-box"}.Record(context.Background(), runtime.AuditRecord{
 		ActionRef: "aileron:metrics.query_series",
 		Fields:    map[string]any{"rows": 3},
 		Sink:      "customer-store",
@@ -699,8 +762,8 @@ func TestDaemonAuditSink_PostsPerActionRecord(t *testing.T) {
 	if gotBody.EventType != string(model.EventTypeFlightPlanLaunchAction) {
 		t.Errorf("event_type = %q, want %q", gotBody.EventType, model.EventTypeFlightPlanLaunchAction)
 	}
-	if gotBody.Actor.Type != string(model.ActorTypeService) || gotBody.Actor.ID != "flightplan-launch" {
-		t.Errorf("actor = %+v, want {service, flightplan-launch}", gotBody.Actor)
+	if gotBody.Actor.Type != string(model.ActorTypeHuman) || gotBody.Actor.ID != "alice@dev-box" {
+		t.Errorf("actor = %+v, want {human, alice@dev-box}", gotBody.Actor)
 	}
 	if gotBody.Payload["actionRef"] != "aileron:metrics.query_series" {
 		t.Errorf("payload.actionRef = %v", gotBody.Payload["actionRef"])

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -405,8 +405,8 @@ const (
 	// Flight-Plan launch provenance events (#1751). The in-process launch
 	// runtime's audit sink emits one per-action record (ActionRef set) and
 	// one per-launch summary record so `aileron audit list` / `aileron audit
-	// show` surface launch provenance. Actor is {type: service, id:
-	// "flightplan-launch"}.
+	// show` surface launch provenance. Actor is {type: human, id:
+	// "<user>@<host>"}, the operator who ran the launch (#1875).
 	EventTypeFlightPlanLaunchAction EventType = "flightplan.launch.action"
 	EventTypeFlightPlanLaunch       EventType = "flightplan.launch"
 
@@ -420,8 +420,8 @@ const (
 	// credential restricted to the verified lock's sealed reach, and false when
 	// the step declared a contract with no sealed entry. The single source of
 	// truth for the marker's semantics is buildReachRecord in
-	// internal/flightplan/runtime/audit.go. Actor is {type: service, id:
-	// "flightplan-launch"}.
+	// internal/flightplan/runtime/audit.go. Actor is {type: human, id:
+	// "<user>@<host>"}, the operator who ran the launch (#1875).
 	EventTypeFlightPlanLaunchReach EventType = "flightplan.launch.reach"
 
 	// EventTypeOutputMaterialized is one per-output-per-step provenance event
@@ -431,6 +431,7 @@ const (
 	// its own event rather than being lumped into the launch summary). The
 	// flat `aileron.*` payload carries the output's content hash, mime, byte
 	// count, and originating step provenance plus the plan/invocation identity.
-	// Actor is {type: service, id: "flightplan-launch"}.
+	// Actor is {type: human, id: "<user>@<host>"}, the operator who ran the
+	// launch (#1875).
 	EventTypeOutputMaterialized EventType = "output.materialized"
 )


### PR DESCRIPTION
## Summary

Launch-scoped audit records hardcoded every `Actor` to `{type: service, id: "flightplan-launch"}` (the runtime component that emitted the record) rather than the operator who ran the invocation. That made it impossible to correlate action / reach / output / launch-summary records back to a person.

This computes an operator identity `<user>@<host>` at CLI launch via a test-hookable `operatorActorID` helper (`user.Current()` + `os.Hostname()`) and stamps it as `event.Actor {type: human, id: "<user>@<host>"}` on every record emitted by `daemonAuditSink`. The daemon already accepts the `human` actor type (`normalizeActorType` in `internal/app/handlers_audit.go`), so there is no OpenAPI / generated-code change.

Scope notes (settled forks from triage): actor `type=human` with id `user@host` matches the established invoking-user convention and the feedback's exact shape; the redundant service id is replaced rather than augmented (the eventType prefix already names the component, and there is no backwards-compat obligation pre-release); the vault-anchored "configured operator identity" is explicitly aspirational in the feedback with no existing config surface, so it stays a follow-up.

Files:
- `cmd/aileron/skill_launch.go` — `operatorActorID` helper seam, `daemonAuditSink.actorID`, human Actor stamp.
- `internal/model/model.go` — three doc comments updated (service → human).
- `cmd/aileron/skill_launch_test.go` — updated existing assertion + regression tests.

## Test plan

- `go build` of `cmd/aileron`, `internal/app`, `internal/model` — clean.
- `go test ./cmd/aileron/... ./internal/...` — all green.
- New `TestNewLaunchAuditSink_StampsOperatorHumanActor` regression asserts the human `<user>@<host>` actor across all four record kinds (launch summary, per-action, reach, output); fails before the fix (was service/flightplan-launch), passes after.
- New `TestOperatorActorID_ComposesUserAtHost` asserts the helper yields a non-empty `user@host` shape.

Closes #1875

🤖 Generated with [Claude Code](https://claude.com/claude-code)