### PR TITLE
feat(audit): add `aileron audit dashboard` to open the provenance view

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -4227,7 +4228,8 @@ type auditListWire struct {
 
 const auditUsage = `usage:
   aileron audit list  [--since RFC3339] [--audit-id ID] [--connector FQN] [--class CLASS] [--output NAME] [--content-hash sha256:...] [--invocation-id ID] [--limit N] [--json]
-  aileron audit show  <audit-id> [--json] [--verbose|-v]`
+  aileron audit show  <audit-id> [--json] [--verbose|-v]
+  aileron audit dashboard [--content-hash sha256:...]`
 
 // auditListFetcher and auditGetFetcher are the HTTP clients for the
 // two audit endpoints. Replaceable in tests so they don't depend on a
@@ -4346,11 +4348,64 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 		return runAuditList(args[1:], stdout, stderr)
 	case "show":
 		return runAuditShow(args[1:], stdout, stderr)
+	case "dashboard":
+		return runAuditDashboard(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown audit command: %q\n", args[0])
 		fmt.Fprintln(stderr, auditUsage)
 		return 1
 	}
+}
+
+// runAuditDashboard opens the `/audit` provenance walk-back view in the
+// operator's default browser. It resolves the running daemon's webapp
+// URL from <stateDir>/daemon.json (same discovery path as `aileron
+// open`) and shells out to the OS opener. An optional `--content-hash`
+// deep-links the view to the trace that produced that materialized
+// output, matching the query contract the /audit route honors.
+//
+// This is a read-only local convenience: it talks to the webapp through
+// the browser and adds no API surface. If the daemon isn't running it
+// exits 1 with a hint rather than auto-spawning one — the operator who
+// wants the dashboard has already run something that started the daemon.
+func runAuditDashboard(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("audit dashboard", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	contentHash := flags.String("content-hash", "", "Deep-link the view to the trace with this output content hash (sha256:<hex>)")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "aileron: `audit dashboard` takes no positional arguments; got %q\n", flags.Arg(0))
+		fmt.Fprintln(stderr, auditUsage)
+		return 1
+	}
+
+	stateDir, err := defaultStateDirFn()
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: %v\n", err)
+		return 1
+	}
+	info, err := discoveryReadFn(stateDir)
+	if err != nil {
+		if errors.Is(err, discovery.ErrNotRunning) {
+			fmt.Fprintln(stderr, "aileron: daemon is not running.")
+			fmt.Fprintln(stderr, "Hint: any 'aileron <command>' or 'aileron launch <agent>' will start it.")
+			return 1
+		}
+		fmt.Fprintf(stderr, "aileron: read daemon.json: %v\n", err)
+		return 1
+	}
+
+	openURL := buildAuditDashboardURL(info.URL, *contentHash)
+
+	if err := openInBrowserFn(context.Background(), openURL); err != nil {
+		fmt.Fprintf(stderr, "aileron: failed to launch browser: %v\n", err)
+		fmt.Fprintf(stderr, "Open this URL manually: %s\n", openURL)
+		return 1
+	}
+	fmt.Fprintln(stdout, openURL)
+	return 0
 }
 
 func runAuditList(args []string, stdout, stderr io.Writer) int {

--- a/cmd/aileron/open.go
+++ b/cmd/aileron/open.go
@@ -124,6 +124,24 @@ func buildOpenURL(base string, target openTarget, approvalID string) string {
 	}
 }
 
+// buildAuditDashboardURL composes the URL for the `/audit` provenance
+// walk-back view from the daemon's base URL and an optional content
+// hash. When a hash is supplied it is carried in the `content_hash`
+// query parameter, matching the deep-link contract the webapp's /audit
+// route honors (webapp/src/routes/audit/+page.svelte). Trailing slashes
+// on the base URL are stripped so the result never has a doubled slash.
+//
+// It is a sibling of buildOpenURL rather than a new openTarget: the
+// audit dashboard is a distinct surface with its own query grammar, and
+// a separate helper keeps each independently unit-testable.
+func buildAuditDashboardURL(base, contentHash string) string {
+	base = strings.TrimRight(base, "/")
+	if contentHash == "" {
+		return base + "/audit"
+	}
+	return base + "/audit?content_hash=" + url.QueryEscape(contentHash)
+}
+
 // openInBrowser shells out to the platform's URL-opener. macOS and
 // Linux pass the URL as a single argv element with no shell. Windows
 // goes through `cmd /c start`, whose command-line parser treats `&` and

--- a/cmd/aileron/open_test.go
+++ b/cmd/aileron/open_test.go
@@ -306,3 +306,184 @@ func TestRunOpen_DiscoveryReadGenericErrorReturns1(t *testing.T) {
 		t.Errorf("stderr should include underlying error; got %q", stderr.String())
 	}
 }
+
+// --- buildAuditDashboardURL contract ---
+
+func TestBuildAuditDashboardURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		base        string
+		contentHash string
+		want        string
+	}{
+		{
+			name: "no hash opens audit root",
+			base: "http://127.0.0.1:5041",
+			want: "http://127.0.0.1:5041/audit",
+		},
+		{
+			name:        "hash is carried as content_hash query",
+			base:        "http://127.0.0.1:5041",
+			contentHash: "sha256:abc",
+			want:        "http://127.0.0.1:5041/audit?content_hash=sha256%3Aabc",
+		},
+		{
+			name: "trailing slash on base is trimmed",
+			base: "http://127.0.0.1:5041/",
+			want: "http://127.0.0.1:5041/audit",
+		},
+		{
+			name:        "hash needing escaping is query-escaped",
+			base:        "http://127.0.0.1:5041",
+			contentHash: "sha256:a b&c",
+			want:        "http://127.0.0.1:5041/audit?content_hash=sha256%3Aa+b%26c",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildAuditDashboardURL(tc.base, tc.contentHash)
+			if got != tc.want {
+				t.Errorf("buildAuditDashboardURL(%q, %q) = %q, want %q", tc.base, tc.contentHash, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- runAuditDashboard ---
+
+func TestRunAuditDashboard_OpensAuditView(t *testing.T) {
+	info := discovery.Info{URL: "http://127.0.0.1:50419"}
+	opener := withStubs(t, info, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard(nil, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(opener.called) != 1 || opener.called[0] != "http://127.0.0.1:50419/audit" {
+		t.Fatalf("opener.called = %v, want [http://127.0.0.1:50419/audit]", opener.called)
+	}
+	if !strings.Contains(stdout.String(), "http://127.0.0.1:50419/audit") {
+		t.Errorf("stdout missing URL; got %q", stdout.String())
+	}
+}
+
+func TestRunAuditDashboard_ContentHashDeepLinks(t *testing.T) {
+	info := discovery.Info{URL: "http://127.0.0.1:50419"}
+	opener := withStubs(t, info, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard([]string{"--content-hash", "sha256:abc"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if len(opener.called) != 1 || opener.called[0] != "http://127.0.0.1:50419/audit?content_hash=sha256%3Aabc" {
+		t.Fatalf("opener.called = %v, want deep-linked audit URL", opener.called)
+	}
+}
+
+func TestRunAuditDashboard_DaemonNotRunningReturns1AndPrintsHint(t *testing.T) {
+	opener := withStubs(t, discovery.Info{}, discovery.ErrNotRunning, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard(nil, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "daemon is not running") {
+		t.Errorf("stderr missing not-running message; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "aileron launch") {
+		t.Errorf("stderr missing actionable hint; got %q", stderr.String())
+	}
+	if len(opener.called) != 0 {
+		t.Errorf("opener should not be called when daemon is down; got %v", opener.called)
+	}
+}
+
+func TestRunAuditDashboard_DiscoveryReadGenericErrorReturns1(t *testing.T) {
+	opener := withStubs(t, discovery.Info{}, errors.New("permission denied"), nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard(nil, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if strings.Contains(stderr.String(), "is not running") {
+		t.Errorf("stderr should not mislead with 'not running' on generic error; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "permission denied") {
+		t.Errorf("stderr should include underlying error; got %q", stderr.String())
+	}
+	if len(opener.called) != 0 {
+		t.Errorf("opener should not be called on read error; got %v", opener.called)
+	}
+}
+
+func TestRunAuditDashboard_OpenerFailurePrintsURLForCopyPaste(t *testing.T) {
+	info := discovery.Info{URL: "http://127.0.0.1:50419"}
+	withStubs(t, info, nil, errors.New("no xdg-open"))
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard(nil, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "http://127.0.0.1:50419/audit") {
+		t.Errorf("stderr should print URL for copy-paste; got %q", stderr.String())
+	}
+}
+
+func TestRunAuditDashboard_ExtraPositionalArgReturns1AndPrintsUsage(t *testing.T) {
+	info := discovery.Info{URL: "http://127.0.0.1:50419"}
+	opener := withStubs(t, info, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard([]string{"bogus"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "audit dashboard") {
+		t.Errorf("stderr should include usage; got %q", stderr.String())
+	}
+	if len(opener.called) != 0 {
+		t.Errorf("opener should not be called on bad args; got %v", opener.called)
+	}
+}
+
+func TestRunAuditDashboard_UnknownFlagReturns1(t *testing.T) {
+	info := discovery.Info{URL: "http://127.0.0.1:50419"}
+	opener := withStubs(t, info, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard([]string{"--nope"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(opener.called) != 0 {
+		t.Errorf("opener should not be called on flag parse error; got %v", opener.called)
+	}
+}
+
+func TestRunAuditDashboard_StateDirErrorReturns1(t *testing.T) {
+	prev := defaultStateDirFn
+	defaultStateDirFn = func() (string, error) { return "", errors.New("no home directory") }
+	t.Cleanup(func() { defaultStateDirFn = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := runAuditDashboard(nil, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no home directory") {
+		t.Errorf("stderr should surface state-dir error; got %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds `aileron audit dashboard`, a read-only local convenience that opens the `/audit` provenance walk-back view (shipped in #1909) in the operator's default browser.

- Resolves the running daemon's webapp URL from `<stateDir>/daemon.json` using the same discovery + browser-open seams as `aileron open` (`defaultStateDirFn` / `discoveryReadFn` / `openInBrowserFn`) — no new dependency.
- Optional `--content-hash sha256:...` deep-links the view to the trace that produced a materialized output, carried as the `content_hash` query param the `/audit` route already honors. Flag spelling matches `audit list`'s `--content-hash` verbatim.
- Daemon-not-running prints the same actionable hint as `aileron open` and exits 1 without opening a browser; a generic `daemon.json` read error exits 1 without the misleading "not running" hint; opener failure prints the URL for copy-paste and exits 1.
- New `buildAuditDashboardURL` helper sits beside `buildOpenURL` (same `TrimRight` + `url.QueryEscape` discipline) so each surface stays independently unit-testable.

Scope: only the `dashboard` subcommand + helper + tests, plus one `auditUsage` line. No changes to `runAuditList`/`runAuditShow`, the audit HTTP fetchers, the OpenAPI spec, generated code, `openInBrowser`/`buildOpenURL`, or `webapp/**`.

## Test plan

- `go build ./cmd/aileron/...` and `go vet ./cmd/aileron/...` clean.
- `go test ./cmd/aileron/...` green (full package suite).
- New tests in `cmd/aileron/open_test.go`:
  - `buildAuditDashboardURL`: root, `content_hash` query, trailing-slash trim, escaping.
  - `runAuditDashboard`: happy path (URL opened + echoed), `--content-hash` deep-link, daemon-not-running hint (opener not called), generic read error, opener failure copy-paste, extra positional arg, unknown flag, state-dir error.
- Coverage: `runAuditDashboard` and `buildAuditDashboardURL` at 100%.

Closes #1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)
