### PR TITLE
refactor(webapp): assemble /audit graph from the server trace endpoint

### DIFF
--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -381,6 +381,11 @@ describe('getAuditTrace — URL construction, unwrap, and 404→null', () => {
 		await expect(getAuditTrace({ contentHash: 'sha256:none' })).resolves.toBeNull();
 	});
 
+	it('throws without issuing a request when neither identifier is supplied', async () => {
+		await expect(getAuditTrace({})).rejects.toThrow(/requires contentHash or invocationId/);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
 	it('still throws on a non-404 error', async () => {
 		fetchSpy.mockResolvedValue(
 			new Response(JSON.stringify({ error: { message: 'trace assembly failed' } }), {

--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -4,9 +4,10 @@ import {
 	getHubInstallDecision,
 	listRecentMaterialized,
 	getAuditByContentHash,
-	getAuditByInvocation
+	getAuditByInvocation,
+	getAuditTrace
 } from './api';
-import type { HubInstallDecision, AuditEvent } from './api';
+import type { HubInstallDecision, AuditEvent, AuditTraceResponse } from './api';
 
 // Regression target: the user clicked "Approve" in the webapp, the
 // daemon executed the action successfully, but the page surfaced
@@ -287,6 +288,109 @@ describe('audit wrappers — URL construction and unwrap', () => {
 		);
 		await expect(getAuditByContentHash('sha256:x')).rejects.toThrow(
 			'audit list failed'
+		);
+	});
+});
+
+// --- Server-assembled provenance trace (#1913/#1930) ---
+//
+// `getAuditTrace` collapses the old N+1 client walk into one round-trip
+// against `GET /v1/audit/trace`. These tests pin the URL it builds (with
+// encoding + content_hash precedence), the unwrap of `{root_id,nodes,edges}`,
+// and the 404→null contract that preserves the #1894 unknown-hash empty
+// state without a throw. Every other non-2xx still throws.
+
+function traceResponse(resp: AuditTraceResponse): Response {
+	return new Response(JSON.stringify(resp), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
+const sampleTrace: AuditTraceResponse = {
+	root_id: 'artifact:sha256:root',
+	nodes: [
+		{
+			id: 'artifact:sha256:root',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			content_hash: 'sha256:root'
+		}
+	],
+	edges: []
+};
+
+describe('getAuditTrace — URL construction, unwrap, and 404→null', () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, 'fetch');
+	});
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('encodes content_hash into the trace query', async () => {
+		fetchSpy.mockResolvedValue(traceResponse(sampleTrace));
+
+		await getAuditTrace({ contentHash: 'sha256:dead beef' });
+
+		const url = auditCall(fetchSpy, '/v1/audit/trace?');
+		expect(url).toContain('content_hash=sha256%3Adead%20beef');
+	});
+
+	it('roots on content_hash when both content_hash and invocation_id are supplied', async () => {
+		fetchSpy.mockResolvedValue(traceResponse(sampleTrace));
+
+		await getAuditTrace({ contentHash: 'sha256:root', invocationId: 'inv-9' });
+
+		const url = auditCall(fetchSpy, '/v1/audit/trace?');
+		expect(url).toContain('content_hash=sha256%3Aroot');
+		expect(url).not.toContain('invocation_id=');
+	});
+
+	it('roots on invocation_id when only that is given', async () => {
+		fetchSpy.mockResolvedValue(traceResponse(sampleTrace));
+
+		await getAuditTrace({ invocationId: 'inv/42' });
+
+		const url = auditCall(fetchSpy, '/v1/audit/trace?');
+		expect(url).toContain('invocation_id=inv%2F42');
+		expect(url).not.toContain('content_hash=');
+	});
+
+	it('unwraps a 200 into {root_id,nodes,edges}', async () => {
+		fetchSpy.mockResolvedValue(traceResponse(sampleTrace));
+
+		const got = await getAuditTrace({ contentHash: 'sha256:root' });
+
+		expect(got).toEqual(sampleTrace);
+		expect(got?.root_id).toBe('artifact:sha256:root');
+		expect(got?.nodes[0].content_hash).toBe('sha256:root');
+	});
+
+	it('resolves to null on a 404 (unknown hash) rather than throwing', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: 'not found' } }), {
+				status: 404,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+
+		await expect(getAuditTrace({ contentHash: 'sha256:none' })).resolves.toBeNull();
+	});
+
+	it('still throws on a non-404 error', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: 'trace assembly failed' } }), {
+				status: 500,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+
+		await expect(getAuditTrace({ contentHash: 'sha256:x' })).rejects.toThrow(
+			'trace assembly failed'
 		);
 	});
 });

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -29,7 +29,21 @@ async function ensureDaemonHandshake(): Promise<void> {
 	return daemonHandshake;
 }
 
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+/** Cross-cutting options for {@link apiFetch} that are not part of the
+ *  wire request. `allow404` makes a 404 resolve to `null` instead of
+ *  throwing, so callers whose "not found" is a normal, non-error result
+ *  (e.g. the audit trace endpoint's unknown-hash empty state) keep the
+ *  centralized handshake + 423 vault-lock retry without special-casing
+ *  the status themselves. All other non-ok statuses still throw. */
+type ApiFetchOptions = {
+	allow404?: boolean;
+};
+
+async function apiFetch<T>(
+	path: string,
+	init?: RequestInit,
+	opts?: ApiFetchOptions
+): Promise<T> {
 	await ensureDaemonHandshake();
 	const res = await fetch(`${API_BASE}${path}`, {
 		...init,
@@ -42,9 +56,10 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 		// Vault locked. Open the passphrase modal; on unlock, retry
 		// the original request once. The modal is responsible for
 		// resolving the promise we hand it via onVaultLocked.
-		return onVaultLocked(() => apiFetch<T>(path, init));
+		return onVaultLocked(() => apiFetch<T>(path, init, opts));
 	}
 	if (res.status === 204) return null as T;
+	if (res.status === 404 && opts?.allow404) return null as T;
 	if (!res.ok) {
 		const body = await res
 			.json()
@@ -168,6 +183,67 @@ export async function getAuditByInvocation(id: string): Promise<AuditEvent[]> {
 		`/v1/audit?invocation_id=${encodeURIComponent(id)}`
 	);
 	return resp.events ?? [];
+}
+
+// --- Server-assembled provenance trace (#1913/#1930) ---
+//
+// `GET /v1/audit/trace` assembles the provenance graph server-side: the
+// same walk-back the webapp used to do client-side (N+1 fan-out over
+// `content_hash`) collapsed into one round-trip. The `/audit` graph view
+// maps this response into the render model (`$lib/audit/provenance`); the
+// timeline stays a flat list via `getAuditByInvocation`. Field names and
+// node kinds mirror the client model, so this is a thin snake→camel map.
+
+/** One directed edge in a server-assembled provenance graph, running
+ *  parent → child (downstream consumer → upstream producer). Identical
+ *  in shape to `ProvenanceEdge`. Mirrors `AuditTraceEdge` in the spec. */
+export type AuditTraceEdge = {
+	from: string;
+	to: string;
+};
+
+/** One node in a server-assembled provenance graph. Mirrors
+ *  `AuditTraceNode` in the spec — the wire shape differs from the render
+ *  model (`ProvenanceNode`) only by `content_hash` being snake_case. */
+export type AuditTraceNode = {
+	id: string;
+	kind: 'artifact' | 'step' | 'literal' | 'launch';
+	title: string;
+	subtitle?: string;
+	depth: number;
+	/** For an artifact node, the content hash it materialized. */
+	content_hash?: string;
+	/** True when an artifact node's hash resolved to no producing record. */
+	dangling?: boolean;
+	/** The backing audit event, when the node was derived from one. */
+	event?: AuditEvent;
+	/** For a literal node, the input binding/source it stands for. */
+	literal?: { binding: string; source?: string };
+};
+
+/** Server-assembled provenance graph. Mirrors `AuditTraceResponse`.
+ *  `root_id` is the id of the node the walk started at. */
+export type AuditTraceResponse = {
+	root_id: string;
+	nodes: AuditTraceNode[];
+	edges: AuditTraceEdge[];
+};
+
+/** Fetches the server-assembled provenance trace rooted at a content
+ *  hash (precedence) or a launch invocation id. Returns `null` when the
+ *  daemon reports 404 (unknown hash / invocation) so the caller renders
+ *  the friendly empty state (#1894 contract) rather than treating a
+ *  not-found as an error. Every other non-2xx still throws. */
+export async function getAuditTrace(opts: {
+	contentHash?: string;
+	invocationId?: string;
+}): Promise<AuditTraceResponse | null> {
+	const query = opts.contentHash
+		? `content_hash=${encodeURIComponent(opts.contentHash)}`
+		: `invocation_id=${encodeURIComponent(opts.invocationId ?? '')}`;
+	return apiFetch<AuditTraceResponse>(`/v1/audit/trace?${query}`, undefined, {
+		allow404: true
+	});
 }
 
 // --- Action-level approvals (#418) ---

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -238,6 +238,9 @@ export async function getAuditTrace(opts: {
 	contentHash?: string;
 	invocationId?: string;
 }): Promise<AuditTraceResponse | null> {
+	if (!opts.contentHash && !opts.invocationId) {
+		throw new Error('getAuditTrace requires contentHash or invocationId');
+	}
 	const query = opts.contentHash
 		? `content_hash=${encodeURIComponent(opts.contentHash)}`
 		: `invocation_id=${encodeURIComponent(opts.invocationId ?? '')}`;

--- a/webapp/src/lib/audit/provenance.test.ts
+++ b/webapp/src/lib/audit/provenance.test.ts
@@ -1,162 +1,138 @@
 import { describe, it, expect } from 'vitest';
-import { assembleProvenance, type ResolveByHash } from './provenance';
-import type { AuditEvent } from '$lib/api';
+import { mapTraceResponse } from './provenance';
+import type { AuditEvent, AuditTraceNode, AuditTraceResponse } from '$lib/api';
 
-// Fixture builder for a materialized-output audit event. Only the flat
-// `aileron.*` payload keys the walk-back reads are set.
-function output(opts: {
-	hash: string;
-	name?: string;
-	mime?: string;
-	bytes?: number;
-	stepId?: string;
-	kind?: string;
-	transform?: string;
-	command?: string;
-	skill?: string;
-	actor?: string;
-	inputs?: Array<{ binding: string; source?: string; content_hash?: string; query_execution_id?: string }>;
-}): AuditEvent {
-	const payload: Record<string, unknown> = {
-		'aileron.output.name': opts.name ?? 'artifact',
-		'aileron.output.content_hash': opts.hash,
-		'aileron.output.mime': opts.mime ?? 'text/csv',
-		'aileron.output.bytes': opts.bytes ?? 1024,
-		'aileron.step.id': opts.stepId ?? 'step-x',
-		'aileron.step.kind': opts.kind ?? 'action_call'
-	};
-	if (opts.transform) payload['aileron.step.transform'] = opts.transform;
-	if (opts.command) payload['aileron.step.command'] = opts.command;
-	if (opts.skill) payload['aileron.plan.skill'] = opts.skill;
-	if (opts.actor) payload['aileron.actor.identity_label'] = opts.actor;
-	if (opts.inputs) payload['aileron.step.inputs'] = opts.inputs;
+// The provenance render model is now assembled server-side and mapped
+// here (#1930). These tests pin the pure snake→camel projection:
+// `content_hash` → `contentHash`, `root_id` → `rootId`, with every other
+// field (kind, title, subtitle, depth, embedded event, literal, dangling)
+// and every edge passing through verbatim. This is the shape `GraphView`
+// consumes, so the mapping is the whole contract.
+
+function eventFor(hash: string): AuditEvent {
 	return {
-		audit_id: `evt-${opts.hash}`,
+		audit_id: `evt-${hash}`,
 		event_type: 'output.materialized',
 		timestamp: '2026-07-04T00:00:00Z',
-		payload
+		payload: { 'aileron.output.content_hash': hash }
 	};
 }
 
-function mapResolver(events: AuditEvent[]): ResolveByHash {
-	const byHash = new Map<string, AuditEvent>();
-	for (const e of events) {
-		const h = e.payload['aileron.output.content_hash'];
-		if (typeof h === 'string') byHash.set(h, e);
-	}
-	return async (hash) => byHash.get(hash) ?? null;
+function traceResponse(overrides?: Partial<AuditTraceResponse>): AuditTraceResponse {
+	const artifactEvent = eventFor('sha256:root');
+	const nodes: AuditTraceNode[] = [
+		{
+			id: 'artifact:sha256:root',
+			kind: 'artifact',
+			title: 'report.csv',
+			subtitle: 'text/csv · 1 KB',
+			depth: 0,
+			content_hash: 'sha256:root',
+			event: artifactEvent
+		},
+		{
+			id: 'step:artifact:sha256:root',
+			kind: 'step',
+			title: 'Step step-1',
+			depth: 1,
+			event: artifactEvent
+		},
+		{
+			id: 'literal:0',
+			kind: 'literal',
+			title: 'threshold',
+			subtitle: 'inputs.threshold',
+			depth: 2,
+			literal: { binding: 'threshold', source: 'inputs.threshold' }
+		},
+		{
+			id: 'artifact:sha256:missing',
+			kind: 'artifact',
+			title: '(unresolved artifact)',
+			subtitle: 'sha256:missing',
+			depth: 2,
+			content_hash: 'sha256:missing',
+			dangling: true
+		},
+		{
+			id: 'launch',
+			kind: 'launch',
+			title: 'Launch: ingest',
+			depth: 3,
+			event: artifactEvent
+		}
+	];
+	return {
+		root_id: 'artifact:sha256:root',
+		nodes,
+		edges: [
+			{ from: 'artifact:sha256:root', to: 'step:artifact:sha256:root' },
+			{ from: 'step:artifact:sha256:root', to: 'literal:0' },
+			{ from: 'step:artifact:sha256:root', to: 'artifact:sha256:missing' },
+			{ from: 'step:artifact:sha256:root', to: 'launch' }
+		],
+		...overrides
+	};
 }
 
-const kinds = (g: { nodes: Array<{ kind: string }> }) => g.nodes.map((n) => n.kind).sort();
-
-describe('assembleProvenance — linear chain', () => {
-	it('walks artifact → step → upstream artifact → step → launch', async () => {
-		const upstream = output({ hash: 'sha256:up', name: 'raw.json', skill: 'ingest' });
-		const root = output({
-			hash: 'sha256:root',
-			name: 'report.csv',
-			skill: 'ingest',
-			actor: 'analyst',
-			inputs: [{ binding: 'data', source: 'steps.q1.rows', content_hash: 'sha256:up' }]
-		});
-
-		const g = await assembleProvenance(root, mapResolver([upstream, root]));
-
+describe('mapTraceResponse — snake→camel projection', () => {
+	it('maps root_id to rootId', () => {
+		const g = mapTraceResponse(traceResponse());
 		expect(g.rootId).toBe('artifact:sha256:root');
-		// two artifacts, two steps, one launch
-		const artifactNodes = g.nodes.filter((n) => n.kind === 'artifact');
-		expect(artifactNodes.map((n) => n.contentHash)).toEqual(
-			expect.arrayContaining(['sha256:root', 'sha256:up'])
-		);
-		expect(g.nodes.filter((n) => n.kind === 'step')).toHaveLength(2);
-		expect(g.nodes.filter((n) => n.kind === 'launch')).toHaveLength(1);
-
-		// The root artifact's step is wired to the upstream artifact.
-		expect(g.edges).toContainEqual({ from: 'artifact:sha256:root', to: 'step:artifact:sha256:root' });
-		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:root', to: 'artifact:sha256:up' });
-		// terminal launch node hangs off the root step
-		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:root', to: 'launch' });
-		expect(g.nodes.find((n) => n.kind === 'launch')?.title).toContain('ingest');
+		// The mapped rootId resolves to a node in the graph.
+		expect(g.nodes.find((n) => n.id === g.rootId)).toBeTruthy();
 	});
-});
 
-describe('assembleProvenance — branching', () => {
-	it('walks both hashed upstreams of a two-input step', async () => {
-		const a = output({ hash: 'sha256:a', name: 'a.json' });
-		const b = output({ hash: 'sha256:b', name: 'b.json' });
-		const root = output({
-			hash: 'sha256:merged',
-			name: 'merged.csv',
-			kind: 'transform',
-			transform: 'join',
-			inputs: [
-				{ binding: 'left', content_hash: 'sha256:a' },
-				{ binding: 'right', content_hash: 'sha256:b' }
-			]
-		});
-
-		const g = await assembleProvenance(root, mapResolver([a, b, root]));
-
-		const hashes = g.nodes.filter((n) => n.kind === 'artifact').map((n) => n.contentHash);
-		expect(hashes).toEqual(expect.arrayContaining(['sha256:merged', 'sha256:a', 'sha256:b']));
-		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:merged', to: 'artifact:sha256:a' });
-		expect(g.edges).toContainEqual({ from: 'step:artifact:sha256:merged', to: 'artifact:sha256:b' });
+	it('maps an artifact node content_hash to contentHash and drops the snake key', () => {
+		const g = mapTraceResponse(traceResponse());
+		const root = g.nodes.find((n) => n.id === 'artifact:sha256:root')!;
+		expect(root.contentHash).toBe('sha256:root');
+		expect((root as Record<string, unknown>).content_hash).toBeUndefined();
 	});
-});
 
-describe('assembleProvenance — literal input', () => {
-	it('emits a literal node and does not recurse', async () => {
-		const root = output({
-			hash: 'sha256:root',
-			inputs: [{ binding: 'threshold', source: 'inputs.threshold' }]
-		});
-
-		const g = await assembleProvenance(root, mapResolver([root]));
-
-		const literals = g.nodes.filter((n) => n.kind === 'literal');
-		expect(literals).toHaveLength(1);
-		expect(literals[0].literal).toEqual({ binding: 'threshold', source: 'inputs.threshold' });
-		// only the one root artifact — no upstream artifact was fetched
-		expect(g.nodes.filter((n) => n.kind === 'artifact')).toHaveLength(1);
+	it('carries the embedded event through unchanged', () => {
+		const g = mapTraceResponse(traceResponse());
+		const root = g.nodes.find((n) => n.id === 'artifact:sha256:root')!;
+		expect(root.event?.audit_id).toBe('evt-sha256:root');
+		expect(root.event?.payload['aileron.output.content_hash']).toBe('sha256:root');
 	});
-});
 
-describe('assembleProvenance — dangling upstream', () => {
-	it('marks an unresolvable hash and does not throw', async () => {
-		const root = output({
-			hash: 'sha256:root',
-			inputs: [{ binding: 'data', content_hash: 'sha256:missing' }]
-		});
-		// resolver knows only the root, returns null for the upstream
-		const g = await assembleProvenance(root, mapResolver([root]));
+	it('preserves a literal node binding/source', () => {
+		const g = mapTraceResponse(traceResponse());
+		const lit = g.nodes.find((n) => n.kind === 'literal')!;
+		expect(lit.literal).toEqual({ binding: 'threshold', source: 'inputs.threshold' });
+	});
 
+	it('preserves the dangling flag on an unresolved upstream', () => {
+		const g = mapTraceResponse(traceResponse());
 		const dangling = g.nodes.find((n) => n.dangling);
-		expect(dangling).toBeTruthy();
 		expect(dangling?.contentHash).toBe('sha256:missing');
-		expect(g.edges).toContainEqual({
-			from: 'step:artifact:sha256:root',
-			to: 'artifact:sha256:missing'
-		});
+		expect(dangling?.kind).toBe('artifact');
 	});
-});
 
-describe('assembleProvenance — cycle safety', () => {
-	it('terminates when an upstream points back to an already-seen artifact', async () => {
-		// root -> back references root's own hash as an input (degenerate cycle)
-		const root = output({
-			hash: 'sha256:cyc',
-			inputs: [{ binding: 'self', content_hash: 'sha256:cyc' }]
-		});
+	it('passes title, subtitle, depth, and kind through verbatim', () => {
+		const g = mapTraceResponse(traceResponse());
+		const step = g.nodes.find((n) => n.kind === 'step')!;
+		expect(step.title).toBe('Step step-1');
+		expect(step.depth).toBe(1);
+		const launch = g.nodes.find((n) => n.kind === 'launch')!;
+		expect(launch.title).toBe('Launch: ingest');
+	});
 
-		const g = await assembleProvenance(root, mapResolver([root]));
+	it('preserves edges verbatim', () => {
+		const resp = traceResponse();
+		const g = mapTraceResponse(resp);
+		expect(g.edges).toEqual(resp.edges);
+	});
 
-		// Exactly one artifact node for the cyclic hash — never expanded twice.
-		expect(g.nodes.filter((n) => n.contentHash === 'sha256:cyc')).toHaveLength(1);
-		// The self-edge is still recorded so the cycle is visible.
-		expect(g.edges).toContainEqual({
-			from: 'step:artifact:sha256:cyc',
-			to: 'artifact:sha256:cyc'
-		});
-		expect(kinds(g)).toEqual(['artifact', 'launch', 'step']);
+	it('produces the kinds GraphView renders (artifact, step, literal, launch)', () => {
+		const g = mapTraceResponse(traceResponse());
+		const kinds = new Set(g.nodes.map((n) => n.kind));
+		expect(kinds).toEqual(new Set(['artifact', 'step', 'literal', 'launch']));
+	});
+
+	it('maps an empty graph (no nodes/edges) without throwing', () => {
+		const g = mapTraceResponse({ root_id: '', nodes: [], edges: [] });
+		expect(g).toEqual({ rootId: '', nodes: [], edges: [] });
 	});
 });

--- a/webapp/src/lib/audit/provenance.ts
+++ b/webapp/src/lib/audit/provenance.ts
@@ -1,19 +1,21 @@
-// Provenance graph assembly — a pure, DOM-free walk-back that turns a
-// starting materialized-artifact record into a node/edge graph.
+// Provenance render model + a pure map from the server-assembled trace.
 //
-// The walk starts at an `output.materialized` event and follows its
-// `aileron.step.inputs[]` upstream: for each input carrying a
-// `content_hash`, it resolves the record that produced that hash and
-// recurses. It terminates at a literal input (no `content_hash`), at a
-// dangling hash (resolver returns null), and at the top with a launch /
-// actor node derived from the artifact's `aileron.plan.*` / `aileron.actor.*`.
+// The `/audit` graph is assembled server-side by `GET /v1/audit/trace`
+// (#1913): one round-trip returns the whole node/edge DAG that the
+// webapp used to walk client-side. This module keeps the render model
+// (`ProvenanceGraph` / `ProvenanceNode` / `ProvenanceEdge`) the graph
+// components consume and provides `mapTraceResponse`, a pure snake→camel
+// map from the wire shape (`AuditTraceResponse`) into that model.
 //
-// Provenance DAGs are tiny (a handful of nodes), so this is deliberately
-// simple. It is a pure module so it is unit-testable against fixtures
-// (repo testing philosophy: test the contract, not the render).
+// The wire and render models differ only cosmetically: the wire node
+// carries `content_hash` (snake) where the render node carries
+// `contentHash` (camel); `root_id` → `rootId`. Everything else — kinds,
+// titles, subtitles, depth, embedded `event`, `literal`, `dangling`, and
+// edges — passes through unchanged. It is a pure module so it is
+// unit-testable against fixtures (repo testing philosophy: test the
+// contract, not the render).
 
-import type { AuditEvent } from '$lib/api';
-import * as p from './payload';
+import type { AuditEvent, AuditTraceResponse } from '$lib/api';
 
 export type ProvenanceNodeKind = 'artifact' | 'step' | 'literal' | 'launch';
 
@@ -51,160 +53,27 @@ export type ProvenanceGraph = {
 	edges: ProvenanceEdge[];
 };
 
-/** Async resolver: given a content hash, return the materialized-output
- *  event that produced it, or null when unknown. Production passes a
- *  wrapper over `getAuditByContentHash`; tests pass a fixture map. */
-export type ResolveByHash = (hash: string) => Promise<AuditEvent | null>;
-
-const MAX_DEPTH = 32;
-
-function artifactTitle(e: AuditEvent): string {
-	return p.outputName(e) ?? '(unnamed artifact)';
-}
-
-function artifactSubtitle(e: AuditEvent): string {
-	const mime = p.outputMime(e);
-	const size = p.formatBytes(p.outputBytes(e));
-	const hash = p.shortHash(p.outputContentHash(e));
-	return [mime, size, hash].filter((s) => s && s.length > 0).join(' · ');
-}
-
-function stepSubtitle(e: AuditEvent): string {
-	const kind = p.stepKind(e);
-	const detail = p.stepTransform(e) ?? p.stepCommand(e);
-	return [kind, detail].filter((s) => s && s.length > 0).join(' · ');
-}
-
-/** Builds the terminal launch/actor node from the root artifact's
- *  plan/actor provenance. */
-function launchNode(root: AuditEvent, depth: number): ProvenanceNode {
-	const skill = p.planSkill(root);
-	const actor = p.actorIdentityLabel(root);
-	const subtitleParts = [
-		skill ? `skill ${skill}` : undefined,
-		actor ? `by ${actor}` : undefined
-	].filter((s): s is string => !!s);
-	return {
-		id: 'launch',
-		kind: 'launch',
-		title: skill ? `Launch: ${skill}` : 'Launch',
-		subtitle: subtitleParts.join(' · ') || undefined,
-		depth,
-		event: root
-	};
-}
-
-/**
- * Assembles the provenance graph for a starting materialized artifact.
+/** Maps a server-assembled provenance trace into the render model.
  *
- * @param start   the `output.materialized` event to walk back from.
- * @param resolve async resolver from content hash to producing event.
+ * A pure snake→camel projection: the wire node's `content_hash` becomes
+ * `contentHash`, `root_id` becomes `rootId`, and every other field
+ * (`kind`, `title`, `subtitle`, `depth`, `event`, `literal`, `dangling`)
+ * and every edge pass through unchanged. The daemon already performed the
+ * walk-back (steps, literal leaves, upstream artifacts, terminal launch
+ * node, dangling/cycle termination), so there is nothing to traverse here.
  */
-export async function assembleProvenance(
-	start: AuditEvent,
-	resolve: ResolveByHash
-): Promise<ProvenanceGraph> {
-	const nodes: ProvenanceNode[] = [];
-	const edges: ProvenanceEdge[] = [];
-	// Guard against cycles: an artifact is keyed by its content hash, so a
-	// hash we have already expanded is never expanded twice.
-	const seenHashes = new Set<string>();
-	let literalSeq = 0;
-
-	// walk expands one artifact event: emits its step node, its input
-	// nodes/edges, and recurses into hashed upstreams. Returns the id of
-	// the artifact node it created so callers can wire an edge to it.
-	async function walk(event: AuditEvent, depth: number): Promise<string> {
-		const hash = p.outputContentHash(event);
-		const artifactId = hash ? `artifact:${hash}` : `artifact:node${nodes.length}`;
-
-		nodes.push({
-			id: artifactId,
-			kind: 'artifact',
-			title: artifactTitle(event),
-			subtitle: artifactSubtitle(event),
-			depth,
-			event,
-			contentHash: hash
-		});
-
-		if (hash) seenHashes.add(hash);
-
-		// The materializing step node hangs directly off the artifact.
-		const sid = p.stepId(event);
-		const stepNodeId = `step:${artifactId}`;
-		nodes.push({
-			id: stepNodeId,
-			kind: 'step',
-			title: sid ? `Step ${sid}` : 'Step',
-			subtitle: stepSubtitle(event) || undefined,
-			depth: depth + 1,
-			event
-		});
-		edges.push({ from: artifactId, to: stepNodeId });
-
-		if (depth + 2 > MAX_DEPTH) {
-			return artifactId;
-		}
-
-		const inputs = p.stepInputs(event);
-		for (const input of inputs) {
-			if (!input.content_hash) {
-				// Literal input: a terminal leaf, never recursed.
-				const litId = `literal:${literalSeq++}`;
-				nodes.push({
-					id: litId,
-					kind: 'literal',
-					title: input.binding || '(literal)',
-					subtitle: input.source,
-					depth: depth + 2,
-					literal: { binding: input.binding, source: input.source }
-				});
-				edges.push({ from: stepNodeId, to: litId });
-				continue;
-			}
-
-			if (seenHashes.has(input.content_hash)) {
-				// Already expanded upstream (or in-flight): wire the edge to
-				// the existing artifact node and do not recurse (cycle guard).
-				edges.push({ from: stepNodeId, to: `artifact:${input.content_hash}` });
-				continue;
-			}
-			// Reserve the hash before awaiting so a concurrent/cyclic path
-			// cannot re-enter it.
-			seenHashes.add(input.content_hash);
-
-			const upstream = await resolve(input.content_hash);
-			if (!upstream) {
-				// Dangling upstream: mark it and stop, do not throw.
-				const danglingId = `artifact:${input.content_hash}`;
-				nodes.push({
-					id: danglingId,
-					kind: 'artifact',
-					title: '(unresolved artifact)',
-					subtitle: p.shortHash(input.content_hash),
-					depth: depth + 2,
-					contentHash: input.content_hash,
-					dangling: true
-				});
-				edges.push({ from: stepNodeId, to: danglingId });
-				continue;
-			}
-
-			const upstreamId = await walk(upstream, depth + 2);
-			edges.push({ from: stepNodeId, to: upstreamId });
-		}
-
-		return artifactId;
-	}
-
-	const rootId = await walk(start, 0);
-
-	// Terminal launch/actor node, attached below the root artifact's step.
-	const maxDepth = nodes.reduce((m, n) => Math.max(m, n.depth), 0);
-	const launch = launchNode(start, maxDepth + 1);
-	nodes.push(launch);
-	edges.push({ from: `step:${rootId}`, to: launch.id });
-
-	return { rootId, nodes, edges };
+export function mapTraceResponse(resp: AuditTraceResponse): ProvenanceGraph {
+	const nodes: ProvenanceNode[] = resp.nodes.map((n) => ({
+		id: n.id,
+		kind: n.kind,
+		title: n.title,
+		subtitle: n.subtitle,
+		depth: n.depth,
+		event: n.event,
+		contentHash: n.content_hash,
+		literal: n.literal,
+		dangling: n.dangling
+	}));
+	const edges: ProvenanceEdge[] = resp.edges.map((e) => ({ from: e.from, to: e.to }));
+	return { rootId: resp.root_id, nodes, edges };
 }

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -4,12 +4,12 @@
 	import { Button } from '$lib/components/ui/button';
 	import {
 		listRecentMaterialized,
-		getAuditByContentHash,
+		getAuditTrace,
 		getAuditByInvocation,
 		type AuditEvent
 	} from '$lib/api';
 	import {
-		assembleProvenance,
+		mapTraceResponse,
 		type ProvenanceGraph,
 		type ProvenanceNode
 	} from '$lib/audit/provenance';
@@ -42,17 +42,6 @@
 
 	let selectedNode = $state<ProvenanceNode | null>(null);
 
-	// Production resolver: the walk-back asks for the record that produced
-	// a content hash. `content_hash` may match several events (the same
-	// artifact re-materialized); the first is the producing record.
-	async function resolveByHash(hash: string): Promise<AuditEvent | null> {
-		const events = await getAuditByContentHash(hash);
-		const materialized = events.find(
-			(e) => p.outputContentHash(e) === hash
-		);
-		return materialized ?? events[0] ?? null;
-	}
-
 	async function openArtifact(hash: string) {
 		resolving = true;
 		graphError = '';
@@ -63,13 +52,18 @@
 		timelineEvents = [];
 		timelineError = '';
 		try {
-			const startEvent = await resolveByHash(hash);
-			if (!startEvent) {
+			// One round-trip: the daemon assembles the whole provenance graph
+			// (#1913). A 404 (unknown hash) resolves to null — the friendly
+			// empty state, not an error (#1894 contract).
+			const resp = await getAuditTrace({ contentHash: hash });
+			const rootNode = resp?.nodes.find((n) => n.id === resp.root_id);
+			if (!resp || !rootNode) {
 				graphError = `No artifact found for ${hash}.`;
 				return;
 			}
-			root = startEvent;
-			graph = await assembleProvenance(startEvent, resolveByHash);
+			// The root node's embedded event backs the header + timeline id.
+			root = rootNode.event ?? null;
+			graph = mapTraceResponse(resp);
 		} catch (e) {
 			graphError = e instanceof Error ? e.message : String(e);
 		} finally {

--- a/webapp/src/routes/audit/page.test.ts
+++ b/webapp/src/routes/audit/page.test.ts
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 
 vi.mock('$lib/api', () => ({
 	listRecentMaterialized: vi.fn(),
+	getAuditTrace: vi.fn(),
 	getAuditByContentHash: vi.fn(),
 	getAuditByInvocation: vi.fn(),
 	EVENT_OUTPUT_MATERIALIZED: 'output.materialized'
@@ -11,9 +12,12 @@ vi.mock('$lib/api', () => ({
 import Page from './+page.svelte';
 import {
 	listRecentMaterialized,
+	getAuditTrace,
 	getAuditByContentHash,
 	getAuditByInvocation,
-	type AuditEvent
+	type AuditEvent,
+	type AuditTraceNode,
+	type AuditTraceResponse
 } from '$lib/api';
 
 // --- fixtures ---
@@ -51,6 +55,93 @@ function materialized(opts: {
 	};
 }
 
+// Assembles the server-assembled trace response the daemon would return
+// for a root event, mirroring `GET /v1/audit/trace` (#1913): the root
+// artifact, its step, literal-input leaves, recursively-resolved upstream
+// artifacts (from `upstreams`), dangling markers for unresolved hashes,
+// and a terminal launch node. This stands in for the server walk so the
+// page tests exercise the single-round-trip contract against a realistic
+// wire shape.
+function traceFor(root: AuditEvent, upstreams: Record<string, AuditEvent> = {}): AuditTraceResponse {
+	const nodes: AuditTraceNode[] = [];
+	const edges: AuditTraceResponse['edges'] = [];
+	const seen = new Set<string>();
+	let litSeq = 0;
+
+	function walk(event: AuditEvent, depth: number): string {
+		const hash = event.payload['aileron.output.content_hash'] as string | undefined;
+		const artifactId = hash ? `artifact:${hash}` : `artifact:node${nodes.length}`;
+		nodes.push({
+			id: artifactId,
+			kind: 'artifact',
+			title: (event.payload['aileron.output.name'] as string) ?? '(unnamed artifact)',
+			subtitle: 'text/csv',
+			depth,
+			content_hash: hash,
+			event
+		});
+		if (hash) seen.add(hash);
+		const stepId = `step:${artifactId}`;
+		nodes.push({ id: stepId, kind: 'step', title: 'Step step-1', depth: depth + 1, event });
+		edges.push({ from: artifactId, to: stepId });
+
+		const inputs = (event.payload['aileron.step.inputs'] as
+			| Array<{ binding: string; source?: string; content_hash?: string }>
+			| undefined) ?? [];
+		for (const input of inputs) {
+			if (!input.content_hash) {
+				const litId = `literal:${litSeq++}`;
+				nodes.push({
+					id: litId,
+					kind: 'literal',
+					title: input.binding || '(literal)',
+					subtitle: input.source,
+					depth: depth + 2,
+					literal: { binding: input.binding, source: input.source }
+				});
+				edges.push({ from: stepId, to: litId });
+				continue;
+			}
+			if (seen.has(input.content_hash)) {
+				edges.push({ from: stepId, to: `artifact:${input.content_hash}` });
+				continue;
+			}
+			const up = upstreams[input.content_hash];
+			if (!up) {
+				const dId = `artifact:${input.content_hash}`;
+				nodes.push({
+					id: dId,
+					kind: 'artifact',
+					title: '(unresolved artifact)',
+					subtitle: input.content_hash,
+					depth: depth + 2,
+					content_hash: input.content_hash,
+					dangling: true
+				});
+				edges.push({ from: stepId, to: dId });
+				continue;
+			}
+			seen.add(input.content_hash);
+			const upId = walk(up, depth + 2);
+			edges.push({ from: stepId, to: upId });
+		}
+		return artifactId;
+	}
+
+	const rootId = walk(root, 0);
+	const maxDepth = nodes.reduce((m, n) => Math.max(m, n.depth), 0);
+	const skill = root.payload['aileron.plan.skill'] as string | undefined;
+	nodes.push({
+		id: 'launch',
+		kind: 'launch',
+		title: skill ? `Launch: ${skill}` : 'Launch',
+		depth: maxDepth + 1,
+		event: root
+	});
+	edges.push({ from: `step:${rootId}`, to: 'launch' });
+	return { root_id: rootId, nodes, edges };
+}
+
 function setLocationSearch(search: string) {
 	Object.defineProperty(window, 'location', {
 		writable: true,
@@ -60,6 +151,7 @@ function setLocationSearch(search: string) {
 
 beforeEach(() => {
 	vi.mocked(listRecentMaterialized).mockReset();
+	vi.mocked(getAuditTrace).mockReset();
 	vi.mocked(getAuditByContentHash).mockReset();
 	vi.mocked(getAuditByInvocation).mockReset();
 	setLocationSearch('');
@@ -102,7 +194,7 @@ describe('Audit page — landing', () => {
 });
 
 describe('Audit page — deep link (#1894 affordance)', () => {
-	it('resolves and renders the artifact graph on load, skipping the landing', async () => {
+	it('resolves and renders the artifact graph on load in a single trace call, skipping the landing', async () => {
 		setLocationSearch('?content_hash=sha256:root');
 		const root = materialized({
 			hash: 'sha256:root',
@@ -111,7 +203,7 @@ describe('Audit page — deep link (#1894 affordance)', () => {
 			signedBy: 'sha256:key',
 			sigStatus: 'verified'
 		});
-		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
 
 		render(Page);
 
@@ -121,14 +213,19 @@ describe('Audit page — deep link (#1894 affordance)', () => {
 		// The landing must not render.
 		expect(screen.queryByTestId('artifact-lookup')).not.toBeInTheDocument();
 		expect(vi.mocked(listRecentMaterialized)).not.toHaveBeenCalled();
-		// Header shows the verified signature badge and skill.
+		// Exactly one round-trip, rooted at the deep-linked hash — no N+1
+		// per-input fan-out (the old getAuditByContentHash walk is gone).
+		expect(vi.mocked(getAuditTrace)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(getAuditTrace)).toHaveBeenCalledWith({ contentHash: 'sha256:root' });
+		expect(vi.mocked(getAuditByContentHash)).not.toHaveBeenCalled();
+		// Header shows the verified signature badge and skill from the root event.
 		expect(screen.getByTestId('header-signature-badge')).toHaveTextContent(/verified/i);
 		expect(screen.getByTestId('header-skill')).toHaveTextContent('pipeline');
 	});
 
-	it('shows a friendly message when the deep-linked hash resolves to nothing', async () => {
+	it('shows a friendly message when the trace resolves to null (unknown hash 404)', async () => {
 		setLocationSearch('?content_hash=sha256:missing');
-		vi.mocked(getAuditByContentHash).mockResolvedValue([]);
+		vi.mocked(getAuditTrace).mockResolvedValue(null);
 
 		render(Page);
 
@@ -139,7 +236,7 @@ describe('Audit page — deep link (#1894 affordance)', () => {
 });
 
 describe('Audit page — graph + side panel', () => {
-	it('renders node cards for a linked fixture and opens the side panel on click', async () => {
+	it('renders node cards for a linked fixture in one trace call and opens the side panel on click', async () => {
 		vi.mocked(listRecentMaterialized).mockResolvedValue([
 			materialized({ hash: 'sha256:root', name: 'joined.csv' })
 		]);
@@ -150,11 +247,7 @@ describe('Audit page — graph + side panel', () => {
 			skill: 'etl',
 			inputs: [{ binding: 'data', source: 'steps.q.rows', content_hash: 'sha256:up' }]
 		});
-		vi.mocked(getAuditByContentHash).mockImplementation(async (h: string) => {
-			if (h === 'sha256:root') return [root];
-			if (h === 'sha256:up') return [upstream];
-			return [];
-		});
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root, { 'sha256:up': upstream }));
 
 		render(Page);
 
@@ -164,10 +257,13 @@ describe('Audit page — graph + side panel', () => {
 		await waitFor(() => {
 			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
 		});
-		// Both artifacts appear as node cards.
+		// Both artifacts appear as node cards (parity with the old client walk).
 		await waitFor(() => {
 			expect(screen.getAllByTestId('provenance-node').length).toBeGreaterThanOrEqual(2);
 		});
+		// A single trace round-trip served the whole graph — no per-hash fan-out.
+		expect(vi.mocked(getAuditTrace)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(getAuditByContentHash)).not.toHaveBeenCalled();
 
 		// Clicking a node opens the side panel with full fields.
 		const nodeButtons = screen.getAllByRole('button', { name: /open details/i });
@@ -176,20 +272,55 @@ describe('Audit page — graph + side panel', () => {
 			expect(screen.getByTestId('side-panel-title')).toBeInTheDocument();
 		});
 	});
+
+	it('renders a dangling upstream node rather than dropping it', async () => {
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'out.csv',
+			inputs: [{ binding: 'data', content_hash: 'sha256:missing' }]
+		});
+		// No upstream provided for sha256:missing → server marks it dangling.
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+		// The dangling node card is present and shows the unresolved-upstream cue.
+		const dangling = await waitFor(() => {
+			const nodes = screen.getAllByTestId('provenance-node');
+			const node = nodes.find((n) => n.textContent?.includes('unresolved artifact'));
+			expect(node).toBeTruthy();
+			return node!;
+		});
+		expect(dangling).toHaveTextContent(/unresolved upstream/i);
+	});
 });
 
 describe('Audit page — timeline toggle', () => {
-	it('switches to timeline and fetches by invocation id in time order', async () => {
+	it('switches to timeline and fetches by invocation id (flat, time order) — not the trace endpoint', async () => {
 		setLocationSearch('?content_hash=sha256:root');
 		const root = materialized({
 			hash: 'sha256:root',
 			name: 'final.csv',
 			invocation: 'inv-9'
 		});
-		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
 		vi.mocked(getAuditByInvocation).mockResolvedValue([
-			materialized({ hash: 'sha256:root', name: 'final.csv', invocation: 'inv-9', timestamp: '2026-07-04T00:00:02Z' }),
-			materialized({ hash: 'sha256:up', name: 'raw.json', invocation: 'inv-9', timestamp: '2026-07-04T00:00:01Z' })
+			materialized({
+				hash: 'sha256:root',
+				name: 'final.csv',
+				invocation: 'inv-9',
+				timestamp: '2026-07-04T00:00:02Z'
+			}),
+			materialized({
+				hash: 'sha256:up',
+				name: 'raw.json',
+				invocation: 'inv-9',
+				timestamp: '2026-07-04T00:00:01Z'
+			})
 		]);
 
 		render(Page);
@@ -215,7 +346,7 @@ describe('Audit page — collapse behavior for large literal input', () => {
 			name: 'out.csv',
 			inputs: [{ binding: 'blob', source: bigValue }]
 		});
-		vi.mocked(getAuditByContentHash).mockResolvedValue([root]);
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
 
 		render(Page);
 


### PR DESCRIPTION
## Summary

The `/audit` provenance view assembled its walk-back graph client-side, doing an N+1 fan-out over each input's `content_hash`. This retargets the **graph** to the already-shipped server endpoint `GET /v1/audit/trace` (#1913): one round-trip returns the whole node/edge DAG, and the CLI walk-back and the webapp now render the identical graph. The **timeline** toggle is unchanged — it stays a flat, time-ordered list via `getAuditByInvocation` (`GET /v1/audit?invocation_id=`). No API/spec change (the endpoint already exists); no Go changes.

### What changed
- **`webapp/src/lib/api.ts`** — add `getAuditTrace({ contentHash?, invocationId? })` plus the `AuditTraceResponse` / `AuditTraceNode` / `AuditTraceEdge` types (a snake_case mirror of the render model). Add an additive `allow404` option to `apiFetch` so a 404 (unknown hash) resolves to `null` instead of throwing, preserving the #1894 empty-state contract while keeping the handshake + 423 vault-lock retry centralized. `getAuditByContentHash` / `getAuditByInvocation` / `listRecentMaterialized` are unchanged.
- **`webapp/src/lib/audit/provenance.ts`** — keep the render types (`ProvenanceGraph` / `ProvenanceNode` / `ProvenanceEdge`) exactly, so `GraphView` / `NodeCard` / `RecordSidePanel` imports are untouched. Delete the client walk (`assembleProvenance`, `ResolveByHash`, `MAX_DEPTH`, and the private title/subtitle helpers) and add the pure `mapTraceResponse(resp)` snake→camel projection (`content_hash`→`contentHash`, `root_id`→`rootId`; everything else passes through).
- **`webapp/src/routes/audit/+page.svelte`** — `openArtifact` now issues one `getAuditTrace({ contentHash })`, derives `root` from the root node's embedded `event`, and maps the response into `graph`. A `null` response (404) renders the existing "No artifact found" empty state. Timeline logic untouched.

### Scope boundary
Only the graph walk-back moves server-side. The timeline is deliberately left on the flat `invocation_id` list (the trace endpoint's `invocation_id` rooting returns a graph, the wrong shape for a time-ordered list). `internal/**` and the gitignored `internal/app/webapp_dist/**` are out of scope.

## Test plan
- `task test:webapp` — green (135 tests). New coverage:
  - `api.test.ts`: `getAuditTrace` encodes `content_hash`, applies `content_hash` precedence when both are supplied, roots on `invocation_id` when only that is given, unwraps a 200 into `{root_id,nodes,edges}`, resolves to `null` on 404, and still throws on a non-404 error.
  - `provenance.test.ts`: rewritten from `assembleProvenance` fixtures to `mapTraceResponse` — `content_hash`→`contentHash`, `literal`/`dangling`/`event` survive, edges verbatim, `rootId` equals `root_id`, all four kinds present.
  - `page.test.ts`: single trace call with zero `getAuditByContentHash` fan-out on select and deep-link; graph parity (artifact + step + upstream + launch); dangling upstream renders (`unresolved upstream`); deep-link shows the verified signature badge + skill from the root event; unknown-hash `null` shows the `graph-error` empty state; timeline toggle still calls `getAuditByInvocation`; large-literal collapse still passes.
- `task lint:webapp` — 0 errors / 0 warnings (svelte-check).
- `task build:webapp` — succeeds (embedded dist is gitignored, not committed).

Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
