### PR TITLE
fix(skill-launch): decouple docker -i from TTY so batch runs don't hang

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -1356,15 +1356,16 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	)
 
 	runOpts := sandboxcontainer.RunOptions{
-		Runtime: plan.Runtime,
-		Image:   plan.Image,
-		WorkDir: config.Dir,
-		Env:     agentEnv,
-		Volumes: mounts,
-		Command: command,
-		User:    user,
-		TTY:     term.IsTerminal(int(os.Stdin.Fd())),
-		Name:    containerName,
+		Runtime:     plan.Runtime,
+		Image:       plan.Image,
+		WorkDir:     config.Dir,
+		Env:         agentEnv,
+		Volumes:     mounts,
+		Command:     command,
+		User:        user,
+		Interactive: true,
+		TTY:         term.IsTerminal(int(os.Stdin.Fd())),
+		Name:        containerName,
 	}
 
 	// Graceful-shutdown salvage (ADR-0025, R13/R15): the one-shot

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -148,7 +148,14 @@ func (execRunner) Run(ctx context.Context, name string, args []string, stdout, s
 		}
 	}
 
-	cmd.Stdin = os.Stdin
+	// Bind the host's stdin only for an interactive run (`-i` present).
+	// A batch run reads no host stdin; leaving os.Stdin attached to the
+	// docker CLI's stdin pump keeps stdin open with no EOF on a real
+	// terminal, so the run never returns and the caller hangs (issue
+	// #1889). Mirror the arg-inspection pattern interactiveTTYRun uses.
+	if interactiveRun(args) {
+		cmd.Stdin = os.Stdin
+	}
 	return cmd.Run()
 }
 
@@ -190,6 +197,23 @@ func interactiveTTYRun(args []string) bool {
 	}
 	for _, a := range args {
 		if a == "-t" {
+			return true
+		}
+	}
+	return false
+}
+
+// interactiveRun reports whether args describe a container `run` or
+// `exec` that keeps STDIN open (`-i`). Only such a command needs the
+// host's os.Stdin bound to the runtime child; a batch run reads no host
+// stdin, and binding it would leave stdin open with no EOF on a real
+// terminal so the run never returns (issue #1889).
+func interactiveRun(args []string) bool {
+	if len(args) == 0 || (args[0] != "run" && args[0] != "exec") {
+		return false
+	}
+	for _, a := range args {
+		if a == "-i" {
 			return true
 		}
 	}
@@ -295,7 +319,14 @@ type RunOptions struct {
 	Volumes []Volume
 	Command []string
 	User    string
-	TTY     bool
+	// Interactive maps to docker's `-i` (keep STDIN open even if not
+	// attached). Set it for runs whose in-container process reads the
+	// host's stdin (an agent shell). Leave it false for batch runs that
+	// read no host stdin: a batch `docker run -i` on a real terminal
+	// leaves stdin attached with no EOF, so the run never returns and the
+	// caller hangs (issue #1889).
+	Interactive bool
+	TTY         bool
 	// Name, when non-empty, is passed as `--name <Name>` so the
 	// container is addressable for a later `stop` (the AuthSpec
 	// graceful-shutdown salvage path; see ADR-0025). An anonymous
@@ -1014,7 +1045,10 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve sandbox workdir: %w", err)
 	}
-	args := []string{"run", "--rm", "-i"}
+	args := []string{"run", "--rm"}
+	if opts.Interactive {
+		args = append(args, "-i")
+	}
 	if opts.TTY {
 		args = append(args, "-t")
 	}

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1103,7 +1103,7 @@ func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
 		t.Fatalf("runtime = %q, want docker", result.Runtime)
 	}
 	want := []string{
-		"run", "--rm", "-i",
+		"run", "--rm",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
 		"--env", "A_VAR=first",
@@ -1130,7 +1130,7 @@ func TestRunCanOverrideContainerUser(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	want := []string{
-		"run", "--rm", "-i",
+		"run", "--rm",
 		"--user", "root",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
@@ -1165,7 +1165,7 @@ func TestRunMountsAdditionalReadOnlyVolumes(t *testing.T) {
 	}
 	absExtra, _ := filepath.Abs(extra)
 	want := []string{
-		"run", "--rm", "-i",
+		"run", "--rm",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
 		"--volume", absExtra + ":/opt/aileron/manifests/actions:ro",
@@ -1287,15 +1287,88 @@ func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
 func TestRunAddsTTYWhenRequested(t *testing.T) {
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron-sandbox-base:test",
-		Command: []string{"claude"},
-		TTY:     true,
+		Image:       "aileron-sandbox-base:test",
+		Command:     []string{"claude"},
+		Interactive: true,
+		TTY:         true,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if !reflect.DeepEqual(runner.args[:4], []string{"run", "--rm", "-i", "-t"}) {
 		t.Fatalf("args prefix = %#v, want tty run prefix", runner.args[:4])
+	}
+}
+
+// TestRunBatchOmitsInteractiveFlag is the regression guard for issue
+// #1889: a default (batch) RunOptions must NOT emit docker's `-i`. The
+// skill-launch path leaves Interactive false, and a batch `docker run
+// -i` on a real terminal keeps stdin attached with no EOF so the run
+// never returns and the caller hangs.
+func TestRunBatchOmitsInteractiveFlag(t *testing.T) {
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron-sandbox-base:test",
+		Command: []string{"aileron", "skill", "run"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(runner.args[:2], []string{"run", "--rm"}) {
+		t.Fatalf("args prefix = %#v, want [run --rm] with no -i", runner.args[:2])
+	}
+	for _, a := range runner.args {
+		if a == "-i" {
+			t.Fatalf("batch run args must not contain -i: %#v", runner.args)
+		}
+		if a == "-t" {
+			t.Fatalf("batch run args must not contain -t: %#v", runner.args)
+		}
+	}
+}
+
+// TestRunInteractiveEmitsInteractiveFlag pins the interactive contract:
+// an Interactive RunOptions (the agent-shell launch path) emits `-i` so
+// the in-container process keeps stdin open.
+func TestRunInteractiveEmitsInteractiveFlag(t *testing.T) {
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:       "aileron-sandbox-base:test",
+		Command:     []string{"claude"},
+		Interactive: true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(runner.args[:3], []string{"run", "--rm", "-i"}) {
+		t.Fatalf("args prefix = %#v, want [run --rm -i]", runner.args[:3])
+	}
+	for _, a := range runner.args {
+		if a == "-t" {
+			t.Fatalf("non-TTY interactive run must not contain -t: %#v", runner.args)
+		}
+	}
+}
+
+func TestInteractiveRun(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"run with -i", []string{"run", "--rm", "-i", "img", "claude"}, true},
+		{"run without -i", []string{"run", "--rm", "img", "codex"}, false},
+		{"exec with -i", []string{"exec", "-i", "c", "gh", "auth", "login"}, true},
+		{"exec without -i", []string{"exec", "c", "gh", "auth", "token"}, false},
+		{"build is never interactive", []string{"build", "-t", "tag", "."}, false},
+		{"empty", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := interactiveRun(tc.args); got != tc.want {
+				t.Fatalf("interactiveRun(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -1336,7 +1409,7 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 		t.Fatalf("runtime = %q, want docker", runner.name)
 	}
 	wantPrefix := []string{
-		"run", "--rm", "-i",
+		"run", "--rm",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
 		"--env", "HTTPS_PROXY=http://host.docker.internal:48123",


### PR DESCRIPTION
## Summary

`skill launch` hung after the flight plan completed. The skill-launch path runs the plan in a batch container that reads no host stdin, but `runArgs` (internal/sandbox/container/runtime.go) always emitted `docker run -i`. On a real terminal, `-i` with no `-t` keeps stdin attached with no EOF, so `execRunner.Run`'s `cmd.Run()` never returns and the CLI hangs. `aileron launch` was unaffected because it sets TTY and takes the PTY path.

The fix decouples `-i` from `-t` via an explicit `RunOptions.Interactive` control rather than gating `-i` on TTY-ness. Gating on TTY would also strip `-i` from the non-terminal `aileron launch` branch and regress piped/scripted agent launches, which legitimately read stdin.

Changes:
- `RunOptions.Interactive bool` (maps to docker `-i`, "keep STDIN open").
- `runArgs`: emit `-i` only when `Interactive`, `-t` only when `TTY`.
- Agent-shell launch path (launcher.go) sets `Interactive: true` — keeps `-it` on a terminal and `-i` when piped (no behavior change).
- skill-launch and Validate-probe batch paths leave `Interactive` false — the fix.
- `execRunner.Run` binds `os.Stdin` only when `-i` is present in args (new `interactiveRun` arg-inspection helper mirroring `interactiveTTYRun`) — belt-and-suspenders against the docker CLI's stdin pump.

## Test plan

- New regression test `TestRunBatchOmitsInteractiveFlag`: a default/batch `RunOptions` (Interactive:false) produces run args with no `-i` (and no `-t`) — the skill-launch contract that prevents the hang.
- New `TestRunInteractiveEmitsInteractiveFlag`: `Interactive:true` includes `-i`.
- New `TestInteractiveRun`: unit coverage of the `-i` arg-inspection helper.
- Updated the `runArgs` `want` slices that hardcoded `-i` without setting Interactive (batch + Validate probe lose `-i`; the TTY test sets `Interactive:true` to keep `-it`).
- `go test -cover ./internal/sandbox/container/... ./internal/launch/...` green (container 92.2%, launch 88.3%); `cmd/aileron` tests green. Build clean.

Closes #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)
