### PR TITLE
fix(audit): resolve actor label and render launch inputs in /audit provenance

### DIFF
--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -397,7 +397,7 @@ func (w *traceWalker) resolve(hash string) (Event, bool) {
 // artifact's plan/actor provenance, mirroring provenance.ts's launchNode.
 func launchNode(root Event, depth int) TraceNode {
 	skill := planSkill(root)
-	actor := actorIdentityLabel(root)
+	actor := actorLabel(root)
 	var parts []string
 	if skill != "" {
 		parts = append(parts, "skill "+skill)

--- a/internal/audit/trace_payload.go
+++ b/internal/audit/trace_payload.go
@@ -119,11 +119,31 @@ func planSkill(e Event) string { return payloadStr(e.Payload, "aileron.plan.skil
 
 // actorIdentityLabel prefers the normalized Actor.IdentityLabel (lifted
 // at ingest by handlers_audit.go), falling back to the flat payload key.
+// This is the acting credential's identity label specifically; it is
+// intentionally blank when no credential backs the action (e.g. a
+// human-launched or transform-produced artifact), which the chain-of-
+// custody Actor row treats as truthful.
 func actorIdentityLabel(e Event) string {
 	if e.Actor.IdentityLabel != "" {
 		return e.Actor.IdentityLabel
 	}
 	return payloadStr(e.Payload, "aileron.actor.identity_label")
+}
+
+// actorLabel resolves a non-empty "who launched" label for the header,
+// landing cards, and the graph's launch node. It falls back
+// identity_label -> display_name -> id so a human-launched or
+// transform-produced artifact (which carries no credential identity
+// label) still names its actor instead of rendering blank. The mirror is
+// payload.ts `actorLabel`.
+func actorLabel(e Event) string {
+	if l := actorIdentityLabel(e); l != "" {
+		return l
+	}
+	if e.Actor.DisplayName != "" {
+		return e.Actor.DisplayName
+	}
+	return e.Actor.ID
 }
 
 // --- title/subtitle helpers, mirroring provenance.ts ---

--- a/internal/audit/trace_test.go
+++ b/internal/audit/trace_test.go
@@ -710,3 +710,83 @@ func TestAssembleTrace_JSONRoundTrippedPayload(t *testing.T) {
 		t.Errorf("literal count = %d, want 1 (from []any input)", literals)
 	}
 }
+
+// TestActorLabel_FallbackOrder pins the identity_label -> display_name ->
+// id fallback the "who launched" surfaces resolve through. A credential
+// identity label wins when present; a human-launched or transform-produced
+// artifact (no credential label) falls back to the display name, then to
+// the actor id, so the label is never blank.
+func TestActorLabel_FallbackOrder(t *testing.T) {
+	cases := []struct {
+		name  string
+		actor model.ActorRef
+		want  string
+	}{
+		{
+			name:  "identity label preferred",
+			actor: model.ActorRef{IdentityLabel: "analytics@corp", DisplayName: "Analytics Bot", ID: "runtime"},
+			want:  "analytics@corp",
+		},
+		{
+			name:  "falls back to display name",
+			actor: model.ActorRef{DisplayName: "Analytics Bot", ID: "runtime"},
+			want:  "Analytics Bot",
+		},
+		{
+			name:  "falls back to id",
+			actor: model.ActorRef{ID: "alr@host"},
+			want:  "alr@host",
+		},
+		{
+			name:  "all empty yields empty",
+			actor: model.ActorRef{},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := Event{Actor: tc.actor, Payload: map[string]any{}}
+			if got := actorLabel(ev); got != tc.want {
+				t.Errorf("actorLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLaunchNode_ActorFallsBackToID is the regression for the blank-actor
+// defect: an artifact whose actor carries only an id (the human-launched
+// case, where ingest populates actor.id/type only) must still render a
+// non-blank "by ..." subtitle on the graph's launch node.
+func TestLaunchNode_ActorFallsBackToID(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	reportBytes := []byte("human-launched")
+	hash := digest(reportBytes)
+	ev := Event{
+		EventID:   "evt-human",
+		EventType: materializedEventType,
+		Actor:     model.ActorRef{Type: model.ActorTypeHuman, ID: "alr@host"},
+		Payload: map[string]any{
+			"aileron.output.name":         "report.csv",
+			"aileron.output.content_hash": hash,
+			"aileron.step.id":             "s1",
+			"aileron.step.kind":           "transform",
+			"aileron.plan.skill":          "athena-report",
+		},
+	}
+	if err := store.Append(ctx, ev); err != nil {
+		t.Fatal(err)
+	}
+	g, err := AssembleTrace(ctx, store, TraceRoot{ContentHash: hash})
+	if err != nil {
+		t.Fatalf("AssembleTrace: %v", err)
+	}
+	launch, ok := nodeByID(g)["launch"]
+	if !ok {
+		t.Fatal("launch terminal node missing")
+	}
+	want := "skill athena-report · by alr@host"
+	if launch.Subtitle != want {
+		t.Errorf("launch subtitle = %q, want %q", launch.Subtitle, want)
+	}
+}

--- a/webapp/src/lib/audit/payload.test.ts
+++ b/webapp/src/lib/audit/payload.test.ts
@@ -4,6 +4,8 @@ import {
 	formatBytes,
 	stepInputs,
 	signatureVerified,
+	actorLabel,
+	resolvedInputs,
 	SIGNATURE_STATUS_VERIFIED
 } from './payload';
 import type { AuditEvent } from '$lib/api';
@@ -87,5 +89,71 @@ describe('stepInputs', () => {
 		expect(
 			stepInputs(ev({ 'aileron.step.inputs': [null, 42, {}, { binding: '' }, { binding: 'ok' }] }))
 		).toEqual([{ binding: 'ok' }]);
+	});
+});
+
+describe('actorLabel', () => {
+	function evActor(
+		actor: AuditEvent['actor'],
+		payload: Record<string, unknown> = {}
+	): AuditEvent {
+		return { audit_id: 'x', event_type: 'output.materialized', timestamp: 't', payload, actor };
+	}
+	it('prefers the credential identity label', () => {
+		expect(
+			actorLabel(
+				evActor({ id: 'runtime', type: 'agent', display_name: 'Bot', identity_label: 'analytics@corp' })
+			)
+		).toBe('analytics@corp');
+	});
+	it('falls back to display name when no identity label', () => {
+		expect(actorLabel(evActor({ id: 'runtime', type: 'agent', display_name: 'Analytics Bot' }))).toBe(
+			'Analytics Bot'
+		);
+	});
+	it('falls back to id when no identity label or display name (human-launched)', () => {
+		expect(actorLabel(evActor({ id: 'alr@host', type: 'human' }))).toBe('alr@host');
+	});
+	it('is undefined when the actor carries nothing usable', () => {
+		expect(actorLabel(evActor(undefined))).toBeUndefined();
+		expect(actorLabel(evActor({ id: '', type: 'human', display_name: '' }))).toBeUndefined();
+	});
+	it('still reads the flat payload identity label when the normalized field is absent', () => {
+		expect(
+			actorLabel(evActor(undefined, { 'aileron.actor.identity_label': 'flat@corp' }))
+		).toBe('flat@corp');
+	});
+});
+
+describe('resolvedInputs', () => {
+	function ev(payload: Record<string, unknown>): AuditEvent {
+		return { audit_id: 'x', event_type: 'output.materialized', timestamp: 't', payload };
+	}
+	it('returns name/type/size descriptors sorted by name', () => {
+		expect(
+			resolvedInputs(
+				ev({
+					'aileron.resolved_inputs': { region: 'us-east-1', limit: 10, flags: ['a', 'b'] }
+				})
+			)
+		).toEqual([
+			{ name: 'flags', type: 'array', size: JSON.stringify(['a', 'b']).length },
+			{ name: 'limit', type: 'number', size: 2 },
+			{ name: 'region', type: 'string', size: JSON.stringify('us-east-1').length }
+		]);
+	});
+	it('classifies null and object values distinctly from bare typeof', () => {
+		expect(
+			resolvedInputs(ev({ 'aileron.resolved_inputs': { a: null, b: { k: 1 } } }))
+		).toEqual([
+			{ name: 'a', type: 'null', size: 4 },
+			{ name: 'b', type: 'object', size: JSON.stringify({ k: 1 }).length }
+		]);
+	});
+	it('returns [] for a missing, non-object, or array value', () => {
+		expect(resolvedInputs(ev({}))).toEqual([]);
+		expect(resolvedInputs(ev({ 'aileron.resolved_inputs': 'nope' }))).toEqual([]);
+		expect(resolvedInputs(ev({ 'aileron.resolved_inputs': ['a', 'b'] }))).toEqual([]);
+		expect(resolvedInputs(ev({ 'aileron.resolved_inputs': null }))).toEqual([]);
 	});
 });

--- a/webapp/src/lib/audit/payload.ts
+++ b/webapp/src/lib/audit/payload.ts
@@ -81,6 +81,56 @@ export function stepInputs(e: AuditEvent): StepInput[] {
 	return out;
 }
 
+/** One `aileron.resolved_inputs` entry: the launch-config input's binding
+ *  name, the JS type of its resolved value, and a size measure (character
+ *  length of the value's JSON serialization). Source-resolved dataset
+ *  inputs are excluded upstream (ADR-0027 audit boundary), so every entry
+ *  here is a literal or dynamic launch-config value. */
+export type ResolvedInput = {
+	name: string;
+	type: string;
+	size: number;
+};
+
+/** Reads the `aileron.resolved_inputs` map (name -> resolved value) that
+ *  every `output.materialized` record carries and returns a list of
+ *  name/type/size descriptors, sorted by name for stable rendering. A
+ *  missing or non-object value yields an empty list. The raw values are
+ *  never surfaced directly; only their type and serialized size are, which
+ *  keeps a large or sensitive literal collapsed behind its descriptor. */
+export function resolvedInputs(e: AuditEvent): ResolvedInput[] {
+	const raw = e.payload['aileron.resolved_inputs'];
+	if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return [];
+	const obj = raw as Record<string, unknown>;
+	const out: ResolvedInput[] = [];
+	for (const name of Object.keys(obj)) {
+		const v = obj[name];
+		out.push({ name, type: resolvedInputType(v), size: resolvedInputSize(v) });
+	}
+	out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+	return out;
+}
+
+/** Classifies a resolved-input value into a compact display type. Arrays
+ *  and null narrow out of the bare `typeof object` bucket so the descriptor
+ *  reads naturally. */
+function resolvedInputType(v: unknown): string {
+	if (v === null) return 'null';
+	if (Array.isArray(v)) return 'array';
+	return typeof v;
+}
+
+/** Size of a resolved-input value as the character length of its JSON
+ *  serialization. A value that cannot be serialized (should not occur for
+ *  JSON-carried payloads) reports 0. */
+function resolvedInputSize(v: unknown): number {
+	try {
+		return JSON.stringify(v)?.length ?? 0;
+	} catch {
+		return 0;
+	}
+}
+
 export function planSkill(e: AuditEvent): string | undefined {
 	return str(e.payload, 'aileron.plan.skill');
 }
@@ -109,9 +159,28 @@ export function signatureVerified(e: AuditEvent): boolean {
 }
 
 /** Actor identity label: prefers the normalized `actor.identity_label`,
- *  falling back to the flat payload key. */
+ *  falling back to the flat payload key. This is the acting credential's
+ *  identity label specifically; it is intentionally blank when no
+ *  credential backs the action, which the chain-of-custody Actor row treats
+ *  as truthful. Use `actorLabel` for the "who launched" surfaces that must
+ *  never render blank. */
 export function actorIdentityLabel(e: AuditEvent): string | undefined {
 	return e.actor?.identity_label ?? str(e.payload, 'aileron.actor.identity_label');
+}
+
+/** "Who launched" label for the header, landing cards, and the graph's
+ *  launch node. Falls back identity_label -> display_name -> id so a
+ *  human-launched or transform-produced artifact (which carries no
+ *  credential identity label) still names its actor instead of rendering
+ *  blank. Mirrors the server-side `actorLabel` (internal/audit/trace_payload.go). */
+export function actorLabel(e: AuditEvent): string | undefined {
+	return (
+		actorIdentityLabel(e) ??
+		(e.actor?.display_name && e.actor.display_name.length > 0
+			? e.actor.display_name
+			: undefined) ??
+		(e.actor?.id && e.actor.id.length > 0 ? e.actor.id : undefined)
+	);
 }
 export function actorCredentialBinding(e: AuditEvent): string | undefined {
 	return e.actor?.credential_binding ?? str(e.payload, 'aileron.actor.credential_binding');

--- a/webapp/src/lib/components/audit/ProvenanceHeader.svelte
+++ b/webapp/src/lib/components/audit/ProvenanceHeader.svelte
@@ -12,7 +12,7 @@
 	let { root, graph }: { root: AuditEvent; graph: ProvenanceGraph } = $props();
 
 	const skill = $derived(p.planSkill(root));
-	const actor = $derived(p.actorIdentityLabel(root));
+	const actor = $derived(p.actorLabel(root));
 	const status = $derived(p.planSignatureStatus(root));
 	const verified = $derived(p.signatureVerified(root));
 

--- a/webapp/src/lib/components/audit/ProvenanceHeader.test.ts
+++ b/webapp/src/lib/components/audit/ProvenanceHeader.test.ts
@@ -71,3 +71,38 @@ describe('ProvenanceHeader — chain-level trust rollup', () => {
 		expect(signedBy).toHaveTextContent('sha256:bob');
 	});
 });
+
+describe('ProvenanceHeader — actor label fallback', () => {
+	it('shows the credential identity label when present', () => {
+		const root = event({ skill: 'etl', actor: 'analytics@corp' });
+		render(ProvenanceHeader, { root, graph: graphOf(root, [step('s1', root)]) });
+		expect(screen.getByTestId('header-actor')).toHaveTextContent('analytics@corp');
+	});
+
+	it('falls back to the actor id for a human-launched artifact (no credential label)', () => {
+		// Regression for the blank-actor defect: ingest populates actor.id/type
+		// only for a human launch, so the header Actor row must render the id
+		// rather than blank.
+		const root: AuditEvent = {
+			audit_id: 'evt',
+			event_type: 'output.materialized',
+			timestamp: 't',
+			payload: { 'aileron.plan.skill': 'etl' },
+			actor: { id: 'alr@host', type: 'human' }
+		};
+		render(ProvenanceHeader, { root, graph: graphOf(root, [step('s1', root)]) });
+		expect(screen.getByTestId('header-actor')).toHaveTextContent('alr@host');
+	});
+
+	it('prefers the display name over the id when there is no identity label', () => {
+		const root: AuditEvent = {
+			audit_id: 'evt',
+			event_type: 'output.materialized',
+			timestamp: 't',
+			payload: { 'aileron.plan.skill': 'etl' },
+			actor: { id: 'runtime', type: 'agent', display_name: 'Analytics Bot' }
+		};
+		render(ProvenanceHeader, { root, graph: graphOf(root, [step('s1', root)]) });
+		expect(screen.getByTestId('header-actor')).toHaveTextContent('Analytics Bot');
+	});
+});

--- a/webapp/src/lib/components/audit/RecordSidePanel.svelte
+++ b/webapp/src/lib/components/audit/RecordSidePanel.svelte
@@ -83,6 +83,13 @@
 	const showCustody = $derived(!!node?.dangling || custodyRows.length > 0);
 
 	const inputs = $derived(node?.event ? p.stepInputs(node.event) : []);
+
+	// Launch-config inputs (`aileron.resolved_inputs`) recorded on every
+	// output.materialized record: the literal + dynamic resolved values, each
+	// surfaced as name/type/size only (never the raw value). Rendered wherever
+	// the node's event carries a non-empty map, consistent with how the step
+	// Inputs list renders.
+	const launchInputs = $derived(node?.event ? p.resolvedInputs(node.event) : []);
 </script>
 
 <Dialog.Root bind:open {onOpenChange}>
@@ -175,6 +182,26 @@
 										{#if input.content_hash}<Badge variant="secondary"
 												>{p.shortHash(input.content_hash)}</Badge
 											>{:else}<Badge variant="outline">literal</Badge>{/if}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+
+					{#if launchInputs.length > 0}
+						<div class="mt-4" data-testid="launch-inputs-section">
+							<h3 class="mb-1 text-xs font-semibold text-muted-foreground">Launch inputs</h3>
+							<ul class="flex flex-col gap-1 text-xs">
+								{#each launchInputs as input (input.name)}
+									<li
+										class="flex flex-wrap items-center gap-2"
+										data-testid="side-panel-launch-input"
+									>
+										<span class="font-medium">{input.name}</span>
+										<Badge variant="outline">{input.type}</Badge>
+										{#if input.size > LARGE_LITERAL}
+											<Badge variant="secondary">{input.size} chars</Badge>
+										{/if}
 									</li>
 								{/each}
 							</ul>

--- a/webapp/src/lib/components/audit/RecordSidePanel.test.ts
+++ b/webapp/src/lib/components/audit/RecordSidePanel.test.ts
@@ -72,3 +72,54 @@ describe('RecordSidePanel — chain-of-custody section', () => {
 		expect(screen.queryByTestId('custody-section')).not.toBeInTheDocument();
 	});
 });
+
+describe('RecordSidePanel — launch inputs section', () => {
+	it('renders a name/type descriptor row per resolved input', () => {
+		const node: ProvenanceNode = {
+			id: 'artifact:h',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			event: event({
+				'aileron.output.name': 'report.csv',
+				'aileron.resolved_inputs': { region: 'us-east-1', limit: 10 }
+			})
+		};
+		render(RecordSidePanel, { node });
+		expect(screen.getByTestId('launch-inputs-section')).toBeInTheDocument();
+		const rows = screen.getAllByTestId('side-panel-launch-input');
+		expect(rows).toHaveLength(2);
+		// Sorted by name: limit before region.
+		expect(rows[0]).toHaveTextContent('limit');
+		expect(rows[0]).toHaveTextContent('number');
+		expect(rows[1]).toHaveTextContent('region');
+		expect(rows[1]).toHaveTextContent('string');
+	});
+
+	it('badges the character size of a large literal input', () => {
+		const big = 'x'.repeat(200);
+		const node: ProvenanceNode = {
+			id: 'artifact:h',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			event: event({ 'aileron.resolved_inputs': { blob: big } })
+		};
+		render(RecordSidePanel, { node });
+		const row = screen.getByTestId('side-panel-launch-input');
+		// JSON.stringify adds the surrounding quotes: 202 chars.
+		expect(row).toHaveTextContent('202 chars');
+	});
+
+	it('does not render the section when the event carries no resolved inputs', () => {
+		const node: ProvenanceNode = {
+			id: 'artifact:h',
+			kind: 'artifact',
+			title: 'report.csv',
+			depth: 0,
+			event: event({ 'aileron.output.name': 'report.csv' })
+		};
+		render(RecordSidePanel, { node });
+		expect(screen.queryByTestId('launch-inputs-section')).not.toBeInTheDocument();
+	});
+});

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -218,7 +218,7 @@
 						<Card.Content>
 							<p class="text-xs text-muted-foreground">
 								{[
-									p.actorIdentityLabel(event) && `by ${p.actorIdentityLabel(event)}`,
+									p.actorLabel(event) && `by ${p.actorLabel(event)}`,
 									p.planSkill(event) && `skill ${p.planSkill(event)}`,
 									hash && p.shortHash(hash)
 								]

--- a/webapp/src/routes/audit/page.test.ts
+++ b/webapp/src/routes/audit/page.test.ts
@@ -176,6 +176,27 @@ describe('Audit page — landing', () => {
 		expect(vi.mocked(listRecentMaterialized)).toHaveBeenCalled();
 	});
 
+	it('labels a landing card by the credential identity when present', async () => {
+		vi.mocked(listRecentMaterialized).mockResolvedValue([
+			materialized({ hash: 'sha256:a', name: 'sales.csv', actor: 'analyst@corp' })
+		]);
+		render(Page);
+		const card = await screen.findByTestId('recent-artifact');
+		expect(card).toHaveTextContent('by analyst@corp');
+	});
+
+	it('falls back to the actor id on a landing card for a human-launched artifact', async () => {
+		// Regression for the blank-actor defect: a human launch carries only
+		// actor.id/type, so the "by ..." line must render the id rather than
+		// dropping out.
+		const event = materialized({ hash: 'sha256:a', name: 'sales.csv' });
+		event.actor = { id: 'alr@host', type: 'human' };
+		vi.mocked(listRecentMaterialized).mockResolvedValue([event]);
+		render(Page);
+		const card = await screen.findByTestId('recent-artifact');
+		expect(card).toHaveTextContent('by alr@host');
+	});
+
 	it('shows the empty state when nothing is materialized', async () => {
 		vi.mocked(listRecentMaterialized).mockResolvedValue([]);
 		render(Page);


### PR DESCRIPTION
## Summary

Fixes two real defects in the `/audit` provenance view (feedback #1926).

1. **Blank actor.** The "who launched" label resolved via `actorIdentityLabel`, which only returns the credential `identity_label`. A human-launched or transform-produced artifact carries no credential, so the header Actor row, the landing cards (`by ...`), and the server-assembled launch-node subtitle rendered blank. Added an `actorLabel` accessor that falls back `identity_label -> display_name -> id`:
   - server-side (`internal/audit/trace_payload.go`, used by `launchNode` in `trace.go`),
   - client-side (`webapp/src/lib/audit/payload.ts`),
   - and switched `ProvenanceHeader.svelte` + `routes/audit/+page.svelte` to it.

   `RecordSidePanel`'s chain-of-custody Actor row stays on `actorIdentityLabel`: that row is the *acting credential* identity, and blank-when-no-credential is truthful. At ingest only `actor.id`/`type` are populated for a human launch, so that case resolves to the id (`<user>@<host>`).

2. **Resolved inputs never rendered.** Every `output.materialized` record carries `aileron.resolved_inputs` (`internal/flightplan/runtime/audit.go`), but the client had no accessor and nothing rendered it. Added `resolvedInputs(e)` (name/type/size, source-values excluded upstream per ADR-0027) and a "Launch inputs" section in `RecordSidePanel.svelte`, rendered wherever a node's event carries a non-empty map — consistent with how the step Inputs list renders. Only type and serialized size are surfaced, never the raw value.

No OpenAPI change: `ActorRef` already carries `id`/`display_name`/`identity_label`; only the launch-node subtitle string content changes.

## Test plan

- `go test ./internal/audit/... ./internal/app/...` — pass. New regression tests in `internal/audit/trace_test.go`: `TestActorLabel_FallbackOrder` pins the fallback order; `TestLaunchNode_ActorFallsBackToID` proves the launch-node subtitle renders `by <id>` for a human launch (fails before the fix, which produced `skill athena-report` with no `by ...`).
- `pnpm test` (webapp, 189 tests) — pass. New tests: `payload.test.ts` (actorLabel fallback + resolvedInputs type/size/sort/guards), `ProvenanceHeader.test.ts` (header Actor falls back to id / display_name), `RecordSidePanel.test.ts` (Launch inputs section render + size badge + absent-when-empty), `page.test.ts` (landing card `by <id>` fallback).
- `pnpm check` (svelte-check) — 0 errors, 0 warnings.
- `gofmt -l` / `go vet ./internal/audit/...` — clean.

Closes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
