### PR TITLE
fix(flightplan): match input digest to producer for JSON-string carriers

### DIFF
--- a/internal/flightplan/runtime/materialize.go
+++ b/internal/flightplan/runtime/materialize.go
@@ -73,18 +73,28 @@ func canonicalValueDigest(v any) (string, error) {
 // walk-back records for a resolved binding value, in the SAME digest-space as
 // the producer's `aileron.output.content_hash`.
 //
-// A file-map carrier (a JSON object with a `content` key, #1519) is digested
-// over its carried `entry.Content` bytes — the exact bytes materialize() digests
-// into Artifact.Digest — so a downstream input walks back to the producing
+// It shares materialize()'s exact carrier-decode → digest path so the producer
+// and the consumer always land in the same digest-space. A file-map carrier
+// (a JSON object with a `content` key, #1519) is digested over its carried
+// `entry.Content` bytes — the exact bytes materialize() digests into
+// Artifact.Digest — so a downstream input walks back to the producing
 // `output.materialized` record by an equal hash (#1891/#1912). A plain-data
-// carrier keeps canonicalValueDigest over the whole value object, which already
-// equals the producer's digest for a plain-data carrier (materialize() digests
-// the same canonical bytes). On any decode error the value falls back to
-// canonicalValueDigest so non-file-map / edge values behave exactly as before.
+// carrier is digested over decodeCarrier's canonicalized `rawContent`, the same
+// bytes materialize() digests for a non-file-map carrier; this closes the
+// `tool → transform` (and `action-call → transform`) edge, where the resolved
+// value is a JSON *string* whose canonicalValueDigest would hash the quoted,
+// escaped literal instead of the parsed object bytes the producer digested
+// (#1933). For an already-decoded plain-data object this yields the identical
+// bytes canonicalValueDigest produced, so those edges are unchanged. On any
+// decode error (a scalar or undecodable value) the digest falls back to
+// canonicalValueDigest so non-carrier / edge values behave exactly as before.
 func inputContentDigest(v any) (string, error) {
-	entry, _, isFileMap, err := decodeCarrier(v)
-	if err == nil && isFileMap {
-		return contentDigest([]byte(entry.Content)), nil
+	entry, rawContent, isFileMap, err := decodeCarrier(v)
+	if err == nil {
+		if isFileMap {
+			return contentDigest([]byte(entry.Content)), nil
+		}
+		return contentDigest(rawContent), nil
 	}
 	return canonicalValueDigest(v)
 }

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -233,6 +233,80 @@ func TestMaterialize_RawDataFromJSONString(t *testing.T) {
 	}
 }
 
+func TestInputContentDigest_JSONStringCarrierMatchesProducer(t *testing.T) {
+	// Regression (#1933): a tool step's downstream result is a JSON *string*
+	// (execute.go returns the collected file content as a string). The producer
+	// digests the parsed, canonicalized object bytes via materialize()/
+	// decodeCarrier; the consumer must digest those SAME bytes, not the quoted,
+	// escaped string literal json.Marshal produces for a raw string value. Before
+	// the fix inputContentDigest called canonicalValueDigest(string) and the two
+	// digests diverged, so a `tool → transform` (or `action-call → transform`)
+	// edge dangled as "unresolved upstream" in the /audit walk-back.
+	result := `{"QueryExecutionId":"qeid-1","ResultSet":{"rows":[1,2,3]}}`
+
+	// Producer: materialize the JSON-string carrier as a plain data result.
+	p := planWithOutput(Output{Name: "x.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "x.json"})
+	step := fileMapStep("x.json")
+	art, err := materialize(p, step, map[string]any{"file": result})
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	// Consumer: the input walk-back digests the same resolved string value.
+	got, err := inputContentDigest(result)
+	if err != nil {
+		t.Fatalf("inputContentDigest: %v", err)
+	}
+	if got != art.Digest {
+		t.Errorf("consumer input digest %q must equal producer artifact digest %q for a JSON-string carrier", got, art.Digest)
+	}
+
+	// And it must NOT be the quoted-literal digest the old path produced, so a
+	// future regression to canonicalValueDigest(v) is caught.
+	quoted, err := canonicalValueDigest(result)
+	if err != nil {
+		t.Fatalf("canonicalValueDigest: %v", err)
+	}
+	if got == quoted {
+		t.Error("input digest must be over the parsed object bytes, not the quoted JSON-string literal")
+	}
+}
+
+func TestInputContentDigest_DecodedObjectUnchanged(t *testing.T) {
+	// An already-decoded plain-data object carrier keeps the exact digest the
+	// prior whole-value path produced: decodeCarrier's canonicalization
+	// (marshal → unmarshal → marshal) yields the same bytes canonicalValueDigest
+	// did, so plain-data edges are unchanged by the #1933 fix.
+	v := map[string]any{"b": 2, "a": 1}
+	got, err := inputContentDigest(v)
+	if err != nil {
+		t.Fatalf("inputContentDigest: %v", err)
+	}
+	want, err := canonicalValueDigest(v)
+	if err != nil {
+		t.Fatalf("canonicalValueDigest: %v", err)
+	}
+	if got != want {
+		t.Errorf("decoded-object digest = %q, want %q (unchanged)", got, want)
+	}
+}
+
+func TestInputContentDigest_ScalarFallsBackToCanonical(t *testing.T) {
+	// A bare scalar is not a decodable carrier, so the digest falls back to
+	// canonicalValueDigest exactly as before the #1933 fix.
+	got, err := inputContentDigest("plain text, not json")
+	if err != nil {
+		t.Fatalf("inputContentDigest: %v", err)
+	}
+	want, err := canonicalValueDigest("plain text, not json")
+	if err != nil {
+		t.Fatalf("canonicalValueDigest: %v", err)
+	}
+	if got != want {
+		t.Errorf("scalar digest = %q, want canonicalValueDigest %q", got, want)
+	}
+}
+
 func TestMaterialize_EmptyFileMapContentStaysEmpty(t *testing.T) {
 	// A genuine file-map that explicitly emits empty content keeps writing an
 	// empty file: the `content`-key discriminator preserves the ability to


### PR DESCRIPTION
## Summary

In the `/audit` provenance walk-back, an artifact produced by a `transform` step that consumes a tool step's result (`source: steps.<tool>.result`) rendered its upstream edge as a red "unresolved upstream" node, even though the tool step materialized that exact data as a sibling artifact in the same launch.

Root cause: a tool step's downstream result is a JSON **string** (`execute.go` returns the collected file content as a string). The producer and consumer then digested it through two different paths:

- **Producer** (`materialize` → `decodeCarrier`): a string carrier is parsed and re-marshaled; `Artifact.Digest` is over the **parsed, canonicalized object bytes**.
- **Consumer** (`buildStepInputs` → `inputContentDigest`): a JSON-string carrier is not a file-map, so it fell through to `canonicalValueDigest(v)` with `v` still the string. `json.Marshal` of a string yields the **quoted, escaped literal**, and the digest was over those bytes.

Different byte domains → hashes never matched → the walk-back could not close the edge. #1915 fixed the file-map-object case but not this string-carrier case.

The fix shares `materialize()`'s exact carrier-decode → digest path: `inputContentDigest` now digests `decodeCarrier`'s canonicalized `rawContent` for a non-file-map carrier, so producer and consumer land in the same digest-space. Both the server trace (`internal/audit/trace.go`) and the client walk (`webapp/src/lib/audit/provenance.ts`) consume the recorded hashes, so no view change is needed. Already-decoded plain-data objects yield the identical bytes `canonicalValueDigest` produced (unchanged), and scalar/undecodable values still fall back to `canonicalValueDigest` (unchanged).

## Test plan

- `TestInputContentDigest_JSONStringCarrierMatchesProducer` — asserts the consumer input digest equals the producer's `Artifact.Digest` for a JSON-string carrier, and that it is NOT the quoted-literal digest. Fails before the fix, passes after (verified).
- `TestInputContentDigest_DecodedObjectUnchanged` — an already-decoded plain-data object keeps the prior whole-value digest.
- `TestInputContentDigest_ScalarFallsBackToCanonical` — a bare scalar still falls back to `canonicalValueDigest`.
- `go test ./internal/flightplan/... ./internal/audit/...` green; `go vet ./internal/flightplan/...` clean.

Fixes #1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)