### PR TITLE
fix(audit): summarize resolved inputs in `audit show` instead of inlining

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -4227,7 +4227,7 @@ type auditListWire struct {
 
 const auditUsage = `usage:
   aileron audit list  [--since RFC3339] [--audit-id ID] [--connector FQN] [--class CLASS] [--output NAME] [--content-hash sha256:...] [--limit N] [--json]
-  aileron audit show  <audit-id>`
+  aileron audit show  <audit-id> [--json] [--verbose|-v]`
 
 // auditListFetcher and auditGetFetcher are the HTTP clients for the
 // two audit endpoints. Replaceable in tests so they don't depend on a
@@ -4405,12 +4405,15 @@ func runAuditList(args []string, stdout, stderr io.Writer) int {
 func runAuditShow(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("audit show", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	if err := flags.Parse(args); err != nil {
+	asJSON := flags.Bool("json", false, "Render the complete event record as indented JSON")
+	verbose := flags.Bool("verbose", false, "Print full resolved input values instead of a type+size summary")
+	flags.BoolVar(verbose, "v", false, "Shorthand for --verbose")
+	rest, err := parseInterspersedFlags(flags, args)
+	if err != nil {
 		return 1
 	}
-	rest := flags.Args()
 	if len(rest) != 1 {
-		fmt.Fprintln(stderr, "usage: aileron audit show <audit-id>")
+		fmt.Fprintln(stderr, "usage: aileron audit show <audit-id> [--json] [--verbose|-v]")
 		return 1
 	}
 	ev, status, err := auditGetFetcher(rest[0])
@@ -4422,13 +4425,137 @@ func runAuditShow(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "audit event %q not found\n", rest[0])
 		return 1
 	}
-	enc := json.NewEncoder(stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(ev); err != nil {
-		fmt.Fprintf(stderr, "encode: %v\n", err)
-		return 1
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(ev); err != nil {
+			fmt.Fprintf(stderr, "encode: %v\n", err)
+			return 1
+		}
+		return 0
 	}
+	renderAuditShow(stdout, ev, *verbose)
 	return 0
+}
+
+// renderAuditShow prints a legible, multi-line view of a single audit
+// event. It surfaces the provenance fields an operator reads a record for
+// (actor, plan/skill + signer, step, input hashes) and, by default,
+// summarizes each resolved input as a compact "name · <type, size>"
+// descriptor rather than inlining its full value. A large literal input
+// (e.g. an embedded 50 KB document) would otherwise dominate the record and
+// bury the provenance (issue #1892). --json restores the complete
+// machine-readable record; --verbose restores the full resolved-input
+// values inside this human rendering, reusing the exact summarize/verbose
+// contract shipped for `skill launch` (#1888/#1895).
+//
+// Payload keys follow the OTel-namespaced audit schema (issue #390). Missing
+// keys are omitted; empty values are never printed. The payload comes from
+// arbitrary decoded JSON, so every type assertion is guarded.
+func renderAuditShow(w io.Writer, e *auditEventWire, verbose bool) {
+	fmt.Fprintf(w, "Audit ID:    %s\n", e.AuditID)
+	fmt.Fprintf(w, "Event:       %s\n", e.EventType)
+	if !e.Timestamp.IsZero() {
+		fmt.Fprintf(w, "Timestamp:   %s\n", e.Timestamp.Local().Format("2006-01-02 15:04:05"))
+	}
+	p := e.Payload
+
+	// Actor: struct fields first, then any namespaced payload overrides.
+	actorType := e.Actor.Type
+	if s := payloadString(p, "aileron.actor.type"); s != "" {
+		actorType = s
+	}
+	actorID := e.Actor.ID
+	if s := payloadString(p, "aileron.actor.id"); s != "" {
+		actorID = s
+	}
+	if actorType != "" || actorID != "" {
+		fmt.Fprintf(w, "Actor:       %s\n", strings.TrimSpace(actorType+" "+actorID))
+	}
+
+	// Plan / skill + signer.
+	printAuditField(w, "Plan:", payloadString(p, "aileron.plan.name"))
+	printAuditField(w, "Plan version:", payloadString(p, "aileron.plan.version"))
+	printAuditField(w, "Signer:", payloadString(p, "aileron.plan.signer"))
+
+	// Step provenance.
+	printAuditField(w, "Step ID:", payloadString(p, "aileron.step.id"))
+	printAuditField(w, "Step kind:", payloadString(p, "aileron.step.kind"))
+	printAuditField(w, "Transform:", payloadString(p, "aileron.step.transform"))
+	if cmd, ok := p["aileron.step.command"].([]any); ok && len(cmd) > 0 {
+		parts := make([]string, 0, len(cmd))
+		for _, a := range cmd {
+			parts = append(parts, fmt.Sprintf("%v", a))
+		}
+		fmt.Fprintf(w, "Command:     %s\n", strings.Join(parts, " "))
+	}
+
+	// Output provenance.
+	printAuditField(w, "Output:", payloadString(p, "aileron.output.name"))
+	printAuditField(w, "Content hash:", payloadString(p, "aileron.output.content_hash"))
+	printAuditField(w, "Output path:", payloadString(p, "aileron.output.path"))
+
+	// Input hashes: each entry is a map after JSON decode.
+	if inputs, ok := p["aileron.step.inputs"].([]any); ok && len(inputs) > 0 {
+		fmt.Fprintln(w, "Input hashes:")
+		for _, item := range inputs {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			binding, _ := m["binding"].(string)
+			hash, _ := m["content_hash"].(string)
+			label := binding
+			if label == "" {
+				if src, ok := m["source"].(string); ok {
+					label = src
+				}
+			}
+			switch {
+			case label != "" && hash != "":
+				fmt.Fprintf(w, "    %s  %s\n", label, hash)
+			case hash != "":
+				fmt.Fprintf(w, "    %s\n", hash)
+			case label != "":
+				fmt.Fprintf(w, "    %s\n", label)
+			}
+		}
+	}
+
+	// Resolved inputs: a map after JSON decode. Sort keys (mirrors launch
+	// output). Default summarizes each value; --verbose prints it in full.
+	if resolved, ok := p["aileron.resolved_inputs"].(map[string]any); ok && len(resolved) > 0 {
+		fmt.Fprintln(w, "Resolved inputs:")
+		names := make([]string, 0, len(resolved))
+		for k := range resolved {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			v := resolved[name]
+			if verbose {
+				fmt.Fprintf(w, "    %s · %v\n", name, v)
+			} else {
+				fmt.Fprintf(w, "    %s · %s\n", name, summarizeInputValue(v))
+			}
+		}
+	}
+}
+
+// payloadString reads a string-valued payload key, returning "" when the
+// key is absent or not a string.
+func payloadString(p map[string]any, key string) string {
+	s, _ := p[key].(string)
+	return s
+}
+
+// printAuditField writes a "label value" line only when value is non-empty,
+// mirroring auditPayloadSummary's omit-missing discipline.
+func printAuditField(w io.Writer, label, value string) {
+	if value == "" {
+		return
+	}
+	fmt.Fprintf(w, "%-13s%s\n", label, value)
 }
 
 // auditPayloadSummary renders a one-line, human-readable hint about

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -4453,10 +4453,10 @@ func runAuditShow(args []string, stdout, stderr io.Writer) int {
 // keys are omitted; empty values are never printed. The payload comes from
 // arbitrary decoded JSON, so every type assertion is guarded.
 func renderAuditShow(w io.Writer, e *auditEventWire, verbose bool) {
-	fmt.Fprintf(w, "Audit ID:    %s\n", e.AuditID)
-	fmt.Fprintf(w, "Event:       %s\n", e.EventType)
+	printAuditField(w, "Audit ID:", e.AuditID)
+	printAuditField(w, "Event:", e.EventType)
 	if !e.Timestamp.IsZero() {
-		fmt.Fprintf(w, "Timestamp:   %s\n", e.Timestamp.Local().Format("2006-01-02 15:04:05"))
+		printAuditField(w, "Timestamp:", e.Timestamp.Local().Format("2006-01-02 15:04:05"))
 	}
 	p := e.Payload
 
@@ -4469,9 +4469,7 @@ func renderAuditShow(w io.Writer, e *auditEventWire, verbose bool) {
 	if s := payloadString(p, "aileron.actor.id"); s != "" {
 		actorID = s
 	}
-	if actorType != "" || actorID != "" {
-		fmt.Fprintf(w, "Actor:       %s\n", strings.TrimSpace(actorType+" "+actorID))
-	}
+	printAuditField(w, "Actor:", strings.TrimSpace(actorType+" "+actorID))
 
 	// Plan / skill + signer.
 	printAuditField(w, "Plan:", payloadString(p, "aileron.plan.name"))
@@ -4487,7 +4485,7 @@ func renderAuditShow(w io.Writer, e *auditEventWire, verbose bool) {
 		for _, a := range cmd {
 			parts = append(parts, fmt.Sprintf("%v", a))
 		}
-		fmt.Fprintf(w, "Command:     %s\n", strings.Join(parts, " "))
+		printAuditField(w, "Command:", strings.Join(parts, " "))
 	}
 
 	// Output provenance.
@@ -4550,12 +4548,15 @@ func payloadString(p map[string]any, key string) string {
 }
 
 // printAuditField writes a "label value" line only when value is non-empty,
-// mirroring auditPayloadSummary's omit-missing discipline.
+// mirroring auditPayloadSummary's omit-missing discipline. The label is
+// padded to a fixed column and always followed by a separating space, so a
+// label at (or past) the column width still renders "label value", never
+// "labelvalue".
 func printAuditField(w io.Writer, label, value string) {
 	if value == "" {
 		return
 	}
-	fmt.Fprintf(w, "%-13s%s\n", label, value)
+	fmt.Fprintf(w, "%-13s %s\n", label, value)
 }
 
 // auditPayloadSummary renders a one-line, human-readable hint about

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -7867,8 +7867,9 @@ func TestRunAudit_FetcherErrorExitsNonZero(t *testing.T) {
 	}
 }
 
-// TestRunAuditShow_HappyPath: `aileron audit show <id>` prints the
-// event as pretty JSON.
+// TestRunAuditShow_HappyPath: `aileron audit show <id> --json` prints the
+// event as pretty JSON. The full-JSON contract now lives behind --json;
+// the bare default renders a human summary (see the *Default*/*Verbose* tests).
 func TestRunAuditShow_HappyPath(t *testing.T) {
 	prev := auditGetFetcher
 	auditGetFetcher = func(id string) (*auditEventWire, int, error) {
@@ -7885,7 +7886,7 @@ func TestRunAuditShow_HappyPath(t *testing.T) {
 	defer func() { auditGetFetcher = prev }()
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"audit", "show", "audit-xyz"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"audit", "show", "audit-xyz", "--json"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -7899,7 +7900,7 @@ func TestRunAuditShow_HappyPath(t *testing.T) {
 }
 
 // TestRunAuditShow_RendersFullMaterializedRecord locks the acceptance
-// guarantee that `audit show` renders the complete output.materialized
+// guarantee that `audit show --json` renders the complete output.materialized
 // event, including every aileron.output.* provenance key, verbatim.
 func TestRunAuditShow_RendersFullMaterializedRecord(t *testing.T) {
 	prev := auditGetFetcher
@@ -7920,7 +7921,7 @@ func TestRunAuditShow_RendersFullMaterializedRecord(t *testing.T) {
 	defer func() { auditGetFetcher = prev }()
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"audit", "show", "out-1"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"audit", "show", "out-1", "--json"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -7937,7 +7938,7 @@ func TestRunAuditShow_RendersFullMaterializedRecord(t *testing.T) {
 }
 
 // TestRunAuditShow_RendersToolStepProvenance locks the #1762 acceptance
-// guarantee (retargeted by #1829) that `audit show` renders a tool-step
+// guarantee (retargeted by #1829) that `audit show --json` renders a tool-step
 // output.materialized event verbatim, including aileron.step.kind:"tool" and
 // the executed aileron.step.command argv, through the SAME show surface the
 // connector path uses.
@@ -7959,7 +7960,7 @@ func TestRunAuditShow_RendersToolStepProvenance(t *testing.T) {
 	defer func() { auditGetFetcher = prev }()
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"audit", "show", "tool-out"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"audit", "show", "tool-out", "--json"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -8015,6 +8016,117 @@ func TestRunAuditShow_RequiresAuditID(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "audit-id") {
 		t.Errorf("stderr should mention audit-id; got: %s", stderr.String())
+	}
+}
+
+// showResolvedInputEvent returns a stub fetcher for an output.materialized
+// event whose resolved_inputs hold an oversized literal, plus a little
+// provenance. Shared by the default/verbose tests below.
+func showResolvedInputEvent(bigValue string) func(string) (*auditEventWire, int, error) {
+	return func(_ string) (*auditEventWire, int, error) {
+		return &auditEventWire{
+			AuditID:   "resolved-1",
+			EventType: "output.materialized",
+			Timestamp: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			Payload: map[string]any{
+				"aileron.step.kind": "transform",
+				"aileron.step.inputs": []any{
+					map[string]any{"binding": "html_doc", "content_hash": "sha256:beef"},
+				},
+				"aileron.resolved_inputs": map[string]any{
+					"html_doc": bigValue,
+					"mode":     "csv",
+				},
+			},
+		}, http.StatusOK, nil
+	}
+}
+
+// TestRunAuditShow_DefaultSummarizesResolvedInputs is the regression test for
+// #1892: the bare `audit show` default must NOT inline a large resolved-input
+// value; it must render a compact descriptor instead, while still surfacing
+// provenance. On base (JSON default) this failed because the raw value was
+// inlined in the JSON dump.
+func TestRunAuditShow_DefaultSummarizesResolvedInputs(t *testing.T) {
+	big := strings.Repeat("x", 50000)
+	prev := auditGetFetcher
+	auditGetFetcher = showResolvedInputEvent(big)
+	defer func() { auditGetFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"audit", "show", "resolved-1"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, big) {
+		t.Errorf("default output inlined the raw 50k value; it should summarize.\n%s", out)
+	}
+	if !strings.Contains(out, "html_doc") {
+		t.Errorf("output missing the resolved-input name html_doc; got:\n%s", out)
+	}
+	// Compact descriptor: type marker from summarizeInputValue + a size token.
+	if !strings.Contains(out, "<string,") {
+		t.Errorf("output missing the <string, ...> type descriptor; got:\n%s", out)
+	}
+	if !strings.Contains(out, "KB") {
+		t.Errorf("output missing a human size token (KB); got:\n%s", out)
+	}
+	// Provenance survives the summarization.
+	if !strings.Contains(out, "output.materialized") {
+		t.Errorf("output missing event type; got:\n%s", out)
+	}
+	if !strings.Contains(out, "transform") {
+		t.Errorf("output missing the step kind; got:\n%s", out)
+	}
+}
+
+// TestRunAuditShow_VerboseShowsFullValues: --verbose (and -v) restore the full
+// resolved-input value inside the human rendering.
+func TestRunAuditShow_VerboseShowsFullValues(t *testing.T) {
+	big := strings.Repeat("x", 50000)
+	prev := auditGetFetcher
+	auditGetFetcher = showResolvedInputEvent(big)
+	defer func() { auditGetFetcher = prev }()
+
+	for _, flag := range []string{"--verbose", "-v"} {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"audit", "show", "resolved-1", flag}, newTestRegistry(), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("%s: exit = %d, want 0; stderr=%s", flag, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), big) {
+			t.Errorf("%s: output should contain the full raw value", flag)
+		}
+	}
+}
+
+// TestRunAuditShow_JSONEmitsCompleteRecord: --json round-trips the event and
+// keeps the machine-readable provenance keys verbatim.
+func TestRunAuditShow_JSONEmitsCompleteRecord(t *testing.T) {
+	big := strings.Repeat("x", 50000)
+	prev := auditGetFetcher
+	auditGetFetcher = showResolvedInputEvent(big)
+	defer func() { auditGetFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"audit", "show", "resolved-1", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	var got auditEventWire
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v; out=%s", err, stdout.String())
+	}
+	if got.AuditID != "resolved-1" || got.EventType != "output.materialized" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "aileron.resolved_inputs") {
+		t.Errorf("--json should emit the raw resolved_inputs key; got:\n%s", out)
+	}
+	if !strings.Contains(out, big) {
+		t.Error("--json is the machine escape hatch; it should carry the full value")
 	}
 }
 


### PR DESCRIPTION
## Summary

`aileron audit show <id>` rendered the full event as indented JSON, so a large literal `aileron.resolved_inputs` value (e.g. an embedded 50 KB document) dominated the record and buried the provenance fields an operator opens the record to read.

This makes a legible human rendering the **default**. It surfaces the identifying fields:
- audit id, event type, timestamp (local, `2006-01-02 15:04:05` — matches `audit list`)
- actor (struct fields + any `aileron.actor.*` payload overrides)
- plan/skill name, version, signer
- step id / kind / transform / command (argv joined for display)
- output name / content hash / path
- input hashes (`aileron.step.inputs[].binding` + `content_hash`)
- each resolved input as a compact `name · <type, size>` descriptor instead of the raw value

Two escape hatches, matching the shipped `skill launch` #1888/#1895 contract exactly:
- `--json` restores the prior full-indented-JSON record, **byte-for-byte unchanged** (machine escape hatch).
- `--verbose`/`-v` keeps the human rendering but prints the **full** resolved-input values.

No byte threshold: all resolved-input values are summarized by default. Reuses `summarizeInputValue`/`humanByteSize` from `skill_launch.go` unchanged.

Scope is CLI presentation only. No change to `/v1/audit`, `auditEventWire`, or anything `internal/flightplan/runtime/audit.go` records. No OpenAPI change.

## Test plan

- `go build ./cmd/aileron` and `go vet ./cmd/aileron` — clean.
- `go test ./cmd/aileron -count=1` — full package green.
- New `TestRunAuditShow_DefaultSummarizesResolvedInputs` (the regression): with a 50 KB resolved input, the default output must NOT inline the raw value, MUST show the `html_doc` name + `<string,` type marker + a `KB` size token, and MUST still surface provenance (event type, step kind). **Confirmed red on `origin/main`** (base default JSON inlines the value) and green after.
- New `TestRunAuditShow_VerboseShowsFullValues` — `--verbose` and `-v` both restore the full value.
- New `TestRunAuditShow_JSONEmitsCompleteRecord` — `--json` round-trips `AuditID`/`EventType`, emits raw `aileron.resolved_inputs`, and carries the full value.
- Retargeted the three existing default-JSON tests (`HappyPath`, `RendersFullMaterializedRecord`, `RendersToolStepProvenance`) to pass `--json`, so they keep locking the machine-readable full-record contract that `--json` now provides. `NotFoundExitsNonZero` and `RequiresAuditID` untouched.

Flags parse via the existing `parseInterspersedFlags` helper, so `audit show <id> --json` (flag after the positional) works.

Closes #1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)
