### PR TITLE
fix(skill-launch): select newest frozen version by freeze time, not lexical id

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -127,7 +127,7 @@ func (f *inputFlag) Set(s string) error {
 func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("skill launch", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	version := flags.String("version", "", "Frozen version id to launch (defaults to the only/most recent version)")
+	version := flags.String("version", "", "Frozen version id to launch (defaults to the only/most recently frozen version)")
 	outDir := flags.String("out-dir", ".", "Directory file-target artifacts are written to")
 	// storeDir defaults to the process store seam. The in-container re-entry on
 	// the image-boot path passes the bind-mounted store path here so the inner
@@ -147,7 +147,7 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	name := positionals[0]
 
 	s := store.New(*storeDir)
-	id, err := resolveLaunchVersion(s, name, *version)
+	id, err := resolveLaunchVersion(s, name, *version, stdout)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -217,20 +217,31 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 }
 
 // resolveLaunchVersion resolves the version id to launch: the explicit
-// --version when given, otherwise the single frozen version (or the most
-// recent when several exist, since FrozenVersions returns sorted ids).
-func resolveLaunchVersion(s *store.Store, name, version string) (string, error) {
+// --version when given, otherwise the most-recently-frozen version.
+//
+// Version ids are content-hash slugs, so the store's sorted-ids order is
+// lexicographic, not chronological; picking the sorted max could launch an
+// older version over a newer one (issue #1880). This selects by freeze time
+// (LatestFrozen), so a bare launch always runs the newest frozen version.
+//
+// When more than one version exists and no --version was pinned, a banner is
+// printed to stdout naming the auto-selected version and the total count, so
+// the implicit choice is visible and the operator knows how to pin it.
+func resolveLaunchVersion(s *store.Store, name, version string, stdout io.Writer) (string, error) {
 	if version != "" {
 		return version, nil
 	}
-	ids, err := s.FrozenVersions(name)
+	id, count, err := s.LatestFrozen(name)
 	if err != nil {
 		return "", fmt.Errorf("list frozen versions for %q: %w", name, err)
 	}
-	if len(ids) == 0 {
+	if count == 0 {
 		return "", fmt.Errorf("skill %q has no frozen versions; run `aileron skill freeze %s` first", name, name)
 	}
-	return ids[len(ids)-1], nil
+	if count > 1 {
+		fmt.Fprintf(stdout, "launching %s (newest of %d; use --version to pin)\n", id, count)
+	}
+	return id, nil
 }
 
 // daemonDispatcher dispatches an action through the daemon's

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	"github.com/ALRubinger/aileron/internal/model"
 )
 
@@ -415,6 +417,96 @@ func TestRunSkillLaunch_StoreDirFlagRoutesStore(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Launched \"weekly-metrics-digest\"") {
 		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+// writeLaunchVersion writes a minimal frozen version directory for a skill so
+// resolveLaunchVersion can select it, then stamps its mtime so freeze order is
+// deterministic in the test.
+func writeLaunchVersion(t *testing.T, s *store.Store, name, id string, mod time.Time) {
+	t.Helper()
+	if err := s.WriteFrozen(name, store.FrozenVersion{
+		ID:        id,
+		SkillMD:   []byte("---\nname: " + name + "\n---\nbody\n"),
+		Lockfile:  []byte("contentHash: sha256:abc\n"),
+		Signature: []byte("sig"),
+		PublicKey: []byte("pub"),
+	}); err != nil {
+		t.Fatalf("WriteFrozen %q: %v", id, err)
+	}
+	if err := os.Chtimes(s.FrozenDir(name, id), mod, mod); err != nil {
+		t.Fatalf("Chtimes %q: %v", id, err)
+	}
+}
+
+// TestResolveLaunchVersion_SelectsNewestByFreezeTime is the CLI-level
+// regression test for issue #1880: with two frozen versions whose content-hash
+// ids sort lexicographically opposite to their freeze order, a bare launch
+// (no --version) must resolve to the most-recently-frozen id, not the sorted
+// max, and must print a banner naming the auto-selected version and count.
+func TestResolveLaunchVersion_SelectsNewestByFreezeTime(t *testing.T) {
+	s := store.New(t.TempDir())
+	base := time.Now().Add(-time.Hour)
+	// "fb8f2724" sorts lexicographically AFTER "0f638793" but is frozen FIRST
+	// (older). The newer version's id sorts first, exactly the reported symptom.
+	writeLaunchVersion(t, s, "demo", "fb8f2724", base)
+	writeLaunchVersion(t, s, "demo", "0f638793", base.Add(time.Minute))
+
+	var stdout bytes.Buffer
+	id, err := resolveLaunchVersion(s, "demo", "", &stdout)
+	if err != nil {
+		t.Fatalf("resolveLaunchVersion: %v", err)
+	}
+	if id != "0f638793" {
+		t.Errorf("resolved id = %q, want %q (newest by freeze time, not lexical max)", id, "0f638793")
+	}
+	banner := stdout.String()
+	if !strings.Contains(banner, "launching 0f638793") || !strings.Contains(banner, "newest of 2") {
+		t.Errorf("banner = %q, want it to name 0f638793 as newest of 2", banner)
+	}
+	if !strings.Contains(banner, "--version to pin") {
+		t.Errorf("banner = %q, want it to mention --version to pin", banner)
+	}
+}
+
+// TestResolveLaunchVersion_SingleVersionNoBanner proves the banner is suppressed
+// when only one version exists: there is no implicit choice to surface.
+func TestResolveLaunchVersion_SingleVersionNoBanner(t *testing.T) {
+	s := store.New(t.TempDir())
+	writeLaunchVersion(t, s, "demo", "only1", time.Now())
+
+	var stdout bytes.Buffer
+	id, err := resolveLaunchVersion(s, "demo", "", &stdout)
+	if err != nil {
+		t.Fatalf("resolveLaunchVersion: %v", err)
+	}
+	if id != "only1" {
+		t.Errorf("resolved id = %q, want %q", id, "only1")
+	}
+	if stdout.String() != "" {
+		t.Errorf("single-version launch must not print a banner, got %q", stdout.String())
+	}
+}
+
+// TestResolveLaunchVersion_ExplicitVersionBypassesSelection proves an explicit
+// --version is returned verbatim without consulting the store or printing a
+// banner, even when other newer versions exist.
+func TestResolveLaunchVersion_ExplicitVersionBypassesSelection(t *testing.T) {
+	s := store.New(t.TempDir())
+	base := time.Now().Add(-time.Hour)
+	writeLaunchVersion(t, s, "demo", "pinned0", base)
+	writeLaunchVersion(t, s, "demo", "newer00", base.Add(time.Minute))
+
+	var stdout bytes.Buffer
+	id, err := resolveLaunchVersion(s, "demo", "pinned0", &stdout)
+	if err != nil {
+		t.Fatalf("resolveLaunchVersion: %v", err)
+	}
+	if id != "pinned0" {
+		t.Errorf("resolved id = %q, want the pinned %q", id, "pinned0")
+	}
+	if stdout.String() != "" {
+		t.Errorf("explicit --version must not print a banner, got %q", stdout.String())
 	}
 }
 

--- a/internal/flightplan/store/freeze.go
+++ b/internal/flightplan/store/freeze.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 )
 
 // Frozen-version artifact file names. A frozen version directory holds the
@@ -165,6 +166,65 @@ func (s *Store) FrozenVersions(name string) ([]string, error) {
 	}
 	sort.Strings(ids)
 	return ids, nil
+}
+
+// LatestFrozen returns the id of the most-recently-frozen version of a skill
+// and the total number of frozen versions. "Most recent" is ordered by the
+// version directory's modification time, which reflects freeze order because
+// WriteFrozen finalizes each new version by os.Rename-ing a staged temp dir
+// into place (a fresh mtime), and an idempotent re-freeze of byte-identical
+// content is a no-op that leaves the existing directory (and its mtime)
+// untouched. Ties on mtime are broken by the lexicographically-highest id so
+// the selection is deterministic. A skill with no frozen versions returns
+// ("", 0, nil), not an error, mirroring FrozenVersions.
+//
+// This exists because version ids are content-hash slugs, so FrozenVersions'
+// sorted-ids order is lexicographic, not chronological: picking the sorted max
+// can launch an older version over a newer one (issue #1880). Callers that want
+// the newest frozen version by freeze time use this instead.
+func (s *Store) LatestFrozen(name string) (string, int, error) {
+	dir := filepath.Join(s.Dir(name), versionsSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", 0, nil
+		}
+		return "", 0, fmt.Errorf("store: read frozen versions: %w", err)
+	}
+	var (
+		latestID  string
+		latestSet bool
+		latestMod time.Time
+		count     int
+	)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		if _, err := os.Stat(filepath.Join(dir, id, frozenSkillFile)); err != nil {
+			// Not a valid frozen version directory (no SKILL.md); skip it, matching
+			// FrozenVersions' filtering.
+			continue
+		}
+		info, err := os.Stat(filepath.Join(dir, id))
+		if err != nil {
+			continue
+		}
+		count++
+		mod := info.ModTime()
+		// Select the newest mtime; on a tie prefer the lexicographically-higher id
+		// so the result is deterministic regardless of ReadDir ordering.
+		if !latestSet || mod.After(latestMod) || (mod.Equal(latestMod) && id > latestID) {
+			latestID = id
+			latestMod = mod
+			latestSet = true
+		}
+	}
+	if !latestSet {
+		return "", 0, nil
+	}
+	return latestID, count, nil
 }
 
 // ReadFrozen returns the artifacts of a named skill's frozen version.

--- a/internal/flightplan/store/freeze_test.go
+++ b/internal/flightplan/store/freeze_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func sampleVersion(id string) FrozenVersion {
@@ -171,6 +172,104 @@ func TestFrozenVersions_SortedAndEmpty(t *testing.T) {
 	}
 	if len(ids) != 3 || ids[0] != "v1" || ids[1] != "v2" || ids[2] != "v3" {
 		t.Errorf("FrozenVersions = %v, want sorted [v1 v2 v3]", ids)
+	}
+}
+
+func TestLatestFrozen_EmptyReturnsZero(t *testing.T) {
+	s := New(t.TempDir())
+	id, count, err := s.LatestFrozen("demo")
+	if err != nil {
+		t.Fatalf("LatestFrozen on empty: %v", err)
+	}
+	if id != "" || count != 0 {
+		t.Errorf("LatestFrozen on empty = (%q, %d), want (\"\", 0)", id, count)
+	}
+}
+
+// TestLatestFrozen_PicksNewestByMtimeNotLexical is the regression test for
+// issue #1880: content-hash version ids sort lexicographically, so the newest
+// frozen version can have an id that sorts *before* an older one. LatestFrozen
+// must select by freeze time (directory mtime), not by sorted-id order.
+func TestLatestFrozen_PicksNewestByMtimeNotLexical(t *testing.T) {
+	s := New(t.TempDir())
+	// "older" sorts lexicographically AFTER "newer" (o > n), matching the bug
+	// where fb8f2724… launched over the newer 0f638793…. If LatestFrozen picked
+	// the sorted max it would (wrongly) return "older".
+	const (
+		olderID = "older"
+		newerID = "newer"
+	)
+	if err := s.WriteFrozen("demo", sampleVersion(olderID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteFrozen("demo", sampleVersion(newerID)); err != nil {
+		t.Fatal(err)
+	}
+	// Stamp deterministic mtimes: newerID is frozen more recently.
+	base := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(s.FrozenDir("demo", olderID), base, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(s.FrozenDir("demo", newerID), base.Add(time.Minute), base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	id, count, err := s.LatestFrozen("demo")
+	if err != nil {
+		t.Fatalf("LatestFrozen: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("LatestFrozen count = %d, want 2", count)
+	}
+	if id != newerID {
+		t.Errorf("LatestFrozen id = %q, want %q (newest by mtime, not lexical max)", id, newerID)
+	}
+}
+
+// TestLatestFrozen_TieBreaksLexically pins the deterministic tie-break: equal
+// mtimes resolve to the lexicographically-higher id.
+func TestLatestFrozen_TieBreaksLexically(t *testing.T) {
+	s := New(t.TempDir())
+	for _, id := range []string{"aaa", "ccc", "bbb"} {
+		if err := s.WriteFrozen("demo", sampleVersion(id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ts := time.Now().Add(-time.Hour)
+	for _, id := range []string{"aaa", "bbb", "ccc"} {
+		if err := os.Chtimes(s.FrozenDir("demo", id), ts, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+	id, count, err := s.LatestFrozen("demo")
+	if err != nil {
+		t.Fatalf("LatestFrozen: %v", err)
+	}
+	if count != 3 || id != "ccc" {
+		t.Errorf("LatestFrozen = (%q, %d), want (\"ccc\", 3) on mtime tie", id, count)
+	}
+}
+
+// TestLatestFrozen_IgnoresNonVersionEntries mirrors FrozenVersions' filtering:
+// stray files and dirs without SKILL.md are not counted or selectable.
+func TestLatestFrozen_IgnoresNonVersionEntries(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatal(err)
+	}
+	versionsDir := filepath.Join(s.Dir("demo"), "versions")
+	if err := os.WriteFile(filepath.Join(versionsDir, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(versionsDir, "empty-dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	id, count, err := s.LatestFrozen("demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || id != "v1" {
+		t.Errorf("LatestFrozen = (%q, %d), want (\"v1\", 1) ignoring non-version entries", id, count)
 	}
 }
 


### PR DESCRIPTION
## Summary

`aileron skill launch <name>` with no `--version` was launching the wrong frozen version. `resolveLaunchVersion` (cmd/aileron/skill_launch.go) picked `ids[len(ids)-1]` from `store.FrozenVersions`, which returns version ids via `sort.Strings`. Version ids are content-hash slugs, so "most recent" was really the lexicographically-highest hex string, matching the reported symptom where `fb8f2724…` launched over the newer `0f638793…`.

The fix selects by freeze time instead of lexical order:

- **`store.LatestFrozen(name)`** (internal/flightplan/store/freeze.go) returns the newest frozen version id by version-directory mtime plus the total count. Freeze order is reliable because `WriteFrozen` finalizes each new version via an atomic `os.Rename` of a staged temp dir (fresh mtime), and an idempotent re-freeze of byte-identical content is a no-op that leaves the directory untouched. Mtime ties break on the lexicographically-higher id for determinism. Empty skill returns `("", 0, nil)`, mirroring `FrozenVersions`.
- **`resolveLaunchVersion`** now uses `LatestFrozen`, and prints a banner `launching <id> (newest of N; use --version to pin)` when more than one version exists and no `--version` was given, so the implicit selection is visible.
- The `--version` flag help now says "most recently frozen version".

The existing `FrozenVersions` sorted-ids contract and its test are left intact; its only caller was skill_launch.

No backwards-compat shims (pre-release). No OpenAPI/spec surface touched.

## Test plan

- `TestLatestFrozen_PicksNewestByMtimeNotLexical` — store-level regression: two versions whose ids sort opposite to freeze order; asserts the newer-by-mtime id is returned. Fails before the fix, passes after.
- `TestResolveLaunchVersion_SelectsNewestByFreezeTime` — CLI-level regression using the reported ids (`fb8f2724` frozen first, `0f638793` newer); asserts resolution to `0f638793` and that the banner reports "newest of 2" with the pin hint. Fails before, passes after.
- `TestResolveLaunchVersion_SingleVersionNoBanner` / `TestResolveLaunchVersion_ExplicitVersionBypassesSelection` — banner suppressed for the single-version and explicit-`--version` cases.
- `TestLatestFrozen_EmptyReturnsZero`, `TestLatestFrozen_TieBreaksLexically`, `TestLatestFrozen_IgnoresNonVersionEntries` — empty, deterministic tie-break, and non-version-entry filtering.
- `go build`, `go vet`, and full `go test ./internal/flightplan/store/... ./cmd/aileron/...` all green. `LatestFrozen` at 88% / `resolveLaunchVersion` at 90% coverage; the only uncovered lines are IO-error branches, consistent with the pre-existing `FrozenVersions` (93.3%).

Closes #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)
