### PR TITLE
fix(launch): carry host-resolved operator identity into the sealed boot

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -38,7 +38,21 @@ var newLaunchAuditSink = func(stderr io.Writer) runtime.AuditSink {
 // still more useful than mislabeling the operator as the runtime service. This
 // is the cheap operator-identity floor; a vault-anchored configured identity is
 // a deliberate follow-up (#1875).
+//
+// A non-empty AILERON_OPERATOR_ID env var takes precedence over the
+// user@host floor. On the composed-environment model the CLI that emits
+// audit records runs INSIDE the sealed container, where user.Current() and
+// os.Hostname() resolve to the image's fixed non-root user and the ephemeral
+// container id (agent@<container-id>) — identical for every operator, which
+// defeats attribution. The host resolves the real operator identity once and
+// carries it into the boot via AILERON_OPERATOR_ID (see
+// containerImageRunner.Run), mirroring the existing daemon-coords injection.
+// A host-run launch leaves the env unset and keeps the user@host floor
+// (#1881).
 var operatorActorID = func() string {
+	if id := strings.TrimSpace(os.Getenv("AILERON_OPERATOR_ID")); id != "" {
+		return id
+	}
 	name := "unknown"
 	if u, err := user.Current(); err == nil && u.Username != "" {
 		name = u.Username

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -92,9 +92,10 @@ const envSkillImageBooted = "AILERON_SKILL_IMAGE_BOOTED"
 // reserved boot key, failing closed with a loud, variable-naming error rather
 // than booting with a poisoned token/URL or a lost re-entry sentinel.
 var reservedBootEnvKeys = map[string]struct{}{
-	"AILERON_TOKEN":     {},
-	"AILERON_API_URL":   {},
-	envSkillImageBooted: {},
+	"AILERON_TOKEN":       {},
+	"AILERON_API_URL":     {},
+	"AILERON_OPERATOR_ID": {},
+	envSkillImageBooted:   {},
 }
 
 // containerRunFlightPlan boots the pinned image and runs the plan inside it. It
@@ -221,7 +222,21 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		// the booted pin: it must run the plan in-process rather than boot
 		// the pin again (which would recurse; the image carries no nested
 		// container runtime, and with one it would never terminate).
-		Env: map[string]string{envSkillImageBooted: "1"},
+		//
+		// AILERON_OPERATOR_ID carries the HOST-resolved operator identity
+		// into the boot so the in-container CLI stamps the real human on its
+		// launch audit records (#1881). Resolved once here on the host,
+		// where user.Current()@os.Hostname() names the actual operator; the
+		// inner CLI would otherwise resolve the image's fixed non-root user
+		// and the ephemeral container id (agent@<container-id>) — identical
+		// for every operator — defeating attribution. This mirrors the
+		// daemon-coords injection below. AILERON_OPERATOR_ID is a
+		// reservedBootEnvKey so a placeholder/proxy-bootstrap key cannot
+		// clobber it.
+		Env: map[string]string{
+			envSkillImageBooted:   "1",
+			"AILERON_OPERATOR_ID": operatorActorID(),
+		},
 	}
 
 	// Daemon-audit reachability (#1759): inject the host daemon coordinates so the

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -14,14 +14,24 @@ import (
 	"github.com/ALRubinger/aileron/internal/version"
 )
 
+// stubHostOperatorID is the deterministic host-resolved operator identity the
+// container Run tests stamp via the operatorActorID seam, so the injected
+// AILERON_OPERATOR_ID env is a fixed value independent of the host user/host.
+const stubHostOperatorID = "carol@host-workstation"
+
 // stubContainerBoot swaps the single real-Docker call site for a recorder so the
 // container image runner's spec-construction is testable with no live runtime.
 // It also stubs the CLI-version-skew preflight to "" so every Run test stays
-// Docker-free and warning-silent by default; skew tests override it via
-// stubBakedCLIVersion.
+// Docker-free and warning-silent by default (skew tests override it via
+// stubBakedCLIVersion), and stubs operatorActorID to stubHostOperatorID so the
+// host-resolved AILERON_OPERATOR_ID injected into the boot env (#1881) is
+// deterministic.
 func stubContainerBoot(t *testing.T, capture *sandboxcontainer.RunOptions, err error) {
 	t.Helper()
 	stubBakedCLIVersion(t, "")
+	origActor := operatorActorID
+	operatorActorID = func() string { return stubHostOperatorID }
+	t.Cleanup(func() { operatorActorID = origActor })
 	orig := containerRunFlightPlan
 	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
 		*capture = opts
@@ -307,6 +317,12 @@ func TestContainerImageRunner_InjectsDaemonEnv(t *testing.T) {
 	if got.Env[envSkillImageBooted] != "1" {
 		t.Errorf("%s = %q, want the boot sentinel alongside the daemon env", envSkillImageBooted, got.Env[envSkillImageBooted])
 	}
+	// #1881: the host-resolved operator identity is injected into the boot env
+	// so the in-container CLI stamps the real human on its audit records rather
+	// than the image's fixed non-root user + ephemeral container id.
+	if got.Env["AILERON_OPERATOR_ID"] != stubHostOperatorID {
+		t.Errorf("AILERON_OPERATOR_ID = %q, want the host-resolved operator id %q", got.Env["AILERON_OPERATOR_ID"], stubHostOperatorID)
+	}
 }
 
 // TestContainerImageRunner_PassthroughWhenNoDaemonConfig proves that when the
@@ -329,9 +345,10 @@ func TestContainerImageRunner_PassthroughWhenNoDaemonConfig(t *testing.T) {
 	if _, err := (containerImageRunner{daemonEnv: fake}).Run(context.Background(), spec); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	// Only the boot sentinel: no daemon coordinates on the passthrough boot.
-	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
-		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the passthrough (ok=false) boot", got.Env)
+	// The boot sentinel and the host-resolved operator id (#1881), but no daemon
+	// coordinates, on the passthrough boot.
+	if len(got.Env) != 2 || got.Env[envSkillImageBooted] != "1" || got.Env["AILERON_OPERATOR_ID"] != stubHostOperatorID {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel + operator id on the passthrough (ok=false) boot", got.Env)
 	}
 }
 
@@ -355,8 +372,8 @@ func TestContainerImageRunner_ZeroValueInjectsNoEnv(t *testing.T) {
 	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
-		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the zero-value runner", got.Env)
+	if len(got.Env) != 2 || got.Env[envSkillImageBooted] != "1" || got.Env["AILERON_OPERATOR_ID"] != stubHostOperatorID {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel + operator id on the zero-value runner", got.Env)
 	}
 }
 
@@ -500,6 +517,9 @@ func TestContainerImageRunner_ProxyEnrichesBoot(t *testing.T) {
 	if got.Env["AWS_ACCESS_KEY_ID"] != "AKIAIOSFODNN7PLACEHLDR" || got.Env["GH_TOKEN"] != "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA" {
 		t.Errorf("placeholder creds missing from the merged boot env: %+v", got.Env)
 	}
+	if got.Env["AILERON_OPERATOR_ID"] != stubHostOperatorID {
+		t.Errorf("AILERON_OPERATOR_ID = %q, want the host-resolved operator id preserved through the proxy merge", got.Env["AILERON_OPERATOR_ID"])
+	}
 }
 
 // TestContainerImageRunner_ProxyPassthroughWhenNotOK proves a bootstrapper
@@ -527,8 +547,8 @@ func TestContainerImageRunner_ProxyPassthroughWhenNotOK(t *testing.T) {
 			t.Errorf("passthrough boot must not mount a CA, got %+v", got.Volumes)
 		}
 	}
-	if len(got.Env) != 1 || got.Env[envSkillImageBooted] != "1" {
-		t.Errorf("RunOptions.Env = %v, want only the boot sentinel on the passthrough (ok=false) boot", got.Env)
+	if len(got.Env) != 2 || got.Env[envSkillImageBooted] != "1" || got.Env["AILERON_OPERATOR_ID"] != stubHostOperatorID {
+		t.Errorf("RunOptions.Env = %v, want only the boot sentinel + operator id on the passthrough (ok=false) boot", got.Env)
 	}
 }
 
@@ -567,15 +587,16 @@ func TestContainerImageRunner_ProxyPrepareErrorFailsClosed(t *testing.T) {
 
 // TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap proves that a
 // bootstrap/placeholder env declaring one of the reserved boot keys (the daemon
-// coordinates AILERON_TOKEN / AILERON_API_URL or the AILERON_SKILL_IMAGE_BOOTED
-// sentinel) fails the boot closed with an error naming the offending variable,
-// rather than letting the merge clobber the authoritative daemon token/URL or
-// the re-entry sentinel (#1828). An image-declared credential placeholder is
+// coordinates AILERON_TOKEN / AILERON_API_URL, the host-resolved
+// AILERON_OPERATOR_ID (#1881), or the AILERON_SKILL_IMAGE_BOOTED sentinel) fails
+// the boot closed with an error naming the offending variable, rather than
+// letting the merge clobber the authoritative daemon token/URL, the operator
+// identity, or the re-entry sentinel (#1828). An image-declared credential placeholder is
 // the realistic source of such a key: PlaceholderEnv only rejects
 // convention-vs-convention collisions, so a placeholder that mis-declares a
 // reserved key would otherwise reach the merge site. The boot must NOT run.
 func TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap(t *testing.T) {
-	for _, reserved := range []string{"AILERON_TOKEN", "AILERON_API_URL", envSkillImageBooted} {
+	for _, reserved := range []string{"AILERON_TOKEN", "AILERON_API_URL", "AILERON_OPERATOR_ID", envSkillImageBooted} {
 		reserved := reserved
 		t.Run(reserved, func(t *testing.T) {
 			storeDir := t.TempDir()

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -688,6 +688,38 @@ func TestOperatorActorID_ComposesUserAtHost(t *testing.T) {
 	}
 }
 
+// TestOperatorActorID_PrefersEnvOverride is the #1881 regression: on the
+// composed-environment model the CLI that emits audit records runs INSIDE the
+// sealed container, where user.Current()@os.Hostname() resolves to the image's
+// fixed non-root user + the ephemeral container id (identical for every
+// operator). The host resolves the real operator identity once and carries it
+// into the boot via AILERON_OPERATOR_ID; the inner CLI must stamp that value
+// VERBATIM. A host-run launch leaves the env unset and keeps the user@host
+// floor. Fails before the env-preference seam (the override would be ignored
+// and the floor stamped instead).
+func TestOperatorActorID_PrefersEnvOverride(t *testing.T) {
+	t.Run("env set stamps the host-resolved id verbatim", func(t *testing.T) {
+		t.Setenv("AILERON_OPERATOR_ID", "alice@laptop-42")
+		if got := operatorActorID(); got != "alice@laptop-42" {
+			t.Errorf("operatorActorID() = %q, want %q (host-resolved override verbatim)", got, "alice@laptop-42")
+		}
+	})
+
+	t.Run("blank env falls back to user@host floor", func(t *testing.T) {
+		// A whitespace-only value must not shadow the floor: it carries no
+		// identity, so trimming to empty keeps the user@host resolution.
+		t.Setenv("AILERON_OPERATOR_ID", "   ")
+		got := operatorActorID()
+		user, host, ok := strings.Cut(got, "@")
+		if !ok || user == "" || host == "" {
+			t.Fatalf("operatorActorID() = %q, want user@host floor when env is blank", got)
+		}
+		if got == "   " {
+			t.Errorf("operatorActorID() = %q, blank env must not shadow the floor", got)
+		}
+	})
+}
+
 // TestNewLaunchAuditSink_StampsOperatorHumanActor is the #1875 regression: the
 // production sink seam must stamp the operator identity as a {type: human,
 // id: "<user>@<host>"} Actor on every record kind it emits — the launch


### PR DESCRIPTION
## Summary

Completes #1878's operator-identity floor for the composed-environment model. #1878 stamps launch audit records with a human actor id from `operatorActorID()` (`user.Current()@os.Hostname()`) in the process that emits the records. On the composed-environment model that CLI runs INSIDE the sealed container, so `operatorActorID()` resolves to the image's fixed non-root user + the ephemeral container id (`agent@<container-id>`) — identical for every operator, defeating attribution.

Fix (host-resolve once, carry into the boot, matching the existing daemon-coords injection):

- `cmd/aileron/skill_launch.go` — `operatorActorID` prefers a non-empty `AILERON_OPERATOR_ID` env var, else keeps the `user@host` floor. A blank/whitespace value does not shadow the floor. A host-run launch leaves the env unset and is unchanged.
- `cmd/aileron/skill_launch_container.go` — `containerImageRunner.Run` injects `AILERON_OPERATOR_ID = operatorActorID()` (resolved on the host) into the booted container env alongside the boot sentinel, so the inner CLI stamps the host-resolved identity. Added `AILERON_OPERATOR_ID` to `reservedBootEnvKeys` so a placeholder/proxy-bootstrap key cannot clobber it (same treatment as `AILERON_TOKEN`/`AILERON_API_URL`/`AILERON_SKILL_IMAGE_BOOTED`).

No OpenAPI/generated-code change: the daemon already accepts `ActorTypeHuman` via `normalizeActorType` (#1778) and the payload shape is unchanged.

Why not the daemon-ingest-override alternative the issue floats: the daemon authenticates the inner CLI with the shared `AILERON_TOKEN`, which carries no per-operator identity, so the daemon cannot distinguish operators at ingest. The host-resolved env is the only place the real identity is known. The vault/keyring-anchored richer operator identity remains the deliberate follow-up flagged in #1878; this env-preference seam is exactly the plumbing that later lets the host resolve a richer identity without touching the inner CLI.

## Test plan

Regression tests (fail before the fix, pass after — verified by stashing the production change):

- `skill_launch_test.go` `TestOperatorActorID_PrefersEnvOverride` — proves `operatorActorID()` returns `AILERON_OPERATOR_ID` verbatim when set (`t.Setenv`), and falls back to `user@host` when unset/blank.
- `skill_launch_container_test.go` — `TestContainerImageRunner_InjectsDaemonEnv` / passthrough / zero-value / proxy-enriched tests now assert `opts.Env["AILERON_OPERATOR_ID"]` equals the stubbed host id; `TestContainerImageRunner_RejectsReservedBootKeyFromBootstrap` now covers `AILERON_OPERATOR_ID` proving a bootstrap placeholder collision still fails closed.

- `go build ./cmd/aileron/...` — green
- `go vet ./cmd/aileron/...` — clean
- `go test ./cmd/aileron/ -count=1` — all pass
- `gofmt -l` on changed files — clean

Closes #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
