### PR TITLE
fix(app): default user-credential metadata type to the namespace so the guided vault put is resolvable

### DIFF
--- a/internal/app/handlers_local_vault_user.go
+++ b/internal/app/handlers_local_vault_user.go
@@ -179,6 +179,17 @@ func (s *apiServer) PutUserCredentials(w http.ResponseWriter, r *http.Request, s
 	}
 
 	meta := agentCredentialsMetadataFromRequest(req.Metadata)
+	// Default the metadata type to the namespace. The host-binding
+	// VaultResolver admits a `user/<service>` credential_ref only when the
+	// stored entry's Metadata.Type equals the ref's first segment ("user"),
+	// so an entry written without an explicit type — which is what
+	// `aileron vault put user/<service>` sends — would be stored
+	// successfully and then be unresolvable at injection time, failing the
+	// launch with "host-binding credential is unavailable". A caller that
+	// sets an explicit type keeps it.
+	if meta.Type == "" {
+		meta.Type = "user"
+	}
 	err := s.vault.Put(ctx, userCredentialVaultPath(service), req.Value, meta)
 	if errors.Is(err, vault.ErrCredentialUnavailable) {
 		writeError(w, http.StatusLocked, "vault_locked",

--- a/internal/app/handlers_local_vault_user_test.go
+++ b/internal/app/handlers_local_vault_user_test.go
@@ -110,6 +110,44 @@ func TestPutUserCredentials_StoresAtUserServicePath(t *testing.T) {
 	}
 }
 
+// TestPutUserCredentials_DefaultsMetadataTypeToUser locks the resolver
+// contract: a PUT with no metadata (what `aileron vault put user/<service>`
+// sends) must store Type "user", or the host-binding VaultResolver rejects
+// the entry at injection time and the launch fails with "host-binding
+// credential is unavailable" — found live on the first run of the guided
+// verb. An explicit type is kept verbatim.
+func TestPutUserCredentials_DefaultsMetadataTypeToUser(t *testing.T) {
+	v := vault.NewMemVault()
+	s := newUserCredentialsServer(t, v)
+
+	rec := putUserCredential(t, s, "aws", api.AgentCredentials{Value: []byte("x")})
+	assertStatus(t, rec, http.StatusNoContent)
+	entries, err := v.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got string
+	for _, e := range entries {
+		if e.Path == "user/aws" {
+			got = e.Metadata.Type
+		}
+	}
+	if got != "user" {
+		t.Fatalf("stored Metadata.Type = %q, want %q (no-metadata PUT must default to the namespace)", got, "user")
+	}
+
+	explicit := "api_key"
+	rec = putUserCredential(t, s, "github", api.AgentCredentials{Value: []byte("x"),
+		Metadata: &api.AgentCredentialsMetadata{Type: &explicit}})
+	assertStatus(t, rec, http.StatusNoContent)
+	entries, _ = v.List(context.Background())
+	for _, e := range entries {
+		if e.Path == "user/github" && e.Metadata.Type != "api_key" {
+			t.Fatalf("explicit Metadata.Type overwritten: got %q, want api_key", e.Metadata.Type)
+		}
+	}
+}
+
 func TestGetUserCredentials_MissingEntryReturnsNotFound(t *testing.T) {
 	s := newUserCredentialsServer(t, vault.NewMemVault())
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
`aileron vault put user/<service>` (#1877) sends no metadata, and
PutUserCredentials stored the entry with Metadata.Type "" — but the
host-binding VaultResolver admits a `user/<service>` credential_ref only
when the stored type equals the ref's first segment. The guided verb
therefore produced an entry its own proxy refused at injection time, and
the first live launch after wiring with it failed with "sandbox proxy
host-binding credential is unavailable".

The handler now defaults Type to "user" when the request carries none;
an explicit type is kept verbatim. Fixes every client of the endpoint,
including hand-rolled PUTs.

Found by running the guided credential wiring end-to-end on a real
Flight Plan launch.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012sUjkxyPusyc7FivV3rQpL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User credential entries now default to a user metadata type when none is provided, ensuring they are saved consistently.
  * Explicit metadata types remain unchanged when supplied.
* **Tests**
  * Added coverage for defaulting behavior and for preserving a provided metadata type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->