### PR TITLE
feat(webapp): chain-of-custody overlay on the /audit provenance graph

### DIFF
--- a/webapp/src/lib/audit/payload.test.ts
+++ b/webapp/src/lib/audit/payload.test.ts
@@ -1,6 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { shortHash, formatBytes, stepInputs } from './payload';
+import {
+	shortHash,
+	formatBytes,
+	stepInputs,
+	signatureVerified,
+	SIGNATURE_STATUS_VERIFIED
+} from './payload';
 import type { AuditEvent } from '$lib/api';
+
+function eventWith(payload: Record<string, unknown>): AuditEvent {
+	return { audit_id: 'x', event_type: 'output.materialized', timestamp: 't', payload };
+}
+
+describe('signatureVerified', () => {
+	it('mirrors the daemon constant', () => {
+		expect(SIGNATURE_STATUS_VERIFIED).toBe('verified');
+	});
+	it('is true only when the plan signature status is "verified"', () => {
+		expect(signatureVerified(eventWith({ 'aileron.plan.signature_status': 'verified' }))).toBe(true);
+	});
+	it('is false for a non-verified status', () => {
+		expect(signatureVerified(eventWith({ 'aileron.plan.signature_status': 'unverified' }))).toBe(
+			false
+		);
+		expect(signatureVerified(eventWith({ 'aileron.plan.signature_status': 'failed' }))).toBe(false);
+	});
+	it('is false when the status is missing or empty', () => {
+		expect(signatureVerified(eventWith({}))).toBe(false);
+		expect(signatureVerified(eventWith({ 'aileron.plan.signature_status': '' }))).toBe(false);
+	});
+});
 
 describe('shortHash', () => {
 	it('abbreviates a sha256 hash keeping the algorithm prefix', () => {

--- a/webapp/src/lib/audit/payload.ts
+++ b/webapp/src/lib/audit/payload.ts
@@ -94,6 +94,20 @@ export function planContentHash(e: AuditEvent): string | undefined {
 	return str(e.payload, 'aileron.plan.content_hash');
 }
 
+/** The single `aileron.plan.signature_status` value the daemon writes for a
+ *  plan whose signature actually verified. Mirrors the daemon constant
+ *  `signatureStatusVerified` (internal/flightplan/runtime/audit.go) verbatim,
+ *  so the webapp's notion of "verified" cannot drift from the runtime's. */
+export const SIGNATURE_STATUS_VERIFIED = 'verified';
+
+/** True only when an event's plan signature verified. This is the one
+ *  truthiness test for "verified" on the client; the header, node cards, and
+ *  chain rollup all route through it rather than inlining a string compare, so
+ *  there is a single source of truth mirroring the daemon. */
+export function signatureVerified(e: AuditEvent): boolean {
+	return planSignatureStatus(e) === SIGNATURE_STATUS_VERIFIED;
+}
+
 /** Actor identity label: prefers the normalized `actor.identity_label`,
  *  falling back to the flat payload key. */
 export function actorIdentityLabel(e: AuditEvent): string | undefined {

--- a/webapp/src/lib/audit/trust.test.ts
+++ b/webapp/src/lib/audit/trust.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { nodeTrust, chainTrustSummary, isTrustBearing } from './trust';
+import type { AuditEvent } from '$lib/api';
+import type { ProvenanceGraph, ProvenanceNode } from './provenance';
+
+// Fixtures mirror the `ProvenanceGraph` render shape (see provenance.test.ts).
+// A trust-bearing node (step/launch) carries an embedded event whose payload
+// holds the signature status and signer; artifact/literal nodes do not.
+
+function event(opts: { sigStatus?: string; signedBy?: string; skill?: string }): AuditEvent {
+	const payload: Record<string, unknown> = {};
+	if (opts.sigStatus) payload['aileron.plan.signature_status'] = opts.sigStatus;
+	if (opts.signedBy) payload['aileron.plan.signed_by'] = opts.signedBy;
+	if (opts.skill) payload['aileron.plan.skill'] = opts.skill;
+	return { audit_id: 'evt', event_type: 'output.materialized', timestamp: 't', payload };
+}
+
+function step(id: string, opts: Parameters<typeof event>[0]): ProvenanceNode {
+	return { id, kind: 'step', title: id, depth: 1, event: event(opts) };
+}
+
+function graphOf(nodes: ProvenanceNode[]): ProvenanceGraph {
+	return { rootId: nodes[0]?.id ?? '', nodes, edges: [] };
+}
+
+describe('nodeTrust', () => {
+	it('classifies a verified step as verified', () => {
+		expect(nodeTrust(step('s1', { sigStatus: 'verified', signedBy: 'sha256:k' }))).toBe('verified');
+	});
+	it('classifies a launch node with a verified event as verified', () => {
+		const launch: ProvenanceNode = {
+			id: 'launch',
+			kind: 'launch',
+			title: 'Launch',
+			depth: 3,
+			event: event({ sigStatus: 'verified' })
+		};
+		expect(nodeTrust(launch)).toBe('verified');
+	});
+	it('classifies a trust-bearing node with an unverified signature as unverified', () => {
+		expect(nodeTrust(step('s1', { sigStatus: 'unverified' }))).toBe('unverified');
+		expect(nodeTrust(step('s2', {}))).toBe('unverified');
+	});
+	it('classifies a dangling node as a gap regardless of kind', () => {
+		const dangling: ProvenanceNode = {
+			id: 'artifact:missing',
+			kind: 'artifact',
+			title: '(unresolved artifact)',
+			depth: 2,
+			dangling: true
+		};
+		expect(nodeTrust(dangling)).toBe('gap');
+		// Even a step marked dangling reads as a gap first.
+		const danglingStep: ProvenanceNode = { ...step('s', { sigStatus: 'verified' }), dangling: true };
+		expect(nodeTrust(danglingStep)).toBe('gap');
+	});
+	it('classifies literal and non-dangling artifact nodes as none', () => {
+		const literal: ProvenanceNode = {
+			id: 'literal:0',
+			kind: 'literal',
+			title: 'threshold',
+			depth: 2,
+			literal: { binding: 'threshold' }
+		};
+		const artifact: ProvenanceNode = {
+			id: 'artifact:root',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			event: event({ sigStatus: 'verified' })
+		};
+		expect(nodeTrust(literal)).toBe('none');
+		expect(nodeTrust(artifact)).toBe('none');
+	});
+});
+
+describe('isTrustBearing', () => {
+	it('is true for step/launch nodes with an event', () => {
+		expect(isTrustBearing(step('s', { sigStatus: 'verified' }))).toBe(true);
+	});
+	it('is false for a step without an event', () => {
+		expect(isTrustBearing({ id: 's', kind: 'step', title: 's', depth: 1 })).toBe(false);
+	});
+	it('is false for artifact and literal kinds', () => {
+		expect(isTrustBearing({ id: 'a', kind: 'artifact', title: 'a', depth: 0 })).toBe(false);
+	});
+});
+
+describe('chainTrustSummary', () => {
+	it('reports a fully verified chain with zero counts', () => {
+		const g = graphOf([
+			step('s1', { sigStatus: 'verified', signedBy: 'sha256:k' }),
+			step('s2', { sigStatus: 'verified', signedBy: 'sha256:k' })
+		]);
+		const s = chainTrustSummary(g);
+		expect(s.fullyVerified).toBe(true);
+		expect(s.unverifiedCount).toBe(0);
+		expect(s.gapCount).toBe(0);
+		expect(s.trustBearingCount).toBe(2);
+		expect(s.label).toBe('Chain verified');
+	});
+
+	it('counts a dangling upstream as a gap and is not fully verified', () => {
+		const g = graphOf([
+			step('s1', { sigStatus: 'verified', signedBy: 'sha256:k' }),
+			{ id: 'artifact:missing', kind: 'artifact', title: '(unresolved)', depth: 2, dangling: true }
+		]);
+		const s = chainTrustSummary(g);
+		expect(s.gapCount).toBe(1);
+		expect(s.fullyVerified).toBe(false);
+		expect(s.label).toContain('1 provenance gap');
+	});
+
+	it('counts an unverified step and renders the "N of M steps unverified" label', () => {
+		const g = graphOf([
+			step('s1', { sigStatus: 'verified', signedBy: 'sha256:k' }),
+			step('s2', { sigStatus: 'unverified' }),
+			step('s3', { sigStatus: 'verified', signedBy: 'sha256:k' })
+		]);
+		const s = chainTrustSummary(g);
+		expect(s.unverifiedCount).toBe(1);
+		expect(s.trustBearingCount).toBe(3);
+		expect(s.fullyVerified).toBe(false);
+		expect(s.label).toBe('1 of 3 steps unverified');
+	});
+
+	it('combines the unverified and gap counts in the label', () => {
+		const g = graphOf([
+			step('s1', { sigStatus: 'unverified' }),
+			step('s2', { sigStatus: 'verified', signedBy: 'sha256:k' }),
+			{ id: 'artifact:missing', kind: 'artifact', title: '(unresolved)', depth: 2, dangling: true }
+		]);
+		const s = chainTrustSummary(g);
+		expect(s.label).toBe('1 of 2 steps unverified · 1 provenance gap');
+	});
+
+	it('de-duplicates signers across trust-bearing nodes in first-seen order', () => {
+		const g = graphOf([
+			step('s1', { sigStatus: 'verified', signedBy: 'sha256:alice' }),
+			step('s2', { sigStatus: 'verified', signedBy: 'sha256:bob' }),
+			step('s3', { sigStatus: 'verified', signedBy: 'sha256:alice' })
+		]);
+		expect(chainTrustSummary(g).signers).toEqual(['sha256:alice', 'sha256:bob']);
+	});
+
+	it('reports not-fully-verified with no attestation when there are no trust-bearing nodes', () => {
+		const g = graphOf([
+			{ id: 'artifact:root', kind: 'artifact', title: 'report.csv', depth: 0 },
+			{ id: 'literal:0', kind: 'literal', title: 'threshold', depth: 1 }
+		]);
+		const s = chainTrustSummary(g);
+		expect(s.fullyVerified).toBe(false);
+		expect(s.trustBearingCount).toBe(0);
+		expect(s.label).toBe('No signed steps recorded');
+	});
+});

--- a/webapp/src/lib/audit/trust.ts
+++ b/webapp/src/lib/audit/trust.ts
@@ -1,0 +1,125 @@
+// Chain-of-custody trust classification over a provenance graph.
+//
+// The `/audit` graph already carries every trust field per node (each
+// trust-bearing node embeds an `AuditEvent` whose payload holds the plan
+// skill, signer fingerprint, signature status, and acting identity — see
+// payload.ts). This module is the pure, fixture-tested layer that turns those
+// per-node fields into the two things the render surface needs:
+//
+//   - `nodeTrust(node)` — a per-node classification the card chrome keys off.
+//   - `chainTrustSummary(graph)` — the whole-graph rollup the header renders
+//     ("2 of 5 steps unverified" / "Chain verified", the de-duplicated signer
+//     set, and a single `fullyVerified` flag).
+//
+// It imports nothing from Svelte so the counting logic is unit-testable
+// against graph fixtures without rendering (repo testing philosophy: test the
+// contract, not the render). "Verified" is not redefined here; it routes
+// through `signatureVerified` in payload.ts, which mirrors the daemon.
+
+import type { ProvenanceGraph, ProvenanceNode } from './provenance';
+import { signatureVerified, planSignedBy } from './payload';
+
+/** Per-node chain-of-custody classification.
+ *
+ *  - `verified`   — a trust-bearing node (`step`/`launch`) whose backing
+ *                   event's plan signature verified.
+ *  - `unverified` — a trust-bearing node with a backing event whose plan
+ *                   signature did not verify (unsigned, failed, or unknown).
+ *  - `gap`        — a node whose upstream producer could not be resolved
+ *                   (a `dangling` provenance gap). Takes precedence: a gap is
+ *                   a hole in the chain regardless of kind.
+ *  - `none`       — a node that carries no trust chrome (`literal` inputs and
+ *                   artifact nodes that are neither dangling nor trust-bearing).
+ */
+export type NodeTrust = 'verified' | 'unverified' | 'gap' | 'none';
+
+/** Kinds whose embedded event carries plan/actor provenance. Artifact nodes
+ *  surface a gap marker when dangling but otherwise carry no signature chrome;
+ *  literal nodes never do. */
+const TRUST_BEARING_KINDS: ReadonlySet<ProvenanceNode['kind']> = new Set(['step', 'launch']);
+
+export function isTrustBearing(node: ProvenanceNode): boolean {
+	return TRUST_BEARING_KINDS.has(node.kind) && node.event !== undefined;
+}
+
+export function nodeTrust(node: ProvenanceNode): NodeTrust {
+	// A dangling node is a provenance gap first, whatever its kind.
+	if (node.dangling) return 'gap';
+	if (isTrustBearing(node) && node.event) {
+		return signatureVerified(node.event) ? 'verified' : 'unverified';
+	}
+	return 'none';
+}
+
+/** Whole-graph chain-of-custody rollup for the header.
+ *
+ *  - `signers`           — de-duplicated, non-empty signer fingerprints across
+ *                          trust-bearing nodes, in first-seen order.
+ *  - `trustBearingCount` — number of `step`/`launch` nodes with a backing event.
+ *  - `unverifiedCount`   — trust-bearing nodes whose signature did not verify.
+ *  - `gapCount`          — dangling nodes (unresolved upstream producers).
+ *  - `fullyVerified`     — at least one trust-bearing node and no unverified
+ *                          nodes and no gaps.
+ *  - `label`             — human summary: "Chain verified" when clean,
+ *                          otherwise the gap/unverified breakdown, e.g.
+ *                          "2 of 5 steps unverified" or
+ *                          "1 of 3 steps unverified · 1 provenance gap".
+ */
+export type ChainTrustSummary = {
+	signers: string[];
+	fullyVerified: boolean;
+	trustBearingCount: number;
+	unverifiedCount: number;
+	gapCount: number;
+	label: string;
+};
+
+export function chainTrustSummary(graph: ProvenanceGraph): ChainTrustSummary {
+	const signers: string[] = [];
+	const seenSigners = new Set<string>();
+	let trustBearingCount = 0;
+	let unverifiedCount = 0;
+	let gapCount = 0;
+
+	for (const node of graph.nodes) {
+		if (node.dangling) gapCount++;
+		if (!isTrustBearing(node) || !node.event) continue;
+		trustBearingCount++;
+		if (!signatureVerified(node.event)) unverifiedCount++;
+		const signer = planSignedBy(node.event);
+		if (signer && !seenSigners.has(signer)) {
+			seenSigners.add(signer);
+			signers.push(signer);
+		}
+	}
+
+	const fullyVerified = trustBearingCount > 0 && unverifiedCount === 0 && gapCount === 0;
+
+	return {
+		signers,
+		fullyVerified,
+		trustBearingCount,
+		unverifiedCount,
+		gapCount,
+		label: summaryLabel({ trustBearingCount, unverifiedCount, gapCount, fullyVerified })
+	};
+}
+
+function summaryLabel(s: {
+	trustBearingCount: number;
+	unverifiedCount: number;
+	gapCount: number;
+	fullyVerified: boolean;
+}): string {
+	if (s.fullyVerified) return 'Chain verified';
+	const parts: string[] = [];
+	if (s.unverifiedCount > 0) {
+		parts.push(`${s.unverifiedCount} of ${s.trustBearingCount} steps unverified`);
+	}
+	if (s.gapCount > 0) {
+		parts.push(`${s.gapCount} provenance ${s.gapCount === 1 ? 'gap' : 'gaps'}`);
+	}
+	// No trust-bearing nodes at all and no gaps: nothing to attest.
+	if (parts.length === 0) return 'No signed steps recorded';
+	return parts.join(' · ');
+}

--- a/webapp/src/lib/components/audit/NodeCard.svelte
+++ b/webapp/src/lib/components/audit/NodeCard.svelte
@@ -2,10 +2,14 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import type { ProvenanceNode } from '$lib/audit/provenance';
+	import * as p from '$lib/audit/payload';
 
-	// One node in the provenance DAG. Cards are one-line summaries only:
-	// title + subtitle. Full record fields live in the side panel, opened
-	// by clicking the card (progressive disclosure — #1891 key decision 2).
+	// One node in the provenance DAG. Cards are one-line summaries plus a
+	// terse chain-of-custody strip (signature badge, signer, acting identity)
+	// for trust-bearing nodes; full record fields live in the side panel,
+	// opened by clicking the card (progressive disclosure — #1891 key
+	// decision 2). Dangling nodes surface a first-class "provenance gap"
+	// affordance distinct from an unverified-signature warning.
 	let { node, onselect }: { node: ProvenanceNode; onselect: (n: ProvenanceNode) => void } =
 		$props();
 
@@ -22,15 +26,29 @@
 		literal: 'outline',
 		launch: 'outline'
 	};
+
+	// Trust chrome renders only on the trust-bearing nodes (step/launch),
+	// whose embedded event carries plan/actor provenance.
+	const trustBearing = $derived(
+		node.event !== undefined && (node.kind === 'step' || node.kind === 'launch')
+	);
+	const verified = $derived(node.event ? p.signatureVerified(node.event) : false);
+	const sigStatus = $derived(node.event ? p.planSignatureStatus(node.event) : undefined);
+	const signer = $derived(node.event ? p.planSignedBy(node.event) : undefined);
+	const identity = $derived(node.event ? p.actorIdentityLabel(node.event) : undefined);
+	const consent = $derived(node.event ? p.consentDecision(node.event) : undefined);
 </script>
 
 <Card.Root
 	data-testid="provenance-node"
 	data-node-kind={node.kind}
 	data-node-id={node.id}
+	data-node-trust={node.dangling ? 'gap' : trustBearing ? (verified ? 'verified' : 'unverified') : 'none'}
 	class="w-64 cursor-pointer transition-colors hover:border-primary {node.dangling
 		? 'border-destructive/60'
-		: ''}"
+		: trustBearing && !verified
+			? 'border-destructive/40'
+			: ''}"
 >
 	<button
 		type="button"
@@ -44,15 +62,42 @@
 				<Badge variant={kindVariant[node.kind]}>{kindLabel[node.kind]}</Badge>
 			</div>
 		</Card.Header>
-		{#if node.subtitle}
-			<Card.Content>
+		<Card.Content>
+			{#if node.subtitle}
 				<p class="truncate text-xs text-muted-foreground" title={node.subtitle}>
 					{node.subtitle}
 				</p>
-				{#if node.dangling}
-					<p class="mt-1 text-xs text-destructive">unresolved upstream</p>
-				{/if}
-			</Card.Content>
-		{/if}
+			{/if}
+
+			{#if node.dangling}
+				<p class="mt-1 text-xs font-medium text-destructive" data-testid="node-provenance-gap">
+					Provenance gap — unresolved upstream
+				</p>
+			{:else if trustBearing}
+				<div class="mt-2 flex flex-col gap-1">
+					{#if verified}
+						<Badge variant="default" data-testid="node-signature-badge">Signature verified</Badge>
+					{:else}
+						<Badge variant="destructive" data-testid="node-unverified-warning">
+							{sigStatus ? `Signature ${sigStatus}` : 'Unsigned'}
+						</Badge>
+					{/if}
+					{#if signer}
+						<p
+							class="truncate font-mono text-xs text-muted-foreground"
+							title={signer}
+							data-testid="node-signer"
+						>
+							{p.shortHash(signer)}
+						</p>
+					{/if}
+					{#if identity}
+						<p class="truncate text-xs text-muted-foreground" title={identity} data-testid="node-identity">
+							{identity}{#if consent}<span class="text-muted-foreground/70"> · consent {consent}</span>{/if}
+						</p>
+					{/if}
+				</div>
+			{/if}
+		</Card.Content>
 	</button>
 </Card.Root>

--- a/webapp/src/lib/components/audit/NodeCard.test.ts
+++ b/webapp/src/lib/components/audit/NodeCard.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import NodeCard from './NodeCard.svelte';
+import type { AuditEvent } from '$lib/api';
+import type { ProvenanceNode } from '$lib/audit/provenance';
+
+function event(payload: Record<string, unknown>): AuditEvent {
+	return { audit_id: 'evt', event_type: 'output.materialized', timestamp: 't', payload };
+}
+
+const noop = () => {};
+
+describe('NodeCard — per-node trust chrome', () => {
+	it('renders a verified badge, signer, and identity for a verified step', () => {
+		const node: ProvenanceNode = {
+			id: 's1',
+			kind: 'step',
+			title: 'Step step-1',
+			depth: 1,
+			event: event({
+				'aileron.plan.signature_status': 'verified',
+				'aileron.plan.signed_by': 'sha256:0123456789abcdef0123456789abcdef',
+				'aileron.actor.identity_label': 'analyst@corp'
+			})
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.getByTestId('node-signature-badge')).toHaveTextContent(/verified/i);
+		expect(screen.getByTestId('node-signer')).toBeInTheDocument();
+		expect(screen.getByTestId('node-identity')).toHaveTextContent('analyst@corp');
+		expect(screen.queryByTestId('node-unverified-warning')).not.toBeInTheDocument();
+	});
+
+	it('renders the acting identity with its consent decision', () => {
+		const node: ProvenanceNode = {
+			id: 'launch',
+			kind: 'launch',
+			title: 'Launch: ingest',
+			depth: 3,
+			event: event({
+				'aileron.plan.signature_status': 'verified',
+				'aileron.actor.identity_label': 'svc-bot',
+				'aileron.consent.decision': 'granted'
+			})
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.getByTestId('node-identity')).toHaveTextContent(/svc-bot/);
+		expect(screen.getByTestId('node-identity')).toHaveTextContent(/consent granted/);
+	});
+
+	it('renders the unverified warning and no verified badge for an unverified step', () => {
+		const node: ProvenanceNode = {
+			id: 's2',
+			kind: 'step',
+			title: 'Step step-2',
+			depth: 1,
+			event: event({ 'aileron.plan.signature_status': 'failed' })
+		};
+		render(NodeCard, { node, onselect: noop });
+		const warning = screen.getByTestId('node-unverified-warning');
+		expect(warning).toHaveTextContent(/failed/i);
+		expect(screen.queryByTestId('node-signature-badge')).not.toBeInTheDocument();
+	});
+
+	it('labels an unverified step with no status as "Unsigned"', () => {
+		const node: ProvenanceNode = {
+			id: 's3',
+			kind: 'step',
+			title: 'Step step-3',
+			depth: 1,
+			event: event({})
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.getByTestId('node-unverified-warning')).toHaveTextContent(/unsigned/i);
+	});
+
+	it('renders a provenance-gap affordance for a dangling artifact and no signature chrome', () => {
+		const node: ProvenanceNode = {
+			id: 'artifact:missing',
+			kind: 'artifact',
+			title: '(unresolved artifact)',
+			subtitle: 'sha256:missing',
+			depth: 2,
+			dangling: true
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.getByTestId('node-provenance-gap')).toBeInTheDocument();
+		expect(screen.queryByTestId('node-signature-badge')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('node-unverified-warning')).not.toBeInTheDocument();
+	});
+
+	it('renders no trust chrome for a literal node', () => {
+		const node: ProvenanceNode = {
+			id: 'literal:0',
+			kind: 'literal',
+			title: 'threshold',
+			depth: 2,
+			literal: { binding: 'threshold', source: 'inputs.threshold' }
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.queryByTestId('node-signature-badge')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('node-unverified-warning')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('node-signer')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('node-provenance-gap')).not.toBeInTheDocument();
+	});
+
+	it('renders no trust chrome for a non-dangling artifact node', () => {
+		const node: ProvenanceNode = {
+			id: 'artifact:root',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			event: event({ 'aileron.plan.signature_status': 'verified' })
+		};
+		render(NodeCard, { node, onselect: noop });
+		expect(screen.queryByTestId('node-signature-badge')).not.toBeInTheDocument();
+	});
+
+	it('calls onselect when the card is clicked', async () => {
+		const onselect = vi.fn();
+		const node: ProvenanceNode = {
+			id: 's1',
+			kind: 'step',
+			title: 'Step step-1',
+			depth: 1,
+			event: event({ 'aileron.plan.signature_status': 'verified' })
+		};
+		render(NodeCard, { node, onselect });
+		await screen.getByRole('button', { name: /open details/i }).click();
+		expect(onselect).toHaveBeenCalledWith(node);
+	});
+});

--- a/webapp/src/lib/components/audit/ProvenanceHeader.svelte
+++ b/webapp/src/lib/components/audit/ProvenanceHeader.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
 	import type { AuditEvent } from '$lib/api';
+	import type { ProvenanceGraph } from '$lib/audit/provenance';
 	import * as p from '$lib/audit/payload';
+	import { chainTrustSummary } from '$lib/audit/trust';
 
-	// Header for a provenance graph: the actor, a verified-signature badge,
-	// the signer fingerprint, and the plan/skill name — all read off the
-	// root artifact record.
-	let { root }: { root: AuditEvent } = $props();
+	// Header for a provenance graph: the actor, the root artifact's
+	// verified-signature badge and skill, and a whole-chain trust rollup
+	// (chain-verified badge + gap/unsigned count + the de-duplicated signer
+	// set) computed across every trust-bearing node in the graph.
+	let { root, graph }: { root: AuditEvent; graph: ProvenanceGraph } = $props();
 
 	const skill = $derived(p.planSkill(root));
 	const actor = $derived(p.actorIdentityLabel(root));
-	const signedBy = $derived(p.planSignedBy(root));
 	const status = $derived(p.planSignatureStatus(root));
-	const verified = $derived(status === 'verified');
+	const verified = $derived(p.signatureVerified(root));
+
+	const summary = $derived(chainTrustSummary(graph));
 </script>
 
 <div class="mb-4 rounded-lg border border-border bg-card p-4" data-testid="provenance-header">
@@ -28,6 +32,12 @@
 				{verified ? 'Signature verified' : `Signature ${status}`}
 			</Badge>
 		{/if}
+		<Badge
+			variant={summary.fullyVerified ? 'default' : 'destructive'}
+			data-testid="header-chain-badge"
+		>
+			{summary.label}
+		</Badge>
 	</div>
 	<dl class="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
 		{#if actor}
@@ -36,10 +46,12 @@
 				<dd data-testid="header-actor">{actor}</dd>
 			</div>
 		{/if}
-		{#if signedBy}
+		{#if summary.signers.length > 0}
 			<div class="flex gap-2">
 				<dt class="font-medium">Signed by</dt>
-				<dd class="break-all font-mono" data-testid="header-signed-by">{signedBy}</dd>
+				<dd class="break-all font-mono" data-testid="header-signed-by">
+					{summary.signers.join(', ')}
+				</dd>
 			</div>
 		{/if}
 	</dl>

--- a/webapp/src/lib/components/audit/ProvenanceHeader.test.ts
+++ b/webapp/src/lib/components/audit/ProvenanceHeader.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ProvenanceHeader from './ProvenanceHeader.svelte';
+import type { AuditEvent } from '$lib/api';
+import type { ProvenanceGraph, ProvenanceNode } from '$lib/audit/provenance';
+
+function event(opts: {
+	skill?: string;
+	actor?: string;
+	sigStatus?: string;
+	signedBy?: string;
+}): AuditEvent {
+	const payload: Record<string, unknown> = {};
+	if (opts.skill) payload['aileron.plan.skill'] = opts.skill;
+	if (opts.actor) payload['aileron.actor.identity_label'] = opts.actor;
+	if (opts.sigStatus) payload['aileron.plan.signature_status'] = opts.sigStatus;
+	if (opts.signedBy) payload['aileron.plan.signed_by'] = opts.signedBy;
+	return { audit_id: 'evt', event_type: 'output.materialized', timestamp: 't', payload };
+}
+
+function step(id: string, e: AuditEvent): ProvenanceNode {
+	return { id, kind: 'step', title: id, depth: 1, event: e };
+}
+
+function graphOf(root: AuditEvent, nodes: ProvenanceNode[]): ProvenanceGraph {
+	return { rootId: 'root', nodes, edges: [] };
+}
+
+describe('ProvenanceHeader — chain-level trust rollup', () => {
+	it('shows a green chain-verified rollup for an all-verified graph', () => {
+		const root = event({ skill: 'pipeline', actor: 'analyst', sigStatus: 'verified', signedBy: 'sha256:k' });
+		const graph = graphOf(root, [step('s1', root), step('s2', root)]);
+		render(ProvenanceHeader, { root, graph });
+		expect(screen.getByTestId('header-skill')).toHaveTextContent('pipeline');
+		expect(screen.getByTestId('header-signature-badge')).toHaveTextContent(/verified/i);
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent('Chain verified');
+	});
+
+	it('surfaces the gap count when an upstream is dangling', () => {
+		const root = event({ skill: 'etl', sigStatus: 'verified', signedBy: 'sha256:k' });
+		const graph = graphOf(root, [
+			step('s1', root),
+			{ id: 'artifact:missing', kind: 'artifact', title: '(unresolved)', depth: 2, dangling: true }
+		]);
+		render(ProvenanceHeader, { root, graph });
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent(/provenance gap/i);
+	});
+
+	it('surfaces the unverified count and a warning chain badge', () => {
+		const root = event({ skill: 'etl', sigStatus: 'unverified' });
+		const graph = graphOf(root, [
+			step('s1', root),
+			step('s2', event({ sigStatus: 'verified', signedBy: 'sha256:k' }))
+		]);
+		render(ProvenanceHeader, { root, graph });
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent('1 of 2 steps unverified');
+		// Root signature status also reflects the unverified root.
+		expect(screen.getByTestId('header-signature-badge')).toHaveTextContent(/unverified/i);
+	});
+
+	it('lists the de-duplicated signer set across the chain', () => {
+		const root = event({ skill: 'etl', sigStatus: 'verified', signedBy: 'sha256:alice' });
+		const graph = graphOf(root, [
+			step('s1', root),
+			step('s2', event({ sigStatus: 'verified', signedBy: 'sha256:bob' })),
+			step('s3', event({ sigStatus: 'verified', signedBy: 'sha256:alice' }))
+		]);
+		render(ProvenanceHeader, { root, graph });
+		const signedBy = screen.getByTestId('header-signed-by');
+		expect(signedBy).toHaveTextContent('sha256:alice');
+		expect(signedBy).toHaveTextContent('sha256:bob');
+	});
+});

--- a/webapp/src/lib/components/audit/RecordSidePanel.svelte
+++ b/webapp/src/lib/components/audit/RecordSidePanel.svelte
@@ -2,6 +2,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import { Badge } from '$lib/components/ui/badge';
+	import type { AuditEvent } from '$lib/api';
 	import type { ProvenanceNode } from '$lib/audit/provenance';
 	import * as p from '$lib/audit/payload';
 
@@ -30,36 +31,56 @@
 
 	type Row = { label: string; value: string; mono?: boolean };
 
-	// Full field rows for an artifact/step node, read from the backing
-	// event's flat payload. Ordered for readability.
+	function rowsFrom(
+		e: AuditEvent,
+		specs: Array<[label: string, v: string | number | undefined, mono?: boolean]>
+	): Row[] {
+		const out: Row[] = [];
+		for (const [label, v, mono = false] of specs) {
+			if (v !== undefined && v !== '') out.push({ label, value: String(v), mono });
+		}
+		return out;
+	}
+
+	// Artifact/step record fields, minus the chain-of-custody group below.
 	const rows = $derived.by((): Row[] => {
 		if (!node?.event) return [];
 		const e = node.event;
-		const out: Row[] = [];
-		const add = (label: string, v: string | number | undefined, mono = false) => {
-			if (v !== undefined && v !== '') out.push({ label, value: String(v), mono });
-		};
-		add('Name', p.outputName(e));
-		add('MIME', p.outputMime(e));
-		add('Content hash', p.outputContentHash(e), true);
-		add('Bytes', p.outputBytes(e));
-		add('Path', p.outputPath(e), true);
-		add('Step id', p.stepId(e));
-		add('Step kind', p.stepKind(e));
-		add('Transform', p.stepTransform(e));
-		add('Command', p.stepCommand(e), true);
-		add('Plan / skill', p.planSkill(e));
-		add('Plan hash', p.planContentHash(e), true);
-		add('Signed by', p.planSignedBy(e), true);
-		add('Signature status', p.planSignatureStatus(e));
-		add('Actor', p.actorIdentityLabel(e));
-		add('Credential binding', p.actorCredentialBinding(e));
-		add('Connector version', p.actorConnectorVersion(e));
-		add('Connector hash', p.actorConnectorHash(e), true);
-		add('Consent', p.consentDecision(e));
-		add('Invocation id', p.invocationId(e), true);
-		return out;
+		return rowsFrom(e, [
+			['Name', p.outputName(e)],
+			['MIME', p.outputMime(e)],
+			['Content hash', p.outputContentHash(e), true],
+			['Bytes', p.outputBytes(e)],
+			['Path', p.outputPath(e), true],
+			['Step id', p.stepId(e)],
+			['Step kind', p.stepKind(e)],
+			['Transform', p.stepTransform(e)],
+			['Command', p.stepCommand(e), true],
+			['Plan / skill', p.planSkill(e)],
+			['Plan hash', p.planContentHash(e), true],
+			['Invocation id', p.invocationId(e), true]
+		]);
 	});
+
+	// The explicit chain-of-custody group: who signed the plan, whether the
+	// signature verified, the acting identity, its credential binding, and the
+	// consent decision. Grouped so the trust story reads as one unit.
+	const custodyRows = $derived.by((): Row[] => {
+		if (!node?.event) return [];
+		const e = node.event;
+		return rowsFrom(e, [
+			['Signed by', p.planSignedBy(e), true],
+			['Signature status', p.planSignatureStatus(e)],
+			['Actor', p.actorIdentityLabel(e)],
+			['Credential binding', p.actorCredentialBinding(e)],
+			['Connector version', p.actorConnectorVersion(e)],
+			['Connector hash', p.actorConnectorHash(e), true],
+			['Consent', p.consentDecision(e)]
+		]);
+	});
+
+	const custodyVerified = $derived(node?.event ? p.signatureVerified(node.event) : false);
+	const showCustody = $derived(!!node?.dangling || custodyRows.length > 0);
 
 	const inputs = $derived(node?.event ? p.stepInputs(node.event) : []);
 </script>
@@ -109,6 +130,37 @@
 							</div>
 						{/each}
 					</dl>
+
+					{#if showCustody}
+						<div class="mt-4 rounded-md border border-border p-3" data-testid="custody-section">
+							<div class="mb-2 flex items-center justify-between gap-2">
+								<h3 class="text-xs font-semibold text-muted-foreground">Chain of custody</h3>
+								{#if custodyRows.length > 0}
+									<Badge
+										variant={custodyVerified ? 'default' : 'destructive'}
+										data-testid="custody-indicator"
+									>
+										{custodyVerified ? 'Verified' : 'Unverified'}
+									</Badge>
+								{/if}
+							</div>
+							{#if node.dangling}
+								<p class="mb-2 text-xs font-medium text-destructive" data-testid="custody-gap-note">
+									Producer not recorded — provenance gap
+								</p>
+							{/if}
+							{#if custodyRows.length > 0}
+								<dl class="grid grid-cols-1 gap-y-2 text-sm">
+									{#each custodyRows as row (row.label)}
+										<div class="flex flex-col">
+											<dt class="text-xs font-medium text-muted-foreground">{row.label}</dt>
+											<dd class="break-all {row.mono ? 'font-mono text-xs' : ''}">{row.value}</dd>
+										</div>
+									{/each}
+								</dl>
+							{/if}
+						</div>
+					{/if}
 
 					{#if inputs.length > 0}
 						<div class="mt-4">

--- a/webapp/src/lib/components/audit/RecordSidePanel.test.ts
+++ b/webapp/src/lib/components/audit/RecordSidePanel.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import RecordSidePanel from './RecordSidePanel.svelte';
+import type { AuditEvent } from '$lib/api';
+import type { ProvenanceNode } from '$lib/audit/provenance';
+
+function event(payload: Record<string, unknown>): AuditEvent {
+	return { audit_id: 'evt', event_type: 'output.materialized', timestamp: 't', payload };
+}
+
+describe('RecordSidePanel — chain-of-custody section', () => {
+	it('groups signer, identity, binding, and consent under the custody section for a verified node', () => {
+		const node: ProvenanceNode = {
+			id: 's1',
+			kind: 'step',
+			title: 'Step step-1',
+			depth: 1,
+			event: event({
+				'aileron.plan.signed_by': 'sha256:key',
+				'aileron.plan.signature_status': 'verified',
+				'aileron.actor.identity_label': 'analyst@corp',
+				'aileron.actor.credential_binding': 'vault://cred/x',
+				'aileron.consent.decision': 'granted'
+			})
+		};
+		render(RecordSidePanel, { node });
+		const section = screen.getByTestId('custody-section');
+		expect(section).toHaveTextContent('sha256:key');
+		expect(section).toHaveTextContent('analyst@corp');
+		expect(section).toHaveTextContent('vault://cred/x');
+		expect(section).toHaveTextContent('granted');
+		expect(screen.getByTestId('custody-indicator')).toHaveTextContent('Verified');
+	});
+
+	it('shows a warning indicator for an unverified node', () => {
+		const node: ProvenanceNode = {
+			id: 's2',
+			kind: 'step',
+			title: 'Step step-2',
+			depth: 1,
+			event: event({
+				'aileron.plan.signature_status': 'unverified',
+				'aileron.actor.identity_label': 'analyst@corp'
+			})
+		};
+		render(RecordSidePanel, { node });
+		expect(screen.getByTestId('custody-indicator')).toHaveTextContent('Unverified');
+	});
+
+	it('shows a provenance-gap note for a dangling node', () => {
+		const node: ProvenanceNode = {
+			id: 'artifact:missing',
+			kind: 'artifact',
+			title: '(unresolved artifact)',
+			subtitle: 'sha256:missing',
+			depth: 2,
+			dangling: true
+		};
+		render(RecordSidePanel, { node });
+		expect(screen.getByTestId('custody-gap-note')).toHaveTextContent(/provenance gap/i);
+	});
+
+	it('does not render the custody section for a literal node', () => {
+		const node: ProvenanceNode = {
+			id: 'literal:0',
+			kind: 'literal',
+			title: 'threshold',
+			depth: 2,
+			literal: { binding: 'threshold', source: 'inputs.threshold' }
+		};
+		render(RecordSidePanel, { node });
+		expect(screen.queryByTestId('custody-section')).not.toBeInTheDocument();
+	});
+});

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -161,7 +161,7 @@
 		</div>
 	</div>
 
-	<ProvenanceHeader {root} />
+	<ProvenanceHeader {root} {graph} />
 
 	{#if view === 'graph'}
 		<GraphView {graph} onselect={onNodeSelect} />

--- a/webapp/src/routes/audit/page.test.ts
+++ b/webapp/src/routes/audit/page.test.ts
@@ -221,6 +221,9 @@ describe('Audit page — deep link (#1894 affordance)', () => {
 		// Header shows the verified signature badge and skill from the root event.
 		expect(screen.getByTestId('header-signature-badge')).toHaveTextContent(/verified/i);
 		expect(screen.getByTestId('header-skill')).toHaveTextContent('pipeline');
+		// The chain-of-custody rollup reads clean and per-node trust badges render.
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent('Chain verified');
+		expect(screen.getAllByTestId('node-signature-badge').length).toBeGreaterThanOrEqual(1);
 	});
 
 	it('shows a friendly message when the trace resolves to null (unknown hash 404)', async () => {
@@ -296,6 +299,47 @@ describe('Audit page — graph + side panel', () => {
 			return node!;
 		});
 		expect(dangling).toHaveTextContent(/unresolved upstream/i);
+	});
+
+	it('surfaces the header gap count and a per-node provenance-gap affordance for a dangling upstream', async () => {
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'out.csv',
+			skill: 'etl',
+			sigStatus: 'verified',
+			signedBy: 'sha256:key',
+			inputs: [{ binding: 'data', content_hash: 'sha256:missing' }]
+		});
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+		// Header rollup reports the gap; a node carries the first-class gap marker.
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent(/provenance gap/i);
+		expect(screen.getAllByTestId('node-provenance-gap').length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('surfaces the header unverified count and a per-node warning for an unsigned plan', async () => {
+		setLocationSearch('?content_hash=sha256:root');
+		const root = materialized({
+			hash: 'sha256:root',
+			name: 'out.csv',
+			skill: 'etl',
+			sigStatus: 'unverified'
+		});
+		vi.mocked(getAuditTrace).mockResolvedValue(traceFor(root));
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('provenance-graph')).toBeInTheDocument();
+		});
+		expect(screen.getByTestId('header-chain-badge')).toHaveTextContent(/unverified/i);
+		expect(screen.getAllByTestId('node-unverified-warning').length).toBeGreaterThanOrEqual(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

Renders the chain-of-custody trust story that already rides on every `/audit` provenance node's embedded audit event. No backend, OpenAPI, or endpoint change — this is presentation only; every trust field (plan signer, signature status, acting identity, credential binding, consent) is already present on each trace node after #1930.

- **`payload.ts` — one source of truth for "verified".** Adds `SIGNATURE_STATUS_VERIFIED = 'verified'` and `signatureVerified(event)`, mirroring the daemon's `signatureStatusVerified` constant (`internal/flightplan/runtime/audit.go`). The header, node cards, and rollup all route through it instead of inlining a `status === 'verified'` compare, so the client's notion of verified cannot drift from the runtime's.
- **`trust.ts` (new) — pure chain-trust module.** `nodeTrust(node)` classifies each node `verified | unverified | gap | none` (trust-bearing = `step`/`launch` with an event; `gap` = any `dangling` node); `chainTrustSummary(graph)` reduces the graph to a de-duplicated signer set, per-count breakdown, a single `fullyVerified` flag, and a label ("Chain verified" / "2 of 5 steps unverified · 1 provenance gap"). Imports nothing from Svelte so the counting is fixture-tested without rendering.
- **`NodeCard.svelte`** — per-node trust chrome on `step`/`launch` nodes (signature badge, signer fingerprint, acting identity + consent). The `dangling` marker is now a first-class "Provenance gap" affordance distinct from the unsigned/unverified warning.
- **`ProvenanceHeader.svelte`** — takes the whole `graph` (single call-site wiring change in `+page.svelte`); adds a chain-verified badge + gap/unverified rollup and lists the de-duplicated signer set. Root badge now uses `signatureVerified(root)`.
- **`RecordSidePanel.svelte`** — groups signer / signature status / actor / credential binding / consent under an explicit "Chain of custody" section with a verified/warning indicator; dangling nodes get a "Producer not recorded — provenance gap" note.

## Test plan

- New unit suites: `trust.test.ts` (14), `payload.test.ts` (+`signatureVerified`), `NodeCard.test.ts` (8), `ProvenanceHeader.test.ts` (4), `RecordSidePanel.test.ts` (4).
- Extended `routes/audit/page.test.ts` end-to-end: verified chain → clean header rollup + per-node verified badges; dangling upstream → header gap count + per-node provenance-gap marker; unsigned plan → header unverified count + per-node warning.
- `pnpm test` — 172 passed (16 files). `pnpm check` (svelte-check) — 0 errors. `task build:webapp` — succeeds (regenerates tokens + repopulates the gitignored `internal/app/webapp_dist/`).
- Playwright e2e specs cover only approvals and are unaffected.

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)
