### PR TITLE
fix(skill-launch): summarize resolved input values instead of dumping them

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"sort"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
@@ -150,6 +151,13 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	storeDir := flags.String("store-dir", skillStoreDir, "Skill store directory (defaults to ~/.aileron/skills)")
 	var inputs inputFlag
 	flags.Var(&inputs, "input", "Launch input override as name=value; repeatable")
+	// verbose restores the full resolved-input value dump. By default the
+	// result summary prints a per-input "<type, size>" line instead of the raw
+	// value, so a plan that passes a large input (e.g. an inlined HTML
+	// document) no longer floods the terminal and buries the launch result
+	// (#1888). -v is an alias.
+	verbose := flags.Bool("verbose", false, "Print full resolved input values instead of a type+size summary")
+	flags.BoolVar(verbose, "v", false, "Shorthand for --verbose")
 	positionals, err := parseInterspersedFlags(flags, args)
 	if err != nil {
 		return 1
@@ -210,8 +218,18 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
 	if len(res.ResolvedInputs) > 0 {
 		fmt.Fprintln(stdout, "  Resolved inputs:")
-		for k, v := range res.ResolvedInputs {
-			fmt.Fprintf(stdout, "    %s = %v\n", k, v)
+		keys := make([]string, 0, len(res.ResolvedInputs))
+		for k := range res.ResolvedInputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := res.ResolvedInputs[k]
+			if *verbose {
+				fmt.Fprintf(stdout, "    %s = %v\n", k, v)
+			} else {
+				fmt.Fprintf(stdout, "    %s = %s\n", k, summarizeInputValue(v))
+			}
 		}
 	}
 	if len(res.Artifacts) > 0 {
@@ -228,6 +246,33 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  Audit records: %d\n", len(res.AuditIDs))
 	}
 	return 0
+}
+
+// summarizeInputValue renders a resolved launch input as a compact
+// "<type, size>" summary (e.g. "<string, 48.2 KB>") rather than its full
+// value. The size is the byte length of the value's default string form,
+// which is exactly what an unbounded %v print would have emitted, so the
+// summary tells the operator how large a value they suppressed. This keeps a
+// plan with a large-valued input from flooding the terminal and burying the
+// launch result (#1888); -v/--verbose restores the full-value dump.
+func summarizeInputValue(v any) string {
+	s := fmt.Sprintf("%v", v)
+	return fmt.Sprintf("<%T, %s>", v, humanByteSize(len(s)))
+}
+
+// humanByteSize renders a byte count as a compact human-readable string
+// (e.g. "48.2 KB"). Counts under 1 KiB render as bytes.
+func humanByteSize(n int) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := int64(n) / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 // resolveLaunchVersion resolves the version id to launch: the explicit

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -543,8 +543,98 @@ func TestRunSkillLaunch_InputOverrideReachesImageRunner(t *testing.T) {
 	if runner.spec.Inputs["window_days"] != "30" {
 		t.Errorf("input override not threaded into the image spec: %v", runner.spec.Inputs)
 	}
-	if !strings.Contains(stdout.String(), "window_days = 30") {
-		t.Errorf("override not reflected in resolved inputs: %q", stdout.String())
+	// The default result summary lists the input by name with a "<type, size>"
+	// summary, not the raw value (#1888).
+	if !strings.Contains(stdout.String(), "window_days = <string,") {
+		t.Errorf("override not reflected in resolved-input summary: %q", stdout.String())
+	}
+}
+
+func TestHumanByteSize(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{50000, "48.8 KB"},
+		{1048576, "1.0 MB"},
+		{5 * 1024 * 1024, "5.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, c := range cases {
+		if got := humanByteSize(c.n); got != c.want {
+			t.Errorf("humanByteSize(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestSummarizeInputValue(t *testing.T) {
+	if got := summarizeInputValue("30"); got != "<string, 2 B>" {
+		t.Errorf("string summary = %q", got)
+	}
+	// Non-string values still summarize by their Go type and stringified size.
+	if got := summarizeInputValue(42); got != "<int, 2 B>" {
+		t.Errorf("int summary = %q", got)
+	}
+}
+
+// TestRunSkillLaunch_ResolvedInputsSummarizedByDefault proves the result
+// summary no longer dumps full input values: a large-valued input renders as a
+// compact "<type, size>" line rather than flooding stdout with the value
+// (#1888).
+func TestRunSkillLaunch_ResolvedInputsSummarizedByDefault(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+
+	big := strings.Repeat("x", 50000)
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ResolvedInputs: map[string]any{
+			"dashboard_template": big,
+			"window_days":        "30",
+		}},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, big) {
+		t.Errorf("full input value leaked into stdout; want summary only: %q", out)
+	}
+	if !strings.Contains(out, "dashboard_template = <string, 48.8 KB>") {
+		t.Errorf("large input not summarized as <type, size>: %q", out)
+	}
+	if !strings.Contains(out, "window_days = <string, 2 B>") {
+		t.Errorf("small input not summarized: %q", out)
+	}
+}
+
+// TestRunSkillLaunch_VerboseDumpsFullValues proves -v/--verbose restores the
+// full-value dump for operators who want to inspect resolved inputs (#1888).
+func TestRunSkillLaunch_VerboseDumpsFullValues(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ResolvedInputs: map[string]any{"window_days": "30"}},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+
+	for _, flag := range []string{"--verbose", "-v"} {
+		var stdout, stderr bytes.Buffer
+		code := runSkillLaunch([]string{"--out-dir", t.TempDir(), flag, "weekly-metrics-digest"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("%s launch exit = %d, stderr=%s", flag, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "window_days = 30") {
+			t.Errorf("%s did not dump full input value: %q", flag, stdout.String())
+		}
 	}
 }
 

--- a/docs/src/content/docs/guides/launching-a-flight-plan.md
+++ b/docs/src/content/docs/guides/launching-a-flight-plan.md
@@ -17,6 +17,8 @@ aileron skill launch weekly-metrics-digest --out-dir ./run
 
 The runtime loads the most recent frozen version of that skill from the canonical store. Pass `--version` to launch a specific version id. Pass `--input name=value` once per literal input you want to override. File-target outputs are written under `--out-dir`.
 
+The launch prints a result summary: the version, the content hash, the written artifacts, and the audit-record count. The resolved inputs are listed by name with a compact `<type, size>` summary rather than their full values, so a plan that passes a large input (such as an inlined document) does not bury the result under a wall of text. Pass `--verbose` (or `-v`) to print the full resolved-input values.
+
 ```sh
 aileron skill launch weekly-metrics-digest \
   --version 5f2a9c1e4b7d8a30 \


### PR DESCRIPTION
## Summary

`aileron skill launch` printed every resolved input value in full via `%v`, unconditionally guarded only by `len(...) > 0`. A plan that passes a large input (an inlined HTML document, thousands of lines) stringified the entire value onto a single line and flooded the terminal, pushing the useful launch result (version, content hash, artifacts, audit ids) off-screen.

This changes the resolved-input block to print a compact per-input `<type, size>` summary by default, e.g. `dashboard_template = <string, 48.8 KB>`. Keys are now sorted for stable output. A new `--verbose`/`-v` flag restores the previous full-value dump for operators who want to inspect resolved inputs.

Fixes #1888.

## Changes

- `cmd/aileron/skill_launch.go`: `--verbose`/`-v` flag; sorted-key iteration; `summarizeInputValue` + `humanByteSize` helpers; summary-by-default in the result block.
- `docs/src/content/docs/guides/launching-a-flight-plan.md`: document the summary output and the `--verbose` escape hatch.

## Test plan

- `TestRunSkillLaunch_ResolvedInputsSummarizedByDefault` — a 50 KB input value never appears in stdout; renders as `<string, 48.8 KB>`; a small input renders as `<string, 2 B>`.
- `TestRunSkillLaunch_VerboseDumpsFullValues` — both `--verbose` and `-v` restore the full-value line.
- `TestRunSkillLaunch_InputOverrideReachesImageRunner` — updated to assert the new summary form.
- `TestHumanByteSize` / `TestSummarizeInputValue` — boundary and type coverage (B/KB/MB/GB, string vs int).
- Full `cmd/aileron` package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `aileron skill launch` now shows resolved inputs in a compact, sorted summary by default.
  * Added a `--verbose` / `-v` option to display full resolved input values when needed.

* **Bug Fixes**
  * Output is now consistently ordered for easier reading.
  * Large input values are no longer printed in full unless verbose mode is enabled.

* **Documentation**
  * Updated launch guidance to describe the new summary output and verbose behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->