### PR TITLE
feat(webapp): add /audit provenance walk-back view

### DIFF
--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { decideActionApproval, getHubInstallDecision } from './api';
-import type { HubInstallDecision } from './api';
+import {
+	decideActionApproval,
+	getHubInstallDecision,
+	listRecentMaterialized,
+	getAuditByContentHash,
+	getAuditByInvocation
+} from './api';
+import type { HubInstallDecision, AuditEvent } from './api';
 
 // Regression target: the user clicked "Approve" in the webapp, the
 // daemon executed the action successfully, but the page surfaced
@@ -170,5 +176,117 @@ describe('getHubInstallDecision — key_divergence mirror (#1419)', () => {
 
 		expect(got.key_divergence).toBeUndefined();
 		expect(got.trust_state).toBe('already_trusted');
+	});
+});
+
+// --- Audit provenance wrappers (#1891) ---
+//
+// The provenance view reads `GET /v1/audit` same-origin via `apiFetch`.
+// These tests pin the URL each wrapper builds (with encoding), the
+// unwrap of `AuditListResponse.events`, and the empty-result contract.
+// The handshake is a cached module-level promise; because it is resolved
+// by an earlier test's fetch, we locate the audit call by URL rather than
+// by call index so ordering does not matter.
+
+function auditCall(
+	fetchSpy: ReturnType<typeof vi.spyOn>,
+	needle: string
+): string {
+	const call = fetchSpy.mock.calls.find((args: unknown[]) =>
+		String(args[0]).includes(needle)
+	);
+	expect(call, `expected a fetch to a URL containing ${needle}`).toBeTruthy();
+	return String(call![0]);
+}
+
+function auditResponse(events: AuditEvent[]): Response {
+	return new Response(JSON.stringify({ events }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
+const materializedEvent: AuditEvent = {
+	audit_id: 'a1',
+	event_type: 'output.materialized',
+	timestamp: '2026-07-04T00:00:00Z',
+	payload: {
+		'aileron.output.name': 'report.csv',
+		'aileron.output.content_hash': 'sha256:deadbeef'
+	}
+};
+
+const nonMaterializedEvent: AuditEvent = {
+	audit_id: 'a2',
+	event_type: 'flightplan.launch',
+	timestamp: '2026-07-04T00:00:00Z',
+	payload: { sourceInputBindings: {} }
+};
+
+describe('audit wrappers — URL construction and unwrap', () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, 'fetch');
+	});
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('listRecentMaterialized requests /v1/audit?limit and keeps only records with an output content hash', async () => {
+		fetchSpy.mockResolvedValue(
+			auditResponse([materializedEvent, nonMaterializedEvent])
+		);
+
+		const got = await listRecentMaterialized(25);
+
+		const url = auditCall(fetchSpy, '/v1/audit?limit=');
+		expect(url).toContain('limit=25');
+		expect(got).toHaveLength(1);
+		expect(got[0].audit_id).toBe('a1');
+	});
+
+	it('getAuditByContentHash encodes the hash into the content_hash filter', async () => {
+		fetchSpy.mockResolvedValue(auditResponse([materializedEvent]));
+
+		const got = await getAuditByContentHash('sha256:dead beef');
+
+		const url = auditCall(fetchSpy, 'content_hash=');
+		expect(url).toContain('content_hash=sha256%3Adead%20beef');
+		expect(got).toHaveLength(1);
+	});
+
+	it('getAuditByInvocation encodes the id into the invocation_id filter', async () => {
+		fetchSpy.mockResolvedValue(
+			auditResponse([materializedEvent, nonMaterializedEvent])
+		);
+
+		const got = await getAuditByInvocation('inv/42');
+
+		const url = auditCall(fetchSpy, 'invocation_id=');
+		expect(url).toContain('invocation_id=inv%2F42');
+		// No client-side filtering on invocation: both records come back.
+		expect(got).toHaveLength(2);
+	});
+
+	it('returns [] when the daemon reports no events', async () => {
+		// A Response body can only be read once, so return a fresh Response
+		// per fetch call rather than sharing one instance across awaits.
+		fetchSpy.mockImplementation(async () => auditResponse([]));
+		expect(await getAuditByContentHash('sha256:none')).toEqual([]);
+		expect(await getAuditByInvocation('inv-none')).toEqual([]);
+		expect(await listRecentMaterialized()).toEqual([]);
+	});
+
+	it('surfaces a non-2xx via apiFetch throwing', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: 'audit list failed' } }), {
+				status: 500,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		await expect(getAuditByContentHash('sha256:x')).rejects.toThrow(
+			'audit list failed'
+		);
 	});
 });

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -98,6 +98,78 @@ export async function unlockLocalVault(passphrase: string): Promise<LocalVaultSt
 	return res.json();
 }
 
+// --- Audit provenance (#1891) ---
+//
+// The provenance view (`/audit`) reads `GET /v1/audit` same-origin via
+// `apiFetch`. The wire shape is `AuditListResponse` = `{ events: [] }`
+// where each `AuditEvent` carries a free-form `payload` map. The
+// provenance keys we render (`aileron.output.*`, `aileron.step.*`,
+// `aileron.plan.*`, `aileron.actor.*`, `aileron.invocation.id`) live
+// flat inside that payload (see internal/flightplan/runtime/audit.go),
+// so the webapp models `payload` as an untyped map and reads the keys
+// through the typed getters in `$lib/audit/payload`. Filtering the wire
+// shape into a strong type here would lie about what the daemon sends.
+
+/** Actor reference on an audit event. Mirrors `ActorRef` in the spec;
+ *  the daemon normalizes `aileron.actor.identity_label` /
+ *  `aileron.actor.credential_binding` onto this object at ingest. */
+export type AuditActorRef = {
+	id: string;
+	type: 'agent' | 'human' | 'service' | 'connector_runtime';
+	display_name?: string;
+	identity_label?: string;
+	credential_binding?: string;
+};
+
+/** One audit-log entry. `payload` is deliberately untyped: the provenance
+ *  keys are flat `aileron.*` strings inside it, read through the payload
+ *  getters rather than a strongly-typed wire shape. */
+export type AuditEvent = {
+	audit_id: string;
+	event_type: string;
+	timestamp: string;
+	actor?: AuditActorRef;
+	payload: Record<string, unknown>;
+};
+
+type AuditListResponse = {
+	events?: AuditEvent[];
+};
+
+/** The `output.materialized` discriminator (internal/model EventTypeOutputMaterialized). */
+export const EVENT_OUTPUT_MATERIALIZED = 'output.materialized';
+
+/** Lists recent materialized-output provenance records for the landing
+ *  view. Fetches the most recent audit events and filters to those that
+ *  carry `aileron.output.content_hash` in their payload — robust to the
+ *  exact discriminator string, since only a materialized-output record
+ *  carries that key. */
+export async function listRecentMaterialized(limit = 100): Promise<AuditEvent[]> {
+	const resp = await apiFetch<AuditListResponse>(`/v1/audit?limit=${encodeURIComponent(String(limit))}`);
+	const events = resp.events ?? [];
+	return events.filter(
+		(e) => typeof e.payload?.['aileron.output.content_hash'] === 'string'
+	);
+}
+
+/** Resolves the audit event(s) for a single artifact content hash. The
+ *  daemon supports the `content_hash` filter on `GET /v1/audit`. */
+export async function getAuditByContentHash(hash: string): Promise<AuditEvent[]> {
+	const resp = await apiFetch<AuditListResponse>(
+		`/v1/audit?content_hash=${encodeURIComponent(hash)}`
+	);
+	return resp.events ?? [];
+}
+
+/** Resolves every audit record correlated by a launch invocation id.
+ *  The daemon supports the `invocation_id` filter (#1893/#1907). */
+export async function getAuditByInvocation(id: string): Promise<AuditEvent[]> {
+	const resp = await apiFetch<AuditListResponse>(
+		`/v1/audit?invocation_id=${encodeURIComponent(id)}`
+	);
+	return resp.events ?? [];
+}
+
 // --- Action-level approvals (#418) ---
 //
 // The action-approval queue is the runtime-blocking shape: one entry

--- a/webapp/src/lib/audit/payload.test.ts
+++ b/webapp/src/lib/audit/payload.test.ts
@@ -54,9 +54,9 @@ describe('stepInputs', () => {
 		expect(stepInputs(ev({ 'aileron.step.inputs': 'nope' }))).toEqual([]);
 		expect(stepInputs(ev({}))).toEqual([]);
 	});
-	it('skips malformed entries', () => {
-		expect(stepInputs(ev({ 'aileron.step.inputs': [null, 42, { binding: 'ok' }] }))).toEqual([
-			{ binding: 'ok' }
-		]);
+	it('skips malformed entries, including objects without a real binding', () => {
+		expect(
+			stepInputs(ev({ 'aileron.step.inputs': [null, 42, {}, { binding: '' }, { binding: 'ok' }] }))
+		).toEqual([{ binding: 'ok' }]);
 	});
 });

--- a/webapp/src/lib/audit/payload.test.ts
+++ b/webapp/src/lib/audit/payload.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { shortHash, formatBytes, stepInputs } from './payload';
+import type { AuditEvent } from '$lib/api';
+
+describe('shortHash', () => {
+	it('abbreviates a sha256 hash keeping the algorithm prefix', () => {
+		expect(shortHash('sha256:0123456789abcdef0123456789abcdef')).toBe('sha256:01234567…cdef');
+	});
+	it('returns a short hash unchanged', () => {
+		expect(shortHash('sha256:abc')).toBe('sha256:abc');
+	});
+	it('handles a bare hex digest with no prefix', () => {
+		expect(shortHash('0123456789abcdef0123')).toBe('01234567…0123');
+	});
+	it('returns empty for undefined', () => {
+		expect(shortHash(undefined)).toBe('');
+	});
+});
+
+describe('formatBytes', () => {
+	it('renders bytes below 1KB verbatim', () => {
+		expect(formatBytes(512)).toBe('512 B');
+	});
+	it('renders KB with one decimal below 10', () => {
+		expect(formatBytes(1536)).toBe('1.5 KB');
+	});
+	it('renders MB', () => {
+		expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+	});
+	it('returns empty for undefined', () => {
+		expect(formatBytes(undefined)).toBe('');
+	});
+});
+
+describe('stepInputs', () => {
+	function ev(payload: Record<string, unknown>): AuditEvent {
+		return { audit_id: 'x', event_type: 'output.materialized', timestamp: 't', payload };
+	}
+	it('coerces well-formed entries', () => {
+		const got = stepInputs(
+			ev({
+				'aileron.step.inputs': [
+					{ binding: 'a', source: 's', content_hash: 'sha256:h' },
+					{ binding: 'b', source: 'lit' }
+				]
+			})
+		);
+		expect(got).toEqual([
+			{ binding: 'a', source: 's', content_hash: 'sha256:h' },
+			{ binding: 'b', source: 'lit' }
+		]);
+	});
+	it('returns [] for a non-array value', () => {
+		expect(stepInputs(ev({ 'aileron.step.inputs': 'nope' }))).toEqual([]);
+		expect(stepInputs(ev({}))).toEqual([]);
+	});
+	it('skips malformed entries', () => {
+		expect(stepInputs(ev({ 'aileron.step.inputs': [null, 42, { binding: 'ok' }] }))).toEqual([
+			{ binding: 'ok' }
+		]);
+	});
+});

--- a/webapp/src/lib/audit/payload.ts
+++ b/webapp/src/lib/audit/payload.ts
@@ -1,0 +1,142 @@
+// Typed accessors over the flat `aileron.*` provenance keys that live
+// inside an audit event's free-form `payload` map.
+//
+// The runtime emits provenance as flat string-keyed payload entries (see
+// internal/flightplan/runtime/audit.go). Rather than pretend the wire
+// shape is strongly typed, the webapp reads the keys it needs through
+// these small getters, each of which is defensive about a missing or
+// wrong-typed value. This keeps the provenance-graph module (which is
+// pure and heavily unit-tested) free of `unknown`-narrowing noise.
+
+import type { AuditEvent } from '$lib/api';
+
+/** One `aileron.step.inputs[]` entry: a producing binding, the reference
+ *  it resolved, and (for a hashed input) the content hash of the value it
+ *  carried. A literal input has no `content_hash`. */
+export type StepInput = {
+	binding: string;
+	source?: string;
+	content_hash?: string;
+	query_execution_id?: string;
+};
+
+function str(payload: Record<string, unknown>, key: string): string | undefined {
+	const v = payload[key];
+	return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function num(payload: Record<string, unknown>, key: string): number | undefined {
+	const v = payload[key];
+	return typeof v === 'number' ? v : undefined;
+}
+
+export function outputName(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.output.name');
+}
+export function outputMime(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.output.mime');
+}
+export function outputContentHash(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.output.content_hash');
+}
+export function outputBytes(e: AuditEvent): number | undefined {
+	return num(e.payload, 'aileron.output.bytes');
+}
+export function outputPath(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.output.path');
+}
+
+export function stepId(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.step.id');
+}
+export function stepKind(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.step.kind');
+}
+export function stepTransform(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.step.transform');
+}
+export function stepCommand(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.step.command');
+}
+
+/** Reads the `aileron.step.inputs[]` walk-back list, coercing each entry
+ *  defensively. A non-array or malformed value yields an empty list. */
+export function stepInputs(e: AuditEvent): StepInput[] {
+	const raw = e.payload['aileron.step.inputs'];
+	if (!Array.isArray(raw)) return [];
+	const out: StepInput[] = [];
+	for (const item of raw) {
+		if (item === null || typeof item !== 'object') continue;
+		const obj = item as Record<string, unknown>;
+		const binding = typeof obj.binding === 'string' ? obj.binding : '';
+		const entry: StepInput = { binding };
+		if (typeof obj.source === 'string') entry.source = obj.source;
+		if (typeof obj.content_hash === 'string') entry.content_hash = obj.content_hash;
+		if (typeof obj.query_execution_id === 'string')
+			entry.query_execution_id = obj.query_execution_id;
+		out.push(entry);
+	}
+	return out;
+}
+
+export function planSkill(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.plan.skill');
+}
+export function planSignedBy(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.plan.signed_by');
+}
+export function planSignatureStatus(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.plan.signature_status');
+}
+export function planContentHash(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.plan.content_hash');
+}
+
+/** Actor identity label: prefers the normalized `actor.identity_label`,
+ *  falling back to the flat payload key. */
+export function actorIdentityLabel(e: AuditEvent): string | undefined {
+	return e.actor?.identity_label ?? str(e.payload, 'aileron.actor.identity_label');
+}
+export function actorCredentialBinding(e: AuditEvent): string | undefined {
+	return e.actor?.credential_binding ?? str(e.payload, 'aileron.actor.credential_binding');
+}
+export function actorConnectorVersion(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.actor.connector_version');
+}
+export function actorConnectorHash(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.actor.connector_hash');
+}
+export function consentDecision(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.consent.decision');
+}
+
+export function invocationId(e: AuditEvent): string | undefined {
+	return str(e.payload, 'aileron.invocation.id');
+}
+
+// --- formatting helpers (reused by cards) ---
+
+/** Shortens a `sha256:<hex>` (or bare hex) content hash for card display,
+ *  keeping the algorithm prefix and the first/last few hex chars. */
+export function shortHash(hash: string | undefined): string {
+	if (!hash) return '';
+	const [algo, hex] = hash.includes(':') ? hash.split(':', 2) : ['', hash];
+	if (hex.length <= 12) return hash;
+	const abbreviated = `${hex.slice(0, 8)}…${hex.slice(-4)}`;
+	return algo ? `${algo}:${abbreviated}` : abbreviated;
+}
+
+/** Human-readable byte-size formatter (B / KB / MB / GB, base-1024). */
+export function formatBytes(bytes: number | undefined): string {
+	if (bytes === undefined || bytes < 0) return '';
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ['KB', 'MB', 'GB', 'TB'];
+	let value = bytes / 1024;
+	let unit = 0;
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024;
+		unit++;
+	}
+	const rounded = value < 10 ? value.toFixed(1) : Math.round(value).toString();
+	return `${rounded} ${units[unit]}`;
+}

--- a/webapp/src/lib/audit/payload.ts
+++ b/webapp/src/lib/audit/payload.ts
@@ -68,8 +68,10 @@ export function stepInputs(e: AuditEvent): StepInput[] {
 	for (const item of raw) {
 		if (item === null || typeof item !== 'object') continue;
 		const obj = item as Record<string, unknown>;
-		const binding = typeof obj.binding === 'string' ? obj.binding : '';
-		const entry: StepInput = { binding };
+		// A step input without a real binding name is not a usable walk-back
+		// entry; skip it alongside the other malformed shapes.
+		if (typeof obj.binding !== 'string' || obj.binding.length === 0) continue;
+		const entry: StepInput = { binding: obj.binding };
 		if (typeof obj.source === 'string') entry.source = obj.source;
 		if (typeof obj.content_hash === 'string') entry.content_hash = obj.content_hash;
 		if (typeof obj.query_execution_id === 'string')

--- a/webapp/src/lib/audit/provenance.test.ts
+++ b/webapp/src/lib/audit/provenance.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { assembleProvenance, type ResolveByHash } from './provenance';
+import type { AuditEvent } from '$lib/api';
+
+// Fixture builder for a materialized-output audit event. Only the flat
+// `aileron.*` payload keys the walk-back reads are set.
+function output(opts: {
+	hash: string;
+	name?: string;
+	mime?: string;
+	bytes?: number;
+	stepId?: string;
+	kind?: string;
+	transform?: string;
+	command?: string;
+	skill?: string;
+	actor?: string;
+	inputs?: Array<{ binding: string; source?: string; content_hash?: string; query_execution_id?: string }>;
+}): AuditEvent {
+	const payload: Record<string, unknown> = {
+		'aileron.output.name': opts.name ?? 'artifact',
+		'aileron.output.content_hash': opts.hash,
+		'aileron.output.mime': opts.mime ?? 'text/csv',
+		'aileron.output.bytes': opts.bytes ?? 1024,
+		'aileron.step.id': opts.stepId ?? 'step-x',
+		'aileron.step.kind': opts.kind ?? 'action_call'
+	};
+	if (opts.transform) payload['aileron.step.transform'] = opts.transform;
+	if (opts.command) payload['aileron.step.command'] = opts.command;
+	if (opts.skill) payload['aileron.plan.skill'] = opts.skill;
+	if (opts.actor) payload['aileron.actor.identity_label'] = opts.actor;
+	if (opts.inputs) payload['aileron.step.inputs'] = opts.inputs;
+	return {
+		audit_id: `evt-${opts.hash}`,
+		event_type: 'output.materialized',
+		timestamp: '2026-07-04T00:00:00Z',
+		payload
+	};
+}
+
+function mapResolver(events: AuditEvent[]): ResolveByHash {
+	const byHash = new Map<string, AuditEvent>();
+	for (const e of events) {
+		const h = e.payload['aileron.output.content_hash'];
+		if (typeof h === 'string') byHash.set(h, e);
+	}
+	return async (hash) => byHash.get(hash) ?? null;
+}
+
+const kinds = (g: { nodes: Array<{ kind: string }> }) => g.nodes.map((n) => n.kind).sort();
+
+describe('assembleProvenance — linear chain', () => {
+	it('walks artifact → step → upstream artifact → step → launch', async () => {
+		const upstream = output({ hash: 'sha256:up', name: 'raw.json', skill: 'ingest' });
+		const root = output({
+			hash: 'sha256:root',
+			name: 'report.csv',
+			skill: 'ingest',
+			actor: 'analyst',
+			inputs: [{ binding: 'data', source: 'steps.q1.rows', content_hash: 'sha256:up' }]
+		});
+
+		const g = await assembleProvenance(root, mapResolver([upstream, root]));
+
+		expect(g.rootId).toBe('artifact:sha256:root');
+		// two artifacts, two steps, one launch
+		const artifactNodes = g.nodes.filter((n) => n.kind === 'artifact');
+		expect(artifactNodes.map((n) => n.contentHash)).toEqual(
+			expect.arrayContaining(['sha256:root', 'sha256:up'])
+		);
+		expect(g.nodes.filter((n) => n.kind === 'step')).toHaveLength(2);
+		expect(g.nodes.filter((n) => n.kind === 'launch')).toHaveLength(1);
+
+		// The root artifact's step is wired to the upstream artifact.
+		expect(g.edges).toContainEqual({ from: 'artifact:sha256:root', to: 'step:artifact:sha256:root' });
+		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:root', to: 'artifact:sha256:up' });
+		// terminal launch node hangs off the root step
+		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:root', to: 'launch' });
+		expect(g.nodes.find((n) => n.kind === 'launch')?.title).toContain('ingest');
+	});
+});
+
+describe('assembleProvenance — branching', () => {
+	it('walks both hashed upstreams of a two-input step', async () => {
+		const a = output({ hash: 'sha256:a', name: 'a.json' });
+		const b = output({ hash: 'sha256:b', name: 'b.json' });
+		const root = output({
+			hash: 'sha256:merged',
+			name: 'merged.csv',
+			kind: 'transform',
+			transform: 'join',
+			inputs: [
+				{ binding: 'left', content_hash: 'sha256:a' },
+				{ binding: 'right', content_hash: 'sha256:b' }
+			]
+		});
+
+		const g = await assembleProvenance(root, mapResolver([a, b, root]));
+
+		const hashes = g.nodes.filter((n) => n.kind === 'artifact').map((n) => n.contentHash);
+		expect(hashes).toEqual(expect.arrayContaining(['sha256:merged', 'sha256:a', 'sha256:b']));
+		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:merged', to: 'artifact:sha256:a' });
+		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:merged', to: 'artifact:sha256:b' });
+	});
+});
+
+describe('assembleProvenance — literal input', () => {
+	it('emits a literal node and does not recurse', async () => {
+		const root = output({
+			hash: 'sha256:root',
+			inputs: [{ binding: 'threshold', source: 'inputs.threshold' }]
+		});
+
+		const g = await assembleProvenance(root, mapResolver([root]));
+
+		const literals = g.nodes.filter((n) => n.kind === 'literal');
+		expect(literals).toHaveLength(1);
+		expect(literals[0].literal).toEqual({ binding: 'threshold', source: 'inputs.threshold' });
+		// only the one root artifact — no upstream artifact was fetched
+		expect(g.nodes.filter((n) => n.kind === 'artifact')).toHaveLength(1);
+	});
+});
+
+describe('assembleProvenance — dangling upstream', () => {
+	it('marks an unresolvable hash and does not throw', async () => {
+		const root = output({
+			hash: 'sha256:root',
+			inputs: [{ binding: 'data', content_hash: 'sha256:missing' }]
+		});
+		// resolver knows only the root, returns null for the upstream
+		const g = await assembleProvenance(root, mapResolver([root]));
+
+		const dangling = g.nodes.find((n) => n.dangling);
+		expect(dangling).toBeTruthy();
+		expect(dangling?.contentHash).toBe('sha256:missing');
+		expect(g.edges).toContainEqual({
+			from: 'step:artifact:sha256:root',
+			to: 'artifact:sha256:missing'
+		});
+	});
+});
+
+describe('assembleProvenance — cycle safety', () => {
+	it('terminates when an upstream points back to an already-seen artifact', async () => {
+		// root -> back references root's own hash as an input (degenerate cycle)
+		const root = output({
+			hash: 'sha256:cyc',
+			inputs: [{ binding: 'self', content_hash: 'sha256:cyc' }]
+		});
+
+		const g = await assembleProvenance(root, mapResolver([root]));
+
+		// Exactly one artifact node for the cyclic hash — never expanded twice.
+		expect(g.nodes.filter((n) => n.contentHash === 'sha256:cyc')).toHaveLength(1);
+		// The self-edge is still recorded so the cycle is visible.
+		expect(g.edges).toContainEqual({
+			from: 'step:artifact:sha256:cyc',
+			to: 'artifact:sha256:cyc'
+		});
+		expect(kinds(g)).toEqual(['artifact', 'launch', 'step']);
+	});
+});

--- a/webapp/src/lib/audit/provenance.ts
+++ b/webapp/src/lib/audit/provenance.ts
@@ -1,0 +1,210 @@
+// Provenance graph assembly — a pure, DOM-free walk-back that turns a
+// starting materialized-artifact record into a node/edge graph.
+//
+// The walk starts at an `output.materialized` event and follows its
+// `aileron.step.inputs[]` upstream: for each input carrying a
+// `content_hash`, it resolves the record that produced that hash and
+// recurses. It terminates at a literal input (no `content_hash`), at a
+// dangling hash (resolver returns null), and at the top with a launch /
+// actor node derived from the artifact's `aileron.plan.*` / `aileron.actor.*`.
+//
+// Provenance DAGs are tiny (a handful of nodes), so this is deliberately
+// simple. It is a pure module so it is unit-testable against fixtures
+// (repo testing philosophy: test the contract, not the render).
+
+import type { AuditEvent } from '$lib/api';
+import * as p from './payload';
+
+export type ProvenanceNodeKind = 'artifact' | 'step' | 'literal' | 'launch';
+
+export type ProvenanceNode = {
+	/** Stable node id, unique within the graph. */
+	id: string;
+	kind: ProvenanceNodeKind;
+	/** One-line summary fields the cards render. */
+	title: string;
+	subtitle?: string;
+	/** Distance from the root artifact (0 = root). Assigned during assembly. */
+	depth: number;
+	/** The backing audit event, when the node was derived from one. A
+	 *  literal input has no backing record. */
+	event?: AuditEvent;
+	/** For an artifact node, the content hash it materialized. */
+	contentHash?: string;
+	/** For a literal node, the input binding/source it stands for. */
+	literal?: { binding: string; source?: string };
+	/** True when this node's content hash could not be resolved to a
+	 *  producing record (dangling upstream). */
+	dangling?: boolean;
+};
+
+export type ProvenanceEdge = {
+	/** Parent (downstream/consumer) node id. */
+	from: string;
+	/** Child (upstream/producer) node id. */
+	to: string;
+};
+
+export type ProvenanceGraph = {
+	rootId: string;
+	nodes: ProvenanceNode[];
+	edges: ProvenanceEdge[];
+};
+
+/** Async resolver: given a content hash, return the materialized-output
+ *  event that produced it, or null when unknown. Production passes a
+ *  wrapper over `getAuditByContentHash`; tests pass a fixture map. */
+export type ResolveByHash = (hash: string) => Promise<AuditEvent | null>;
+
+const MAX_DEPTH = 32;
+
+function artifactTitle(e: AuditEvent): string {
+	return p.outputName(e) ?? '(unnamed artifact)';
+}
+
+function artifactSubtitle(e: AuditEvent): string {
+	const mime = p.outputMime(e);
+	const size = p.formatBytes(p.outputBytes(e));
+	const hash = p.shortHash(p.outputContentHash(e));
+	return [mime, size, hash].filter((s) => s && s.length > 0).join(' · ');
+}
+
+function stepSubtitle(e: AuditEvent): string {
+	const kind = p.stepKind(e);
+	const detail = p.stepTransform(e) ?? p.stepCommand(e);
+	return [kind, detail].filter((s) => s && s.length > 0).join(' · ');
+}
+
+/** Builds the terminal launch/actor node from the root artifact's
+ *  plan/actor provenance. */
+function launchNode(root: AuditEvent, depth: number): ProvenanceNode {
+	const skill = p.planSkill(root);
+	const actor = p.actorIdentityLabel(root);
+	const subtitleParts = [
+		skill ? `skill ${skill}` : undefined,
+		actor ? `by ${actor}` : undefined
+	].filter((s): s is string => !!s);
+	return {
+		id: 'launch',
+		kind: 'launch',
+		title: skill ? `Launch: ${skill}` : 'Launch',
+		subtitle: subtitleParts.join(' · ') || undefined,
+		depth,
+		event: root
+	};
+}
+
+/**
+ * Assembles the provenance graph for a starting materialized artifact.
+ *
+ * @param start   the `output.materialized` event to walk back from.
+ * @param resolve async resolver from content hash to producing event.
+ */
+export async function assembleProvenance(
+	start: AuditEvent,
+	resolve: ResolveByHash
+): Promise<ProvenanceGraph> {
+	const nodes: ProvenanceNode[] = [];
+	const edges: ProvenanceEdge[] = [];
+	// Guard against cycles: an artifact is keyed by its content hash, so a
+	// hash we have already expanded is never expanded twice.
+	const seenHashes = new Set<string>();
+	let literalSeq = 0;
+
+	// walk expands one artifact event: emits its step node, its input
+	// nodes/edges, and recurses into hashed upstreams. Returns the id of
+	// the artifact node it created so callers can wire an edge to it.
+	async function walk(event: AuditEvent, depth: number): Promise<string> {
+		const hash = p.outputContentHash(event);
+		const artifactId = hash ? `artifact:${hash}` : `artifact:node${nodes.length}`;
+
+		nodes.push({
+			id: artifactId,
+			kind: 'artifact',
+			title: artifactTitle(event),
+			subtitle: artifactSubtitle(event),
+			depth,
+			event,
+			contentHash: hash
+		});
+
+		if (hash) seenHashes.add(hash);
+
+		// The materializing step node hangs directly off the artifact.
+		const sid = p.stepId(event);
+		const stepNodeId = `step:${artifactId}`;
+		nodes.push({
+			id: stepNodeId,
+			kind: 'step',
+			title: sid ? `Step ${sid}` : 'Step',
+			subtitle: stepSubtitle(event) || undefined,
+			depth: depth + 1,
+			event
+		});
+		edges.push({ from: artifactId, to: stepNodeId });
+
+		if (depth + 2 > MAX_DEPTH) {
+			return artifactId;
+		}
+
+		const inputs = p.stepInputs(event);
+		for (const input of inputs) {
+			if (!input.content_hash) {
+				// Literal input: a terminal leaf, never recursed.
+				const litId = `literal:${literalSeq++}`;
+				nodes.push({
+					id: litId,
+					kind: 'literal',
+					title: input.binding || '(literal)',
+					subtitle: input.source,
+					depth: depth + 2,
+					literal: { binding: input.binding, source: input.source }
+				});
+				edges.push({ from: stepNodeId, to: litId });
+				continue;
+			}
+
+			if (seenHashes.has(input.content_hash)) {
+				// Already expanded upstream (or in-flight): wire the edge to
+				// the existing artifact node and do not recurse (cycle guard).
+				edges.push({ from: stepNodeId, to: `artifact:${input.content_hash}` });
+				continue;
+			}
+			// Reserve the hash before awaiting so a concurrent/cyclic path
+			// cannot re-enter it.
+			seenHashes.add(input.content_hash);
+
+			const upstream = await resolve(input.content_hash);
+			if (!upstream) {
+				// Dangling upstream: mark it and stop, do not throw.
+				const danglingId = `artifact:${input.content_hash}`;
+				nodes.push({
+					id: danglingId,
+					kind: 'artifact',
+					title: '(unresolved artifact)',
+					subtitle: p.shortHash(input.content_hash),
+					depth: depth + 2,
+					contentHash: input.content_hash,
+					dangling: true
+				});
+				edges.push({ from: stepNodeId, to: danglingId });
+				continue;
+			}
+
+			const upstreamId = await walk(upstream, depth + 2);
+			edges.push({ from: stepNodeId, to: upstreamId });
+		}
+
+		return artifactId;
+	}
+
+	const rootId = await walk(start, 0);
+
+	// Terminal launch/actor node, attached below the root artifact's step.
+	const maxDepth = nodes.reduce((m, n) => Math.max(m, n.depth), 0);
+	const launch = launchNode(start, maxDepth + 1);
+	nodes.push(launch);
+	edges.push({ from: `step:${rootId}`, to: launch.id });
+
+	return { rootId, nodes, edges };
+}

--- a/webapp/src/lib/components/audit/ArtifactLookup.svelte
+++ b/webapp/src/lib/components/audit/ArtifactLookup.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+
+	// Artifact lookup: paste a `sha256:<hex>` hash, or drop a file to hash
+	// its bytes client-side (crypto.subtle) into the same `sha256:<hex>`
+	// form. Either path calls back with the resolved hash so the page can
+	// render that artifact's provenance graph.
+	let { onlookup }: { onlookup: (hash: string) => void } = $props();
+
+	let hashInput = $state('');
+	let hashing = $state(false);
+	let dropError = $state('');
+
+	function normalize(raw: string): string {
+		const trimmed = raw.trim();
+		if (!trimmed) return '';
+		// Accept a bare hex digest too, prefixing the algorithm.
+		if (/^[0-9a-fA-F]{64}$/.test(trimmed)) return `sha256:${trimmed.toLowerCase()}`;
+		return trimmed;
+	}
+
+	function submitHash() {
+		const h = normalize(hashInput);
+		if (h) onlookup(h);
+	}
+
+	async function hashFile(file: File): Promise<string> {
+		const buf = await file.arrayBuffer();
+		const digest = await crypto.subtle.digest('SHA-256', buf);
+		const hex = Array.from(new Uint8Array(digest))
+			.map((b) => b.toString(16).padStart(2, '0'))
+			.join('');
+		return `sha256:${hex}`;
+	}
+
+	async function onDrop(e: DragEvent) {
+		e.preventDefault();
+		dropError = '';
+		const file = e.dataTransfer?.files?.[0];
+		if (!file) return;
+		hashing = true;
+		try {
+			const h = await hashFile(file);
+			hashInput = h;
+			onlookup(h);
+		} catch (err) {
+			dropError = err instanceof Error ? err.message : String(err);
+		} finally {
+			hashing = false;
+		}
+	}
+</script>
+
+<section class="rounded-lg border border-border bg-card p-4" data-testid="artifact-lookup">
+	<h2 class="mb-2 text-sm font-semibold">Look up an artifact by content hash</h2>
+	<div class="flex flex-wrap items-center gap-2">
+		<Input
+			type="text"
+			placeholder="sha256:…"
+			bind:value={hashInput}
+			data-testid="lookup-hash-input"
+			class="max-w-md"
+			onkeydown={(e: KeyboardEvent) => {
+				if (e.key === 'Enter') submitHash();
+			}}
+		/>
+		<Button data-testid="lookup-hash-submit" onclick={submitHash} disabled={!hashInput.trim()}>
+			Look up
+		</Button>
+	</div>
+
+	<div
+		role="button"
+		tabindex="0"
+		data-testid="lookup-dropzone"
+		class="mt-3 flex h-20 items-center justify-center rounded border border-dashed border-border text-sm text-muted-foreground"
+		ondragover={(e) => e.preventDefault()}
+		ondrop={onDrop}
+	>
+		{#if hashing}
+			Hashing file…
+		{:else}
+			Drop a file here to hash it locally and look up its provenance
+		{/if}
+	</div>
+	{#if dropError}
+		<p class="mt-1 text-xs text-destructive" data-testid="lookup-drop-error">{dropError}</p>
+	{/if}
+</section>

--- a/webapp/src/lib/components/audit/ArtifactLookup.svelte
+++ b/webapp/src/lib/components/audit/ArtifactLookup.svelte
@@ -11,6 +11,7 @@
 	let hashInput = $state('');
 	let hashing = $state(false);
 	let dropError = $state('');
+	let fileInput: HTMLInputElement;
 
 	function normalize(raw: string): string {
 		const trimmed = raw.trim();
@@ -34,11 +35,10 @@
 		return `sha256:${hex}`;
 	}
 
-	async function onDrop(e: DragEvent) {
-		e.preventDefault();
+	// Shared file → hash → lookup path for both drag-drop and the keyboard/
+	// click-triggered hidden file input.
+	async function ingestFile(file: File) {
 		dropError = '';
-		const file = e.dataTransfer?.files?.[0];
-		if (!file) return;
 		hashing = true;
 		try {
 			const h = await hashFile(file);
@@ -49,6 +49,17 @@
 		} finally {
 			hashing = false;
 		}
+	}
+
+	async function onDrop(e: DragEvent) {
+		e.preventDefault();
+		const file = e.dataTransfer?.files?.[0];
+		if (file) await ingestFile(file);
+	}
+
+	async function onFileSelected(e: Event) {
+		const file = (e.target as HTMLInputElement).files?.[0];
+		if (file) await ingestFile(file);
 	}
 </script>
 
@@ -77,11 +88,25 @@
 		class="mt-3 flex h-20 items-center justify-center rounded border border-dashed border-border text-sm text-muted-foreground"
 		ondragover={(e) => e.preventDefault()}
 		ondrop={onDrop}
+		onclick={() => fileInput.click()}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				fileInput.click();
+			}
+		}}
 	>
+		<input
+			bind:this={fileInput}
+			type="file"
+			class="sr-only"
+			data-testid="lookup-file-input"
+			onchange={onFileSelected}
+		/>
 		{#if hashing}
 			Hashing file…
 		{:else}
-			Drop a file here to hash it locally and look up its provenance
+			Drop a file here (or press Enter to browse) to hash it locally and look up its provenance
 		{/if}
 	</div>
 	{#if dropError}

--- a/webapp/src/lib/components/audit/GraphView.svelte
+++ b/webapp/src/lib/components/audit/GraphView.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import NodeCard from './NodeCard.svelte';
+	import type { ProvenanceGraph, ProvenanceNode } from '$lib/audit/provenance';
+
+	// Hand-rolled top-down DAG (no d3/elkjs/cytoscape — #1891 key decision
+	// 3). Provenance DAGs are tiny, so we bucket nodes by depth into
+	// stacked rows and render CSS connector rails between rows. The root
+	// artifact sits at depth 0; upstreams and the terminal launch node
+	// stack below it.
+	let {
+		graph,
+		onselect
+	}: { graph: ProvenanceGraph; onselect: (n: ProvenanceNode) => void } = $props();
+
+	// Group nodes into depth rows, sorted shallow → deep.
+	const rows = $derived.by(() => {
+		const byDepth = new Map<number, ProvenanceNode[]>();
+		for (const n of graph.nodes) {
+			const bucket = byDepth.get(n.depth) ?? [];
+			bucket.push(n);
+			byDepth.set(n.depth, bucket);
+		}
+		return [...byDepth.entries()]
+			.sort((a, b) => a[0] - b[0])
+			.map(([depth, nodes]) => ({ depth, nodes }));
+	});
+</script>
+
+<div class="flex flex-col items-center gap-0" data-testid="provenance-graph">
+	{#each rows as row, i (row.depth)}
+		<div class="flex flex-wrap justify-center gap-4">
+			{#each row.nodes as node (node.id)}
+				<NodeCard {node} {onselect} />
+			{/each}
+		</div>
+		{#if i < rows.length - 1}
+			<!-- Connector rail between depth rows. The small-N case makes a
+			     single vertical rail legible without per-edge routing. -->
+			<div class="h-6 w-px bg-border" aria-hidden="true"></div>
+		{/if}
+	{/each}
+</div>

--- a/webapp/src/lib/components/audit/NodeCard.svelte
+++ b/webapp/src/lib/components/audit/NodeCard.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import type { ProvenanceNode } from '$lib/audit/provenance';
+
+	// One node in the provenance DAG. Cards are one-line summaries only:
+	// title + subtitle. Full record fields live in the side panel, opened
+	// by clicking the card (progressive disclosure — #1891 key decision 2).
+	let { node, onselect }: { node: ProvenanceNode; onselect: (n: ProvenanceNode) => void } =
+		$props();
+
+	const kindLabel: Record<ProvenanceNode['kind'], string> = {
+		artifact: 'Artifact',
+		step: 'Step',
+		literal: 'Literal input',
+		launch: 'Launch'
+	};
+
+	const kindVariant: Record<ProvenanceNode['kind'], 'default' | 'secondary' | 'outline'> = {
+		artifact: 'default',
+		step: 'secondary',
+		literal: 'outline',
+		launch: 'outline'
+	};
+</script>
+
+<Card.Root
+	data-testid="provenance-node"
+	data-node-kind={node.kind}
+	data-node-id={node.id}
+	class="w-64 cursor-pointer transition-colors hover:border-primary {node.dangling
+		? 'border-destructive/60'
+		: ''}"
+>
+	<button
+		type="button"
+		class="w-full cursor-pointer text-left"
+		aria-label="Open details for {node.title}"
+		onclick={() => onselect(node)}
+	>
+		<Card.Header>
+			<div class="flex items-center justify-between gap-2">
+				<span class="truncate font-semibold" title={node.title}>{node.title}</span>
+				<Badge variant={kindVariant[node.kind]}>{kindLabel[node.kind]}</Badge>
+			</div>
+		</Card.Header>
+		{#if node.subtitle}
+			<Card.Content>
+				<p class="truncate text-xs text-muted-foreground" title={node.subtitle}>
+					{node.subtitle}
+				</p>
+				{#if node.dangling}
+					<p class="mt-1 text-xs text-destructive">unresolved upstream</p>
+				{/if}
+			</Card.Content>
+		{/if}
+	</button>
+</Card.Root>

--- a/webapp/src/lib/components/audit/ProvenanceHeader.svelte
+++ b/webapp/src/lib/components/audit/ProvenanceHeader.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import type { AuditEvent } from '$lib/api';
+	import * as p from '$lib/audit/payload';
+
+	// Header for a provenance graph: the actor, a verified-signature badge,
+	// the signer fingerprint, and the plan/skill name — all read off the
+	// root artifact record.
+	let { root }: { root: AuditEvent } = $props();
+
+	const skill = $derived(p.planSkill(root));
+	const actor = $derived(p.actorIdentityLabel(root));
+	const signedBy = $derived(p.planSignedBy(root));
+	const status = $derived(p.planSignatureStatus(root));
+	const verified = $derived(status === 'verified');
+</script>
+
+<div class="mb-4 rounded-lg border border-border bg-card p-4" data-testid="provenance-header">
+	<div class="flex flex-wrap items-center gap-3">
+		{#if skill}
+			<span class="text-lg font-bold" data-testid="header-skill">{skill}</span>
+		{/if}
+		{#if status}
+			<Badge
+				variant={verified ? 'default' : 'destructive'}
+				data-testid="header-signature-badge"
+			>
+				{verified ? 'Signature verified' : `Signature ${status}`}
+			</Badge>
+		{/if}
+	</div>
+	<dl class="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+		{#if actor}
+			<div class="flex gap-2">
+				<dt class="font-medium">Actor</dt>
+				<dd data-testid="header-actor">{actor}</dd>
+			</div>
+		{/if}
+		{#if signedBy}
+			<div class="flex gap-2">
+				<dt class="font-medium">Signed by</dt>
+				<dd class="break-all font-mono" data-testid="header-signed-by">{signedBy}</dd>
+			</div>
+		{/if}
+	</dl>
+</div>

--- a/webapp/src/lib/components/audit/RecordSidePanel.svelte
+++ b/webapp/src/lib/components/audit/RecordSidePanel.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Collapsible from '$lib/components/ui/collapsible';
+	import { Badge } from '$lib/components/ui/badge';
+	import type { ProvenanceNode } from '$lib/audit/provenance';
+	import * as p from '$lib/audit/payload';
+
+	// Side panel opened when a node is clicked. Shows the full record
+	// fields as labeled rows (never a raw full-JSON dump in the default
+	// view). Large literal input values render collapsed via a collapsible
+	// as `name · mime · size · [view]` and expand on demand only.
+	let {
+		node = $bindable(null)
+	}: { node: ProvenanceNode | null } = $props();
+
+	// The dialog is open exactly when a node is selected; closing it clears
+	// the selection so the parent's binding stays consistent.
+	let open = $state(false);
+	$effect(() => {
+		open = node !== null;
+	});
+	function onOpenChange(next: boolean) {
+		open = next;
+		if (!next) node = null;
+	}
+
+	// A literal value counts as "large" past this length; it renders
+	// collapsed with a descriptor and a [view] toggle.
+	const LARGE_LITERAL = 120;
+
+	type Row = { label: string; value: string; mono?: boolean };
+
+	// Full field rows for an artifact/step node, read from the backing
+	// event's flat payload. Ordered for readability.
+	const rows = $derived.by((): Row[] => {
+		if (!node?.event) return [];
+		const e = node.event;
+		const out: Row[] = [];
+		const add = (label: string, v: string | number | undefined, mono = false) => {
+			if (v !== undefined && v !== '') out.push({ label, value: String(v), mono });
+		};
+		add('Name', p.outputName(e));
+		add('MIME', p.outputMime(e));
+		add('Content hash', p.outputContentHash(e), true);
+		add('Bytes', p.outputBytes(e));
+		add('Path', p.outputPath(e), true);
+		add('Step id', p.stepId(e));
+		add('Step kind', p.stepKind(e));
+		add('Transform', p.stepTransform(e));
+		add('Command', p.stepCommand(e), true);
+		add('Plan / skill', p.planSkill(e));
+		add('Plan hash', p.planContentHash(e), true);
+		add('Signed by', p.planSignedBy(e), true);
+		add('Signature status', p.planSignatureStatus(e));
+		add('Actor', p.actorIdentityLabel(e));
+		add('Credential binding', p.actorCredentialBinding(e));
+		add('Connector version', p.actorConnectorVersion(e));
+		add('Connector hash', p.actorConnectorHash(e), true);
+		add('Consent', p.consentDecision(e));
+		add('Invocation id', p.invocationId(e), true);
+		return out;
+	});
+
+	const inputs = $derived(node?.event ? p.stepInputs(node.event) : []);
+</script>
+
+<Dialog.Root bind:open {onOpenChange}>
+	<Dialog.Content class="sm:max-w-lg">
+		{#if node}
+			<Dialog.Header>
+				<Dialog.Title data-testid="side-panel-title">{node.title}</Dialog.Title>
+				<Dialog.Description>{node.kind} record</Dialog.Description>
+			</Dialog.Header>
+
+			<div class="max-h-[60vh] overflow-y-auto" data-testid="side-panel-body">
+				{#if node.kind === 'literal'}
+					{@const source = node.literal?.source ?? ''}
+					<div data-testid="literal-descriptor" class="text-sm">
+						<div class="flex flex-wrap items-center gap-2">
+							<span class="font-medium">{node.literal?.binding}</span>
+							{#if source.length > LARGE_LITERAL}
+								<Badge variant="outline">{source.length} chars</Badge>
+							{/if}
+						</div>
+						{#if source.length > LARGE_LITERAL}
+							<Collapsible.Root class="mt-2">
+								<Collapsible.Trigger
+									data-testid="literal-view-toggle"
+									class="text-xs text-primary underline underline-offset-2"
+								>
+									view
+								</Collapsible.Trigger>
+								<Collapsible.Content>
+									<pre
+										data-testid="literal-full-value"
+										class="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-xs">{source}</pre>
+								</Collapsible.Content>
+							</Collapsible.Root>
+						{:else if source}
+							<p class="mt-1 break-all font-mono text-xs text-muted-foreground">{source}</p>
+						{/if}
+					</div>
+				{:else}
+					<dl class="grid grid-cols-1 gap-y-2 text-sm">
+						{#each rows as row (row.label)}
+							<div class="flex flex-col">
+								<dt class="text-xs font-medium text-muted-foreground">{row.label}</dt>
+								<dd class="break-all {row.mono ? 'font-mono text-xs' : ''}">{row.value}</dd>
+							</div>
+						{/each}
+					</dl>
+
+					{#if inputs.length > 0}
+						<div class="mt-4">
+							<h3 class="mb-1 text-xs font-semibold text-muted-foreground">Inputs</h3>
+							<ul class="flex flex-col gap-1 text-xs">
+								{#each inputs as input, i (input.binding + i)}
+									<li class="flex flex-wrap items-center gap-2" data-testid="side-panel-input">
+										<span class="font-medium">{input.binding}</span>
+										{#if input.source}<span class="font-mono text-muted-foreground"
+												>{input.source}</span
+											>{/if}
+										{#if input.content_hash}<Badge variant="secondary"
+												>{p.shortHash(input.content_hash)}</Badge
+											>{:else}<Badge variant="outline">literal</Badge>{/if}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				{/if}
+			</div>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/webapp/src/lib/components/audit/TimelineView.svelte
+++ b/webapp/src/lib/components/audit/TimelineView.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import type { AuditEvent } from '$lib/api';
+	import * as p from '$lib/audit/payload';
+
+	// Timeline (secondary) view: the launch's records in explicit time
+	// order. Ordering is oldest-first so a reader follows the launch as it
+	// unfolded (the daemon returns newest-first, so we reverse).
+	let { events }: { events: AuditEvent[] } = $props();
+
+	const ordered = $derived(
+		[...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+	);
+</script>
+
+<div class="flex flex-col gap-3" data-testid="provenance-timeline">
+	{#if ordered.length === 0}
+		<p class="text-sm text-muted-foreground">No records for this launch.</p>
+	{:else}
+		{#each ordered as event (event.audit_id)}
+			<Card.Root data-testid="timeline-row">
+				<Card.Header>
+					<div class="flex items-center justify-between gap-2">
+						<span class="font-mono text-xs text-muted-foreground">{event.timestamp}</span>
+						<Badge variant="outline">{event.event_type}</Badge>
+					</div>
+				</Card.Header>
+				<Card.Content>
+					<p class="text-sm">
+						{p.outputName(event) ?? p.stepId(event) ?? event.audit_id}
+					</p>
+					{#if p.actorIdentityLabel(event)}
+						<p class="text-xs text-muted-foreground">by {p.actorIdentityLabel(event)}</p>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		{/each}
+	{/if}
+</div>

--- a/webapp/src/routes/+layout.svelte
+++ b/webapp/src/routes/+layout.svelte
@@ -59,6 +59,7 @@
 				>Approvals</a
 			>
 			<a href="/hub" class="text-foreground hover:text-primary no-underline">Hub</a>
+			<a href="/audit" class="text-foreground hover:text-primary no-underline">Audit</a>
 		</nav>
 	</div>
 </header>

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -59,6 +59,9 @@
 		graph = null;
 		root = null;
 		view = 'graph';
+		// Switching artifacts must not leave a stale timeline behind.
+		timelineEvents = [];
+		timelineError = '';
 		try {
 			const startEvent = await resolveByHash(hash);
 			if (!startEvent) {
@@ -79,22 +82,31 @@
 		graph = null;
 		graphError = '';
 		view = 'graph';
+		timelineEvents = [];
+		timelineError = '';
 	}
 
 	async function showTimeline() {
 		view = 'timeline';
 		timelineError = '';
+		timelineEvents = [];
 		if (!root) return;
 		const inv = p.invocationId(root);
 		if (!inv) {
 			timelineError = 'This artifact has no invocation id to correlate a timeline.';
-			timelineEvents = [];
 			return;
 		}
 		try {
-			timelineEvents = await getAuditByInvocation(inv);
+			const events = await getAuditByInvocation(inv);
+			// Drop the result if the focused artifact changed while this
+			// request was in flight, so an older fetch can't overwrite a newer.
+			if (root && p.invocationId(root) === inv) {
+				timelineEvents = events;
+			}
 		} catch (e) {
-			timelineError = e instanceof Error ? e.message : String(e);
+			if (root && p.invocationId(root) === inv) {
+				timelineError = e instanceof Error ? e.message : String(e);
+			}
 		}
 	}
 

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import {
+		listRecentMaterialized,
+		getAuditByContentHash,
+		getAuditByInvocation,
+		type AuditEvent
+	} from '$lib/api';
+	import {
+		assembleProvenance,
+		type ProvenanceGraph,
+		type ProvenanceNode
+	} from '$lib/audit/provenance';
+	import * as p from '$lib/audit/payload';
+	import GraphView from '$lib/components/audit/GraphView.svelte';
+	import ProvenanceHeader from '$lib/components/audit/ProvenanceHeader.svelte';
+	import TimelineView from '$lib/components/audit/TimelineView.svelte';
+	import RecordSidePanel from '$lib/components/audit/RecordSidePanel.svelte';
+	import ArtifactLookup from '$lib/components/audit/ArtifactLookup.svelte';
+
+	// `/audit` provenance view (#1891). Graph-first: the landing lists
+	// recent materialized artifacts; selecting one (or deep-linking via a
+	// `content_hash` URL query param, the #1894 affordance) resolves that
+	// artifact and renders its walk-back DAG. A timeline toggle re-renders
+	// the same launch's records in time order.
+
+	let recent = $state<AuditEvent[]>([]);
+	let loadingRecent = $state(true);
+	let recentError = $state('');
+
+	// The currently-focused artifact graph, when one is selected.
+	let root = $state<AuditEvent | null>(null);
+	let graph = $state<ProvenanceGraph | null>(null);
+	let graphError = $state('');
+	let resolving = $state(false);
+
+	let view = $state<'graph' | 'timeline'>('graph');
+	let timelineEvents = $state<AuditEvent[]>([]);
+	let timelineError = $state('');
+
+	let selectedNode = $state<ProvenanceNode | null>(null);
+
+	// Production resolver: the walk-back asks for the record that produced
+	// a content hash. `content_hash` may match several events (the same
+	// artifact re-materialized); the first is the producing record.
+	async function resolveByHash(hash: string): Promise<AuditEvent | null> {
+		const events = await getAuditByContentHash(hash);
+		const materialized = events.find(
+			(e) => p.outputContentHash(e) === hash
+		);
+		return materialized ?? events[0] ?? null;
+	}
+
+	async function openArtifact(hash: string) {
+		resolving = true;
+		graphError = '';
+		graph = null;
+		root = null;
+		view = 'graph';
+		try {
+			const startEvent = await resolveByHash(hash);
+			if (!startEvent) {
+				graphError = `No artifact found for ${hash}.`;
+				return;
+			}
+			root = startEvent;
+			graph = await assembleProvenance(startEvent, resolveByHash);
+		} catch (e) {
+			graphError = e instanceof Error ? e.message : String(e);
+		} finally {
+			resolving = false;
+		}
+	}
+
+	function backToLanding() {
+		root = null;
+		graph = null;
+		graphError = '';
+		view = 'graph';
+	}
+
+	async function showTimeline() {
+		view = 'timeline';
+		timelineError = '';
+		if (!root) return;
+		const inv = p.invocationId(root);
+		if (!inv) {
+			timelineError = 'This artifact has no invocation id to correlate a timeline.';
+			timelineEvents = [];
+			return;
+		}
+		try {
+			timelineEvents = await getAuditByInvocation(inv);
+		} catch (e) {
+			timelineError = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	function onNodeSelect(node: ProvenanceNode) {
+		selectedNode = node;
+	}
+
+	async function loadRecent() {
+		loadingRecent = true;
+		recentError = '';
+		try {
+			recent = await listRecentMaterialized();
+		} catch (e) {
+			recentError = e instanceof Error ? e.message : String(e);
+		} finally {
+			loadingRecent = false;
+		}
+	}
+
+	onMount(() => {
+		// Deep-link contract for #1894: a `content_hash` query param resolves
+		// and renders that artifact's graph directly, skipping the landing.
+		const params = new URLSearchParams(window.location.search);
+		const deepLink = params.get('content_hash');
+		if (deepLink) {
+			void openArtifact(deepLink);
+		} else {
+			void loadRecent();
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Audit — Aileron</title>
+</svelte:head>
+
+<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Audit &amp; Provenance</h1>
+
+{#if root && graph}
+	<!-- Focused artifact graph / timeline -->
+	<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
+		<Button variant="ghost" data-testid="back-to-landing" onclick={backToLanding}>
+			← All artifacts
+		</Button>
+		<div class="flex items-center gap-1 rounded-md border border-border p-0.5">
+			<Button
+				variant={view === 'graph' ? 'default' : 'ghost'}
+				size="sm"
+				data-testid="view-graph"
+				onclick={() => (view = 'graph')}>Graph</Button
+			>
+			<Button
+				variant={view === 'timeline' ? 'default' : 'ghost'}
+				size="sm"
+				data-testid="view-timeline"
+				onclick={showTimeline}>Timeline</Button
+			>
+		</div>
+	</div>
+
+	<ProvenanceHeader {root} />
+
+	{#if view === 'graph'}
+		<GraphView {graph} onselect={onNodeSelect} />
+	{:else if timelineError}
+		<p class="text-destructive" data-testid="timeline-error">{timelineError}</p>
+	{:else}
+		<TimelineView events={timelineEvents} />
+	{/if}
+{:else if resolving}
+	<p class="text-muted-foreground">Resolving provenance…</p>
+{:else if graphError}
+	<p class="mb-4 text-destructive" data-testid="graph-error">{graphError}</p>
+	<Button variant="ghost" data-testid="back-to-landing" onclick={backToLanding}
+		>← All artifacts</Button
+	>
+{:else}
+	<!-- Landing -->
+	<p class="mb-3 text-sm text-muted-foreground">
+		Walk any materialized artifact back to the launch, steps, and inputs that
+		produced it. Pick a recent artifact below, or look one up by its content
+		hash.
+	</p>
+
+	<div class="mb-6">
+		<ArtifactLookup onlookup={openArtifact} />
+	</div>
+
+	<h2 class="mb-2 text-lg font-semibold">Recent artifacts</h2>
+	{#if loadingRecent}
+		<p class="text-muted-foreground">Loading recent artifacts…</p>
+	{:else if recentError}
+		<p class="text-destructive" data-testid="recent-error">{recentError}</p>
+	{:else if recent.length === 0}
+		<p class="text-muted-foreground" data-testid="recent-empty">
+			No materialized outputs recorded yet. Run a Flight Plan launch that
+			materializes an artifact and it will appear here.
+		</p>
+	{:else}
+		<div class="flex flex-col gap-3" data-testid="recent-list">
+			{#each recent as event (event.audit_id)}
+				{@const hash = p.outputContentHash(event)}
+				<Card.Root data-testid="recent-artifact">
+					<button
+						type="button"
+						class="w-full cursor-pointer text-left"
+						onclick={() => hash && openArtifact(hash)}
+					>
+						<Card.Header>
+							<div class="flex items-center justify-between gap-2">
+								<span class="font-semibold">{p.outputName(event) ?? '(unnamed)'}</span>
+								<span class="text-xs text-muted-foreground">{event.timestamp}</span>
+							</div>
+						</Card.Header>
+						<Card.Content>
+							<p class="text-xs text-muted-foreground">
+								{[
+									p.actorIdentityLabel(event) && `by ${p.actorIdentityLabel(event)}`,
+									p.planSkill(event) && `skill ${p.planSkill(event)}`,
+									hash && p.shortHash(hash)
+								]
+									.filter(Boolean)
+									.join(' · ')}
+							</p>
+						</Card.Content>
+					</button>
+				</Card.Root>
+			{/each}
+		</div>
+	{/if}
+{/if}
+
+<RecordSidePanel bind:node={selectedNode} />

--- a/webapp/src/routes/audit/page.test.ts
+++ b/webapp/src/routes/audit/page.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	listRecentMaterialized: vi.fn(),
+	getAuditByContentHash: vi.fn(),
+	getAuditByInvocation: vi.fn(),
+	EVENT_OUTPUT_MATERIALIZED: 'output.materialized'
+}));
+
+import Page from './+page.svelte';
+import {
+	listRecentMaterialized,
+	getAuditByContentHash,
+	getAuditByInvocation,
+	type AuditEvent
+} from '$lib/api';
+
+// --- fixtures ---
+
+function materialized(opts: {
+	hash: string;
+	name?: string;
+	skill?: string;
+	actor?: string;
+	invocation?: string;
+	inputs?: Array<{ binding: string; source?: string; content_hash?: string }>;
+	sigStatus?: string;
+	signedBy?: string;
+	timestamp?: string;
+}): AuditEvent {
+	const payload: Record<string, unknown> = {
+		'aileron.output.name': opts.name ?? 'report.csv',
+		'aileron.output.content_hash': opts.hash,
+		'aileron.output.mime': 'text/csv',
+		'aileron.output.bytes': 2048,
+		'aileron.step.id': 'step-1',
+		'aileron.step.kind': 'action_call'
+	};
+	if (opts.skill) payload['aileron.plan.skill'] = opts.skill;
+	if (opts.actor) payload['aileron.actor.identity_label'] = opts.actor;
+	if (opts.invocation) payload['aileron.invocation.id'] = opts.invocation;
+	if (opts.inputs) payload['aileron.step.inputs'] = opts.inputs;
+	if (opts.sigStatus) payload['aileron.plan.signature_status'] = opts.sigStatus;
+	if (opts.signedBy) payload['aileron.plan.signed_by'] = opts.signedBy;
+	return {
+		audit_id: `evt-${opts.hash}`,
+		event_type: 'output.materialized',
+		timestamp: opts.timestamp ?? '2026-07-04T00:00:00Z',
+		payload
+	};
+}
+
+function setLocationSearch(search: string) {
+	Object.defineProperty(window, 'location', {
+		writable: true,
+		value: { ...window.location, search }
+	});
+}
+
+beforeEach(() => {
+	vi.mocked(listRecentMaterialized).mockReset();
+	vi.mocked(getAuditByContentHash).mockReset();
+	vi.mocked(getAuditByInvocation).mockReset();
+	setLocationSearch('');
+});
+
+afterEach(() => {
+	setLocationSearch('');
+});
+
+describe('Audit page — landing', () => {
+	it('renders recent materialized artifacts', async () => {
+		vi.mocked(listRecentMaterialized).mockResolvedValue([
+			materialized({ hash: 'sha256:a', name: 'sales.csv', skill: 'ingest', actor: 'analyst' })
+		]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('recent-list')).toBeInTheDocument();
+			expect(screen.getByText('sales.csv')).toBeInTheDocument();
+		});
+		expect(vi.mocked(listRecentMaterialized)).toHaveBeenCalled();
+	});
+
+	it('shows the empty state when nothing is materialized', async () => {
+		vi.mocked(listRecentMaterialized).mockResolvedValue([]);
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('recent-empty')).toBeInTheDocument();
+		});
+	});
+
+	it('surfaces a listing error', async () => {
+		vi.mocked(listRecentMaterialized).mockRejectedValue(new Error('audit down'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('recent-error')).toHaveTextContent('audit down');
+		});
+	});
+});
+
+describe('Audit page — deep link (#1894 affordance)', () => {
+	it('resolves and renders the artifact graph on load, skipping the landing', async () => {
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'final.csv',
+			skill: 'pipeline',
+			signedBy: 'sha256:key',
+			sigStatus: 'verified'
+		});
+		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+		// The landing must not render.
+		expect(screen.queryByTestId('artifact-lookup')).not.toBeInTheDocument();
+		expect(vi.mocked(listRecentMaterialized)).not.toHaveBeenCalled();
+		// Header shows the verified signature badge and skill.
+		expect(screen.getByTestId('header-signature-badge')).toHaveTextContent(/verified/i);
+		expect(screen.getByTestId('header-skill')).toHaveTextContent('pipeline');
+	});
+
+	it('shows a friendly message when the deep-linked hash resolves to nothing', async () => {
+		setLocationSearch('?content_hash=sha256:missing');
+		vi.mocked(getAuditByContentHash).mockResolvedValue([]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('graph-error')).toHaveTextContent(/no artifact found/i);
+		});
+	});
+});
+
+describe('Audit page — graph + side panel', () => {
+	it('renders node cards for a linked fixture and opens the side panel on click', async () => {
+		vi.mocked(listRecentMaterialized).mockResolvedValue([
+			materialized({ hash: 'sha256:root', name: 'joined.csv' })
+		]);
+		const upstream = materialized({ hash: 'sha256:up', name: 'raw.json' });
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'joined.csv',
+			skill: 'etl',
+			inputs: [{ binding: 'data', source: 'steps.q.rows', content_hash: 'sha256:up' }]
+		});
+		vi.mocked(getAuditByContentHash).mockImplementation(async (h: string) => {
+			if (h === 'sha256:root') return [root];
+			if (h === 'sha256:up') return [upstream];
+			return [];
+		});
+
+		render(Page);
+
+		const card = await screen.findByText('joined.csv');
+		await fireEvent.click(card);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+		// Both artifacts appear as node cards.
+		await waitFor(() => {
+			expect(screen.getAllByTestId('provenance-node').length).toBeGreaterThanOrEqual(2);
+		});
+
+		// Clicking a node opens the side panel with full fields.
+		const nodeButtons = screen.getAllByRole('button', { name: /open details/i });
+		await fireEvent.click(nodeButtons[0]);
+		await waitFor(() => {
+			expect(screen.getByTestId('side-panel-title')).toBeInTheDocument();
+		});
+	});
+});
+
+describe('Audit page — timeline toggle', () => {
+	it('switches to timeline and fetches by invocation id in time order', async () => {
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'final.csv',
+			invocation: 'inv-9'
+		});
+		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+		vi.mocked(getAuditByInvocation).mockResolvedValue([
+			materialized({ hash: 'sha256:root', name: 'final.csv', invocation: 'inv-9', timestamp: '2026-07-04T00:00:02Z' }),
+			materialized({ hash: 'sha256:up', name: 'raw.json', invocation: 'inv-9', timestamp: '2026-07-04T00:00:01Z' })
+		]);
+
+		render(Page);
+
+		const timelineBtn = await screen.findByTestId('view-timeline');
+		await fireEvent.click(timelineBtn);
+
+		await waitFor(() => {
+			expect(vi.mocked(getAuditByInvocation)).toHaveBeenCalledWith('inv-9');
+			expect(screen.getByTestId('provenance-timeline')).toBeInTheDocument();
+		});
+		const rows = screen.getAllByTestId('timeline-row');
+		expect(rows.length).toBe(2);
+	});
+});
+
+describe('Audit page — collapse behavior for large literal input', () => {
+	it('renders a large literal collapsed with a view toggle that reveals the full value', async () => {
+		const bigValue = 'x'.repeat(300);
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'out.csv',
+			inputs: [{ binding: 'blob', source: bigValue }]
+		});
+		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+
+		// Find and click the literal node card.
+		const literalNode = await waitFor(() => {
+			const nodes = screen.getAllByTestId('provenance-node');
+			const lit = nodes.find((n) => n.getAttribute('data-node-kind') === 'literal');
+			expect(lit).toBeTruthy();
+			return lit!;
+		});
+		const litButton = literalNode.querySelector('button')!;
+		await fireEvent.click(litButton);
+
+		// The descriptor renders collapsed: the view toggle is present but the
+		// full value is hidden until expanded (the collapsible keeps content
+		// mounted-but-hidden, so assert visibility, not presence).
+		await waitFor(() => {
+			expect(screen.getByTestId('literal-descriptor')).toBeInTheDocument();
+			expect(screen.getByTestId('literal-view-toggle')).toBeInTheDocument();
+		});
+		const collapsed = screen.queryByTestId('literal-full-value');
+		// Either fully unmounted or mounted-but-hidden while collapsed.
+		if (collapsed) expect(collapsed).not.toBeVisible();
+
+		await fireEvent.click(screen.getByTestId('literal-view-toggle'));
+		await waitFor(() => {
+			const full = screen.getByTestId('literal-full-value');
+			expect(full).toBeVisible();
+			expect(full).toHaveTextContent(bigValue);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the artifact-centric provenance view at `/audit` (issue #1891). It walks any materialized artifact back through the steps, inputs, plan, and actor that produced it. The view is graph-first, with a secondary timeline toggle on the same route.

- **API client wrappers** over `GET /v1/audit` reusing `apiFetch`: `listRecentMaterialized` (filters client-side to records carrying `aileron.output.content_hash`, robust to the exact discriminator string), `getAuditByContentHash`, `getAuditByInvocation`.
- **Pure provenance-graph assembly** (`$lib/audit/provenance.ts`), DOM-free and unit-tested against fixtures. Walks `aileron.step.inputs[]` upstream by `content_hash`, emits typed artifact/step/literal/launch nodes, terminates at literals, dangling hashes, and the launch/actor node, and is cycle- and depth-guarded.
- **Hand-rolled top-down DAG** (no d3/elkjs/cytoscape). NodeCards are one-line summaries; clicking one opens a side panel with the full record fields. Large literal input values render collapsed with a `[view]` toggle (progressive disclosure).
- **Provenance header** with actor, verified-signature badge (`aileron.plan.signature_status`), signer fingerprint, and plan/skill name.
- **Timeline toggle** reads `aileron.invocation.id` off the graph's root record and calls `getAuditByInvocation`, rendering the launch's records oldest-first.
- **Artifact lookup**: paste a `sha256:…` hash, or drop a file to hash its bytes client-side (`crypto.subtle`) into `sha256:<hex>`.
- **Deep-link contract for #1894**: `/audit?content_hash=sha256:…` resolves and renders that artifact's graph directly on load, skipping the landing. This affordance is implemented here so #1894 can rely on it.
- Nav entry added to `+layout.svelte`.

### Notes on scope

- **Pure webapp, no API/spec/codegen changes.** #1893 (the `invocation_id` filter) is already on `main` via #1907, so the timeline toggle consumes it directly.
- **`internal/app/webapp_dist/**` is gitignored** (only `.gitkeep` is tracked); CI rebuilds the embed via `task build:webapp`. So no dist artifacts are committed here — the plan's assumption that dist is committed does not match the repo's `.gitignore`. The build was run locally to confirm `/audit` compiles into the SPA bundle and the `internal/app` Go tests still pass against the regenerated embed.

## Test plan

- `task test:webapp` — 124 vitest tests pass, including:
  - api wrappers: URL construction/encoding, `events` unwrap, empty-result, non-2xx throw.
  - provenance module: linear chain, branching, literal input, dangling hash, cycle safety.
  - payload helpers: `shortHash`, `formatBytes`, `stepInputs` coercion.
  - route: landing render, empty/error states, deep-link render-on-load (skips landing), graph node cards + side-panel open, large-literal collapse/expand, timeline toggle by invocation id in time order.
- `pnpm check` (svelte-check) — 0 errors, 0 warnings.
- `task build:webapp` — succeeds; `/audit` compiles into the embed.
- `go test ./internal/app/...` — passes against the regenerated embed.

Closes #1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Audit page with recent artifacts, content-hash lookup, provenance graph view, and a related timeline view.
  * Added deeper artifact details, including step inputs, hashes, signatures, actors, and invocation information.
  * Added file drag-and-drop hashing to quickly look up an artifact from a local file.
  * Added a new Audit link in the main navigation.

* **Bug Fixes**
  * Improved handling of missing, malformed, or unresolved provenance data.
  * Added clearer empty and error states across audit views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->