### PR TITLE
feat(flightplan): make requires.actions optional for tool-only plans

### DIFF
--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -20,7 +20,7 @@
       "type": "object",
       "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
       "additionalProperties": false,
-      "required": ["requires", "inputs", "outputs"],
+      "required": ["inputs", "outputs"],
       "properties": {
         "schemaVersion": {
           "type": "string",
@@ -56,14 +56,12 @@
     },
     "requires": {
       "type": "object",
-      "description": "Dependency declaration. Lists the actions the Flight Plan calls. The execution environment lives in the sibling `environment` block, not here. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
+      "description": "Dependency declaration. Lists the actions the Flight Plan calls. OPTIONAL, and `actions` within it is OPTIONAL: a tool-only plan whose every effectful step is an in-container `tool` step calls no connector action and declares none, so an omitted `requires`, a `requires: {}`, and an empty `actions: []` all validate. The execution environment lives in the sibling `environment` block, not here. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
       "additionalProperties": false,
-      "required": ["actions"],
       "properties": {
         "actions": {
           "type": "array",
-          "description": "The actions the Flight Plan calls. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract.",
-          "minItems": 1,
+          "description": "The actions the Flight Plan calls (OPTIONAL). Absent or empty for a tool-only plan that dispatches no connector actions. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract. The declared set stays load-bearing for a plan that does call actions: the runtime refuses an action-call step whose ref is not declared here, so every called action must appear.",
           "items": { "$ref": "#/$defs/actionRequirement" }
         }
       }

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -54,7 +54,7 @@ The tables below give every field's type, required-ness, and semantics. Field na
 | Field | Type | Required | Semantics |
 |---|---|---|---|
 | `schemaVersion` | string | No | When present, must be `aileron.flightplan.v1`. Identifies the block contract this manifest was authored against. |
-| `requires` | object | Yes | The action dependencies. |
+| `requires` | object | No | The action dependencies. Optional: a tool-only plan that dispatches no connector actions omits it. |
 | `environment` | object | No | The single container the plan runs in. Declares `tools`, an `image`, or both. Absent when the plan needs no environment. |
 | `inputs` | array | Yes | The declared inputs, each with a resolution rule. |
 | `outputs` | array | Yes | The declared output artifacts. |
@@ -65,7 +65,7 @@ The tables below give every field's type, required-ness, and semantics. Field na
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|
-| `actions` | array | Yes | The actions the plan calls. At least one entry. Each entry carries a per-action trust contract. |
+| `actions` | array | No | The actions the plan calls, each with a per-action trust contract. Absent or empty for a tool-only plan that dispatches no connector actions. A plan that does call actions must declare each called action here: the runtime refuses an `action-call` step whose ref is not declared. |
 
 Each `actions[]` entry:
 

--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -85,9 +85,11 @@ Open the frontmatter block at the top; close it; write the body underneath. The 
 
 The `requires:` block lists the actions the plan calls. The sibling `environment:` block declares the container it runs in. Together they are the dependency declaration freeze reads when it pins and binds.
 
+The `requires:` block is optional. A tool-only plan whose every effectful step is an in-container `tool` step dispatches no connector action, so it declares no actions and omits the block entirely. Do not carry a dummy action ref to satisfy the schema: an unused ref names nothing the plan calls and surfaces a spurious "not satisfiable here" warning at `aileron skill install`. Declare an action only when a step actually calls it.
+
 ### Actions and the per-action trust contract
 
-Each `requires.actions[]` entry names one action by `ref` and carries a per-action `trustContract`. The `ref` is `aileron:<connector>.<action>`, and it attaches to the [action model](/concepts/actions/). An unsatisfied `requires:` entry is a missing-requirement signal the runtime surfaces, never a parse failure.
+Each `requires.actions[]` entry names one action by `ref` and carries a per-action `trustContract`. The `ref` is `aileron:<connector>.<action>`, and it attaches to the [action model](/concepts/actions/). An unsatisfied `requires:` entry is a missing-requirement signal the runtime surfaces, never a parse failure. The declared set stays load-bearing for a plan that does call actions: the runtime refuses an `action-call` step whose ref is not declared here, so every called action must appear.
 
 The trust contract is the security surface for that action. You write it; freeze attaches it; the detached signature is the human attestation that it is correct. Every field below records something the runtime enforces or the user sees.
 

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -20,7 +20,7 @@
       "type": "object",
       "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
       "additionalProperties": false,
-      "required": ["requires", "inputs", "outputs"],
+      "required": ["inputs", "outputs"],
       "properties": {
         "schemaVersion": {
           "type": "string",
@@ -56,14 +56,12 @@
     },
     "requires": {
       "type": "object",
-      "description": "Dependency declaration. Lists the actions the Flight Plan calls. The execution environment lives in the sibling `environment` block, not here. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
+      "description": "Dependency declaration. Lists the actions the Flight Plan calls. OPTIONAL, and `actions` within it is OPTIONAL: a tool-only plan whose every effectful step is an in-container `tool` step calls no connector action and declares none, so an omitted `requires`, a `requires: {}`, and an empty `actions: []` all validate. The execution environment lives in the sibling `environment` block, not here. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
       "additionalProperties": false,
-      "required": ["actions"],
       "properties": {
         "actions": {
           "type": "array",
-          "description": "The actions the Flight Plan calls. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract.",
-          "minItems": 1,
+          "description": "The actions the Flight Plan calls (OPTIONAL). Absent or empty for a tool-only plan that dispatches no connector actions. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract. The declared set stays load-bearing for a plan that does call actions: the runtime refuses an action-call step whose ref is not declared here, so every called action must appear.",
           "items": { "$ref": "#/$defs/actionRequirement" }
         }
       }

--- a/internal/flightplan/manifest/manifest.go
+++ b/internal/flightplan/manifest/manifest.go
@@ -136,8 +136,9 @@ func Parse(raw []byte) (*Manifest, error) {
 
 	// The aileron block is present. Validate the full required set against
 	// the embedded schema (not just the per-ref regex): aileronBlock
-	// requires requires/inputs/outputs; requires requires a non-empty
-	// actions array; each actionRequirement requires ref + trustContract.
+	// requires inputs/outputs; `requires` and its `actions` array are both
+	// optional (a tool-only plan declares no connector actions, #1932);
+	// each actionRequirement that IS declared requires ref + trustContract.
 	if err := validateFrontmatter(front); err != nil {
 		return nil, err
 	}

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -10,15 +10,6 @@ import (
 // must validate it) but violates exactly one required-field rule.
 func TestParseInvalidBlocks(t *testing.T) {
 	cases := map[string]string{
-		"missing requires": `---
-name: s
-description: d
-aileron:
-  inputs: []
-  outputs: []
----
-body
-`,
 		"missing inputs": `---
 name: s
 description: d
@@ -40,17 +31,6 @@ aileron:
       - ref: aileron:metrics.query_series
         trustContract: {}
   inputs: []
----
-body
-`,
-		"empty actions array": `---
-name: s
-description: d
-aileron:
-  requires:
-    actions: []
-  inputs: []
-  outputs: []
 ---
 body
 `,
@@ -101,6 +81,73 @@ body
 			}
 			if !strings.Contains(err.Error(), "schema validation") {
 				t.Errorf("error should cite schema validation, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestParseToolOnlyPlanNeedsNoActions is the #1932 regression: a tool-only
+// plan whose every effectful step is an in-container tool step dispatches no
+// connector action, so it must not be forced to declare a dummy
+// requires.actions entry. An omitted `requires`, a `requires: {}`, and an
+// empty `actions: []` must all validate — before this change the schema
+// mandated `requires` with a non-empty `actions` array, which forced a
+// vestigial ref that then tripped a spurious "not satisfiable here" install
+// warning.
+func TestParseToolOnlyPlanNeedsNoActions(t *testing.T) {
+	cases := map[string]string{
+		"requires omitted entirely": `---
+name: s
+description: d
+aileron:
+  environment:
+    tools:
+      - aws-cli@2.x
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"requires present but empty": `---
+name: s
+description: d
+aileron:
+  requires: {}
+  environment:
+    tools:
+      - aws-cli@2.x
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"empty actions array": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions: []
+  environment:
+    tools:
+      - aws-cli@2.x
+  inputs: []
+  outputs: []
+---
+body
+`,
+	}
+
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m, err := Parse([]byte(doc))
+			if err != nil {
+				t.Fatalf("a tool-only plan must validate for %q, got: %v", name, err)
+			}
+			if m.InstructionOnly {
+				t.Errorf("a plan with an aileron block must not be InstructionOnly")
+			}
+			if len(m.Refs()) != 0 {
+				t.Errorf("a tool-only plan declares no action refs, got: %v", m.Refs())
 			}
 		})
 	}

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -368,6 +368,39 @@ func TestDecode_ActionCallToUndeclaredAction(t *testing.T) {
 	}
 }
 
+// TestDecode_ToolOnlyPlanNoActions is the decode-side half of the #1932
+// guarantee: a plan that declares no requires.actions and runs only a tool
+// step decodes cleanly. The counterpart guardrail
+// (TestDecode_ActionCallToUndeclaredAction) proves a plan that DOES call an
+// action still needs the ref declared, so relaxing the schema to make actions
+// optional does not weaken the declared-ref check.
+func TestDecode_ToolOnlyPlanNoActions(t *testing.T) {
+	m := &manifest.Manifest{
+		Name: "tool-only",
+		Aileron: manifest.AileronBlock{
+			SchemaVersion: "aileron.flightplan.v1",
+			// Requires left zero: no declared actions, as a tool-only plan.
+			Steps: []any{
+				step(map[string]any{
+					"id": "render", "kind": "tool",
+					"command": []any{"aws", "s3", "ls"},
+					"outputs": []any{"listing"},
+				}),
+			},
+		},
+	}
+	p, err := Decode(m)
+	if err != nil {
+		t.Fatalf("a tool-only plan with no declared actions must decode, got: %v", err)
+	}
+	if len(p.Actions) != 0 {
+		t.Errorf("a tool-only plan decodes no actions, got: %v", p.Actions)
+	}
+	if len(p.Steps) != 1 || p.Steps[0].Kind != KindTool {
+		t.Fatalf("expected one tool step, got: %+v", p.Steps)
+	}
+}
+
 func TestDecodeError_Type(t *testing.T) {
 	_, err := Decode(parseInline(t, "---\nname: x\ndescription: y\n---\n\n# X\n"))
 	var de *DecodeError

--- a/internal/flightplan/store/install_test.go
+++ b/internal/flightplan/store/install_test.go
@@ -113,6 +113,59 @@ func TestInstallInstructionOnlyClean(t *testing.T) {
 	}
 }
 
+// toolOnlySkill is a #1932 tool-only plan: it carries an aileron block (so it
+// is NOT instruction-only) but declares no requires.actions because its one
+// effectful step is an in-container tool step. It must install exactly like a
+// no-action skill: the resolver is never consulted and nothing is unsatisfied,
+// so `aileron skill install` prints no "not satisfiable here" warning.
+const toolOnlySkill = `---
+name: tool-only-plan
+description: A tool-only plan that dispatches no connector actions.
+aileron:
+  environment:
+    tools:
+      - aws-cli@2.x
+  inputs: []
+  outputs: []
+---
+
+# Tool-only plan
+Runs a tool step, calls no connector action.
+`
+
+func TestInstallToolOnlyPlanNoActionsClean(t *testing.T) {
+	s := New(t.TempDir())
+	src := writeSkill(t, toolOnlySkill)
+
+	// A fetcher that fails if touched proves a tool-only plan with no declared
+	// actions never reaches the daemon: with no refs to resolve there is
+	// nothing to warn about.
+	fetcher := &recordingFetcher{err: errors.New("daemon down")}
+
+	res, err := s.Install(context.Background(), src, InstallOptions{Fetcher: fetcher})
+	if err != nil {
+		t.Fatalf("tool-only install must be clean: %v", err)
+	}
+	if fetcher.called {
+		t.Error("resolver/daemon seam was consulted for a plan with no action refs")
+	}
+	if res.InstructionOnly {
+		t.Error("a plan with an aileron block must not be marked InstructionOnly")
+	}
+	if res.ResolverConsulted {
+		t.Error("ResolverConsulted should be false when no actions are declared")
+	}
+	if len(res.Unsatisfied) != 0 {
+		t.Errorf("a tool-only plan has no unsatisfied refs, got: %v", res.Unsatisfied)
+	}
+	if res.Degraded() {
+		t.Error("a tool-only install must not degrade")
+	}
+	if res.Name != "tool-only-plan" {
+		t.Errorf("name = %q", res.Name)
+	}
+}
+
 func TestInstallCredentialedSatisfiable(t *testing.T) {
 	s := New(t.TempDir())
 	src := credentialedSkillDir(t)


### PR DESCRIPTION
## Summary

A tool-only Flight Plan whose every effectful step is an in-container `tool` step dispatches no connector action, so it has nothing real to declare in `requires.actions`. The `aileron.flightplan.v1` schema nonetheless mandated `requires` with a non-empty `actions[]` (`required: [actions]` + `minItems: 1`), forcing such a plan to carry a **dummy** action ref. That vestigial ref then tripped a spurious `warning: ... N action requirement(s) are not satisfiable here` on every clean `aileron skill install`, misleading the operator into thinking a real dependency was missing.

This relaxes the schema so a tool-only plan declares no actions and installs silently:

- `aileronBlock.required`: drop `requires` (keep `inputs`, `outputs`).
- `requires`: drop `required: [actions]` and `minItems: 1` from `actions`.

A tool-only plan now omits `requires` entirely (or `requires: {}` / `actions: []` — all validate). No install-path change was needed: `store.Install` already short-circuits resolution when `Refs()` is empty, so with no refs there is nothing to warn about.

**Guardrail preserved (no regression):** a plan that *does* call connector actions still must declare each called action. The runtime refuses an `action-call` step whose `actionRef` is not in `requires.actions` (`internal/flightplan/runtime/decode.go`), and that check is independent of the schema relaxation — it fires whenever an action-call ref is undeclared, regardless of how many actions are declared.

Both schema copies (the internal `go:embed` copy and the normative `docs/schema` mirror) stay byte-identical (drift-guard test enforces this). Spec table and authoring-guide prose updated to match, including explicit guidance not to carry a dummy ref.

Closes #1932.

## Test plan

- `TestParseToolOnlyPlanNeedsNoActions` (manifest) — a tool-only plan validates whether `requires` is omitted, empty, or carries `actions: []`; parses non-instruction-only with zero refs. Removed the now-obsolete `missing requires` / `empty actions array` invalid cases.
- `TestDecode_ToolOnlyPlanNoActions` (runtime) — a plan with no declared actions and a single tool step decodes cleanly.
- `TestDecode_ActionCallToUndeclaredAction` (runtime, pre-existing) — the guardrail counterpart: a plan that calls an undeclared action is still refused.
- `TestInstallToolOnlyPlanNoActionsClean` (store) — end-to-end acceptance: the resolver/daemon seam is never consulted, `Unsatisfied` is empty, install does not degrade → no "not satisfiable here" warning.
- `go test ./internal/flightplan/... ./cmd/aileron/...` green; `go vet` clean; coverage manifest 80.3% / store 83.2% / runtime 91.5%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8zuihvSqz5B8hdaiEU2tm
