### PR TITLE
feat(skill): launch pulls and verifies a published composed image cross-machine

### DIFF
--- a/cmd/aileron/skill_install_oci.go
+++ b/cmd/aileron/skill_install_oci.go
@@ -80,6 +80,21 @@ func runSkillInstallOCI(ref string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Record the install origin so launch (#1903) can pull and verify the
+	// published image on a machine that never froze the plan. The sidecar is
+	// non-signed provenance (where to fetch), never a verification trust anchor;
+	// its presence is also the signal launch uses to take the registry-pull path
+	// instead of the local-tag boot path. A locally-frozen version has no
+	// sidecar. A sidecar write failure fails the install rather than leaving a
+	// version launch cannot boot on this machine.
+	if err := s.WriteOrigin(res.Name, res.Frozen.ID, store.Origin{
+		Registry:   res.SourceRegistry,
+		VersionTag: res.SourceTag,
+	}); err != nil {
+		fmt.Fprintf(stderr, "error: record install origin for %q: %v\n", res.Frozen.ID, err)
+		return 1
+	}
+
 	fmt.Fprintf(stdout, "Installed frozen version %s of skill %q to %s\n",
 		res.Frozen.ID, res.Name, s.FrozenDir(res.Name, res.Frozen.ID))
 	return 0

--- a/cmd/aileron/skill_install_oci_test.go
+++ b/cmd/aileron/skill_install_oci_test.go
@@ -53,7 +53,12 @@ func TestRunSkillInstallOCIWritesFrozenAndLists(t *testing.T) {
 		if opts.Verifier != nil {
 			t.Error("verifier should be the silenced nil for this test")
 		}
-		return pull.Result{Frozen: installFrozen("v1abc"), Name: "rubber-duck"}, nil
+		return pull.Result{
+			Frozen:         installFrozen("v1abc"),
+			Name:           "rubber-duck",
+			SourceRegistry: "ghcr.io/acme/plan",
+			SourceTag:      "v1abc",
+		}, nil
 	})
 
 	var out, errb bytes.Buffer
@@ -72,12 +77,26 @@ func TestRunSkillInstallOCIWritesFrozenAndLists(t *testing.T) {
 	if !strings.Contains(listOut.String(), "rubber-duck") {
 		t.Errorf("list = %q, want rubber-duck", listOut.String())
 	}
-	ids, err := store.New(skillStoreDir).FrozenVersions("rubber-duck")
+	s := store.New(skillStoreDir)
+	ids, err := s.FrozenVersions("rubber-duck")
 	if err != nil {
 		t.Fatalf("FrozenVersions: %v", err)
 	}
 	if len(ids) != 1 || ids[0] != "v1abc" {
 		t.Errorf("frozen ids = %v, want [v1abc]", ids)
+	}
+
+	// The install records the origin sidecar so launch (#1903) can find the
+	// published image on this machine that never froze the plan.
+	origin, ok, err := s.ReadOrigin("rubber-duck", "v1abc")
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if !ok {
+		t.Fatal("install did not record an origin sidecar")
+	}
+	if origin.Registry != "ghcr.io/acme/plan" || origin.VersionTag != "v1abc" {
+		t.Errorf("origin = %+v, want registry=ghcr.io/acme/plan tag=v1abc", origin)
 	}
 }
 

--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -10,10 +10,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"os/user"
 	"sort"
 	"strings"
+	"syscall"
 
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/pull"
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	"github.com/ALRubinger/aileron/internal/model"
@@ -92,6 +96,55 @@ var newLaunchImageRunner = func() runtime.ImageRunner {
 // path and fails closed on a digest mismatch or a resolve error.
 var newLaunchImageDigestResolver = func() runtime.LocalImageDigestResolver {
 	return containerImageDigestResolver{}
+}
+
+// newLaunchRegistryImageResolver returns the production
+// runtime.RegistryImageResolver that pulls a published composed (or foreign-base)
+// image from a plan's recorded install origin and verifies it against the signed
+// lock pin per the pin's binding kind (#1903). It is consulted only when the
+// loaded plan carries a registry origin (an OCI install), so a plan installed by
+// OCI reference on a machine that never froze it can still boot. It is a
+// package-level seam so CLI tests inject a fake that returns a canned bootRef and
+// never touches the network, mirroring newLaunchImageRunner/skillPullRun. All
+// oras/registry code stays in internal/flightplan/pull, so cmd/aileron stays
+// oras-free.
+var newLaunchRegistryImageResolver = func() runtime.RegistryImageResolver {
+	return launchRegistryImageResolver{}
+}
+
+// launchRegistryImageResolver adapts pull.PullImage to the runtime seam. The
+// pull is bounded by a timeout and honors Ctrl-C so a hung or unreachable
+// registry fails the launch instead of blocking indefinitely, mirroring the OCI
+// install path (installPullTimeout + signal.NotifyContext).
+type launchRegistryImageResolver struct{}
+
+func (launchRegistryImageResolver) Resolve(ctx context.Context, origin runtime.RegistryImageOrigin, pin freeze.ImagePin) (string, error) {
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(ctx, installPullTimeout)
+	defer cancel()
+	res, err := pull.PullImage(ctx, pull.ImagePullOptions{
+		Registry:   origin.Registry,
+		VersionTag: origin.VersionTag,
+		Pin:        pin,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.BootRef, nil
+}
+
+// launchRegistryResolver returns the host-side registry-image resolver wired
+// into the runtime, or nil on the image-boot re-entry. The nil-skip mirrors the
+// InPinnedImage / publisher-verifier guards: when AILERON_SKILL_IMAGE_BOOTED is
+// set this launch is the re-entry INSIDE the sealed pin, which the sentinel
+// already routes in-process before any boot, so the registry path is never
+// entered and no resolver is needed.
+func launchRegistryResolver() runtime.RegistryImageResolver {
+	if os.Getenv(envSkillImageBooted) != "" {
+		return nil
+	}
+	return newLaunchRegistryImageResolver()
 }
 
 // newLaunchToolStepRunner returns the production tool-step runner that
@@ -212,6 +265,15 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		// and fails closed on a mismatch or resolve error; a non-composed
 		// (ref@digest) pin never touches it.
 		ImageDigestResolver: newLaunchImageDigestResolver(),
+		// RegistryImageResolver pulls and verifies the published image for a plan
+		// installed by OCI reference (#1903), so a machine that never froze the
+		// plan can still boot it. The runtime consults it only when the loaded
+		// plan carries a registry origin (an OCI install); a locally-frozen plan
+		// boots by its local tag and never touches this seam. It is nil on the
+		// image-boot re-entry (the same sentinel that sets InPinnedImage): the
+		// sentinel routes in-process before any boot, so the registry path is
+		// never re-entered inside the container.
+		RegistryImageResolver: launchRegistryResolver(),
 		// InPinnedImage: the image-boot re-entry runs with the sentinel its
 		// booting runner injected; it is already inside the certified
 		// environment and must run the plan in-process, not boot the pin

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/pull"
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	"github.com/ALRubinger/aileron/internal/model"
@@ -130,6 +132,55 @@ func stubLaunchImageRunner(t *testing.T, runner *fakeLaunchImageRunner) *fakeLau
 	}
 	t.Cleanup(func() { newLaunchImageRunner = orig })
 	return runner
+}
+
+// fakeLaunchRegistryImageResolver records the origin+pin it was handed and
+// returns a canned bootRef or error, standing in for the registry pull+verify so
+// a registry-origin launch never touches the network.
+type fakeLaunchRegistryImageResolver struct {
+	bootRef   string
+	err       error
+	called    bool
+	gotOrigin runtime.RegistryImageOrigin
+	gotPin    freeze.ImagePin
+}
+
+func (f *fakeLaunchRegistryImageResolver) Resolve(_ context.Context, origin runtime.RegistryImageOrigin, pin freeze.ImagePin) (string, error) {
+	f.called = true
+	f.gotOrigin = origin
+	f.gotPin = pin
+	return f.bootRef, f.err
+}
+
+// stubLaunchRegistryImageResolver swaps the production registry-resolver seam
+// for a fake so a registry-origin launch exercises the pull+verify boot path
+// with no network. When resolver is nil the seam yields nil so the runtime's
+// registry-origin-but-no-resolver fail-closed guard fires.
+func stubLaunchRegistryImageResolver(t *testing.T, resolver *fakeLaunchRegistryImageResolver) {
+	t.Helper()
+	orig := newLaunchRegistryImageResolver
+	newLaunchRegistryImageResolver = func() runtime.RegistryImageResolver {
+		if resolver == nil {
+			return nil
+		}
+		return resolver
+	}
+	t.Cleanup(func() { newLaunchRegistryImageResolver = orig })
+}
+
+// writeLaunchOrigin records an install-origin sidecar for the sole frozen
+// version of name in storeDir, so a subsequent launch takes the registry-pull
+// boot path. It resolves the version id the same way launch does (LatestFrozen).
+func writeLaunchOrigin(t *testing.T, storeDir, name, registry string) {
+	t.Helper()
+	s := store.New(storeDir)
+	id, count, err := s.LatestFrozen(name)
+	if err != nil || count == 0 {
+		t.Fatalf("LatestFrozen(%q) = %q,%d,%v; want a frozen version", name, id, count, err)
+	}
+	if err := s.WriteOrigin(name, id, store.Origin{Registry: registry, VersionTag: id}); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
 }
 
 // freezeExampleForLaunch installs + freezes the worked example into the temp
@@ -308,6 +359,138 @@ func TestRunSkillLaunch_GuardFailsClosedOnDigestMismatch(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), otherDigest) || !strings.Contains(stderr.String(), "refusing to boot") {
 		t.Errorf("stderr must name the mismatch and the refusal, got %q", stderr.String())
+	}
+}
+
+// TestRunSkillLaunch_RegistryOriginPullsVerifiesAndBoots proves the cross-machine
+// launch acceptance property (#1903): a frozen unit installed by OCI reference
+// (an origin sidecar is present) takes the registry pull+verify path. The
+// registry resolver is consulted with the recorded origin and the signed pin,
+// and the image runner boots the verified reference it returns. The local-tag
+// #1863 guard resolver is NOT consulted on this path.
+func TestRunSkillLaunch_RegistryOriginPullsVerifiesAndBoots(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	writeLaunchOrigin(t, storeDir, "weekly-metrics-digest", "ghcr.io/acme/plan")
+
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ContentHash: "sha256:booted"},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	bootRef := "ghcr.io/acme/plan:v1-image"
+	resolver := &fakeLaunchRegistryImageResolver{bootRef: bootRef}
+	stubLaunchRegistryImageResolver(t, resolver)
+	// Wire a local-tag guard resolver too, to prove it is NOT consulted on the
+	// registry path.
+	localGuard := &stubLaunchDigestResolverFake{digest: "sha256:" + strings.Repeat("9", 64)}
+	stubLaunchImageDigestResolver(t, localGuard)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !resolver.called {
+		t.Fatal("a registry-origin launch must consult the registry resolver")
+	}
+	if resolver.gotOrigin.Registry != "ghcr.io/acme/plan" {
+		t.Errorf("resolver origin registry = %q, want ghcr.io/acme/plan", resolver.gotOrigin.Registry)
+	}
+	if localGuard.gotImage != "" {
+		t.Errorf("the local-tag guard was consulted (%q) on the registry path; it must not be", localGuard.gotImage)
+	}
+	if !runner.called || runner.spec.Image != bootRef {
+		t.Errorf("booted image = %q, want the resolver's verified ref %q", runner.spec.Image, bootRef)
+	}
+}
+
+// TestRunSkillLaunch_RegistryOriginResolverErrorExits1 proves a pull/verify
+// failure on the registry path fails the whole launch closed: the image runner
+// is never booted, the CLI exits non-zero, and stderr surfaces the precise
+// refusal.
+func TestRunSkillLaunch_RegistryOriginResolverErrorExits1(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	writeLaunchOrigin(t, storeDir, "weekly-metrics-digest", "ghcr.io/acme/plan")
+
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ContentHash: "sha256:booted"},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	stubLaunchRegistryImageResolver(t, &fakeLaunchRegistryImageResolver{
+		err: pull.ErrImageDigestMismatch,
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("a registry pull/verify failure must fail the launch closed, exit=%d stdout=%s", code, stdout.String())
+	}
+	if runner.called {
+		t.Fatal("a refused registry pull must NOT boot the image runner")
+	}
+	if !strings.Contains(stderr.String(), "refusing to boot") {
+		t.Errorf("stderr must surface the refusal, got %q", stderr.String())
+	}
+}
+
+// TestRunSkillLaunch_RegistryOriginNilResolverExits1 proves a registry-origin
+// plan with no resolver wired fails closed at the CLI rather than falling
+// through to a local-tag boot the machine cannot satisfy.
+func TestRunSkillLaunch_RegistryOriginNilResolverExits1(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	writeLaunchOrigin(t, storeDir, "weekly-metrics-digest", "ghcr.io/acme/plan")
+
+	runner := stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ContentHash: "sha256:booted"},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	stubLaunchRegistryImageResolver(t, nil) // no resolver
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("a registry-origin plan with no resolver must fail closed")
+	}
+	if runner.called {
+		t.Fatal("a fail-closed registry-origin launch must NOT boot the runner")
+	}
+	if !strings.Contains(stderr.String(), "no registry image resolver is configured") {
+		t.Errorf("stderr = %q, want a no-resolver-configured message", stderr.String())
+	}
+}
+
+// TestRunSkillLaunch_RegistryOriginAttributionStaysLauncher proves the
+// multi-identity property is unchanged on the registry path: the pulled image
+// holds no credential and the audit is stamped with the launching operator's
+// identity (operatorActorID), never the publisher. The daemon proxy injects the
+// launcher's vault credential at egress (unchanged); here we assert the audit
+// actor is the launcher.
+func TestRunSkillLaunch_RegistryOriginAttributionStaysLauncher(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	writeLaunchOrigin(t, storeDir, "weekly-metrics-digest", "ghcr.io/acme/plan")
+
+	t.Setenv("AILERON_OPERATOR_ID", "launcher@workstation")
+
+	// The image runner echoes an audit id so the runtime surfaces the boot as a
+	// launch; the operator identity is stamped by the CLI's audit sink, which the
+	// container runner re-enters with AILERON_OPERATOR_ID. Assert the resolved
+	// operator identity is the launcher, the value the boot carries in.
+	stubLaunchImageRunner(t, &fakeLaunchImageRunner{
+		result: runtime.ImageRunResult{ContentHash: "sha256:booted"},
+	})
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	stubLaunchRegistryImageResolver(t, &fakeLaunchRegistryImageResolver{bootRef: "ghcr.io/acme/plan:v1-image"})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := operatorActorID(); got != "launcher@workstation" {
+		t.Errorf("operator actor = %q, want the launcher identity (never the publisher)", got)
 	}
 }
 

--- a/internal/flightplan/freeze/ociartifact.go
+++ b/internal/flightplan/freeze/ociartifact.go
@@ -50,6 +50,16 @@ const (
 	BindingManifestDigest = "manifest-digest"
 )
 
+// ComposedImageTag is the tag a composed-tools image is published under in the
+// destination repository, distinct from the signed-artifact tag (the version
+// id). Publish (#1901) pushes the composed image under this tag and points the
+// signed-artifact referrer's subject at it by digest; launch (#1903) resolves
+// the published composed image back through this same tag. It lives here so the
+// write and read halves cannot drift on the naming convention. versionID is the
+// store version id (the freeze slug), already validated as a single path
+// segment by the store, so the derived tag is a single path segment too.
+func ComposedImageTag(versionID string) string { return versionID + "-image" }
+
 // BindingKind reports how a resolved image pin's signed-lock Digest binds to
 // the published/pulled image, derived purely from the signature-covered pin:
 //

--- a/internal/flightplan/publish/publish.go
+++ b/internal/flightplan/publish/publish.go
@@ -214,11 +214,6 @@ func publishImage(ctx context.Context, opts Options, pin freeze.ImagePin, target
 	}
 }
 
-// composedImageTag is the tag the composed image is pushed under in the
-// destination repository (distinct from the signed-artifact tag, which is the
-// version id). The artifact referrer's subject points at this image by digest.
-func composedImageTag(versionID string) string { return versionID + "-image" }
-
 // publishComposed verifies the local composed image's config digest against the
 // signed lock, pushes it into the destination repository, and returns the
 // pushed image descriptor. The config digest is checked BEFORE the push, so a
@@ -236,7 +231,7 @@ func publishComposed(ctx context.Context, opts Options, pin freeze.ImagePin, tar
 		return ocispec.Descriptor{}, "", fmt.Errorf("%w: local config %s, lock attested %s", ErrConfigDigestMismatch, localConfig, pin.Digest)
 	}
 
-	imageTag := composedImageTag(opts.VersionID)
+	imageTag := freeze.ComposedImageTag(opts.VersionID)
 	if err := src.Push(ctx, pin.LocalTag, opts.Registry, imageTag); err != nil {
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: push composed image: %w", err)
 	}

--- a/internal/flightplan/publish/publish_test.go
+++ b/internal/flightplan/publish/publish_test.go
@@ -53,7 +53,7 @@ func mustPush(t *testing.T, st content.Storage, desc ocispec.Descriptor, data []
 
 // fakeImageSource stands in for the docker CLI: ConfigDigest returns a
 // controllable local config digest, and Push is a no-op (composed tests
-// pre-seed the target with the "pushed" image tagged as composedImageTag).
+// pre-seed the target with the "pushed" image tagged as freeze.ComposedImageTag).
 type fakeImageSource struct {
 	configDigest string
 	configErr    error
@@ -73,7 +73,7 @@ func (f fakeImageSource) Push(ctx context.Context, localTag, registry, imageTag 
 func seedComposedTarget(t *testing.T, target *memory.Store, versionID, configBody string) (manifest, config ocispec.Descriptor) {
 	t.Helper()
 	manifest, config = seedImage(t, target, configBody)
-	if err := target.Tag(context.Background(), manifest, composedImageTag(versionID)); err != nil {
+	if err := target.Tag(context.Background(), manifest, freeze.ComposedImageTag(versionID)); err != nil {
 		t.Fatalf("tag composed image: %v", err)
 	}
 	return manifest, config

--- a/internal/flightplan/pull/image.go
+++ b/internal/flightplan/pull/image.go
@@ -1,0 +1,198 @@
+package pull
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+)
+
+// Image-pull errors. Every one is a fail-closed refusal: a mismatch, a missing
+// published image, or a pull/network failure never yields a bootable reference.
+var (
+	// ErrImageMissing is returned when the published image is absent from the
+	// source repository (the composed-image tag or the pinned digest does not
+	// resolve). A clean machine that installed the artifact but whose registry no
+	// longer serves the image cannot boot.
+	ErrImageMissing = errors.New("pull: published image is missing from the source registry")
+	// ErrImageDigestMismatch is returned when the pulled image does not verify
+	// against the signed lock pin under the pin's binding kind (config digest for
+	// a composed pin, manifest digest for an image-only/foreign-base pin). The
+	// registry served a different image than the signature attested.
+	ErrImageDigestMismatch = errors.New("pull: pulled image does not match the signed lock digest")
+	// ErrImagePullFailed wraps any other pull/network/fetch failure so the caller
+	// refuses to boot rather than proceed on a partial pull.
+	ErrImagePullFailed = errors.New("pull: could not pull the published image")
+)
+
+// ImagePullOptions configures a published-image pull+verify (#1903). The source
+// coordinate answers WHERE to pull; the verified Pin answers WHAT to verify. The
+// two roles stay distinct: the coordinate comes from the operator's own install
+// ref (recorded at install), the digest from the signature-covered lock.
+type ImagePullOptions struct {
+	// Source is the content store to resolve+fetch the image from. Nil builds a
+	// remote.Repository from Registry over the operator's docker credentials.
+	// Tests inject an in-memory store.
+	Source oras.ReadOnlyTarget
+	// Registry is the registry+repository the published image lives in (the
+	// install origin, e.g. "ghcr.io/acme/plan"), without tag or digest. It is
+	// the fetch coordinate and, for a composed pin, the base of the returned
+	// bootable reference.
+	Registry string
+	// VersionTag is the store version id (freeze slug). The composed image was
+	// published under freeze.ComposedImageTag(VersionTag); launch resolves it
+	// back through that tag.
+	VersionTag string
+	// Pin is the verified image pin from the signed lock. freeze.BindingKind(Pin)
+	// governs verification; Pin.Digest is the attested digest. It is authoritative
+	// from the signature, never from any registry annotation.
+	Pin freeze.ImagePin
+}
+
+// ImagePullResult reports the verified, bootable reference for the published
+// image.
+type ImagePullResult struct {
+	// BootRef is the reference the runner boots verbatim, content-addressed to a
+	// manifest digest in both cases so a mutable tag can never be booted after
+	// verification. For a composed pin it is "<registry>@<manifest-digest>" where
+	// the manifest was config-digest-verified against the signed lock; for an
+	// image-only/foreign-base pin it is "<registry>@<manifest-digest>" where the
+	// manifest digest itself is the signed lock pin. The value derives only from
+	// the verified digests and the recorded coordinate, never from a re-parse of
+	// untrusted manifest bytes beyond the digest comparison itself.
+	BootRef string
+	// BindingKind is the binding the verification used (freeze.BindingConfigDigest
+	// or freeze.BindingManifestDigest), surfaced for provenance/logging.
+	BindingKind string
+	// ImageDigest is the verified digest the boot reference is anchored to: the
+	// image config digest for a composed pin, the manifest digest for an
+	// image-only/foreign-base pin. Both equal Pin.Digest by construction.
+	ImageDigest string
+}
+
+// PullImage pulls the published image named by the recorded coordinate and
+// verifies it against the signed lock pin under the pin's binding kind, returning
+// a bootable reference. It never boots: a mismatch, a missing image, or a pull
+// failure returns a typed error and no reference.
+//
+// The binding kind is derived purely from freeze.BindingKind(opts.Pin), rooted
+// in the signature-covered lock, so a tampered registry annotation cannot change
+// what launch verifies. This mirrors publish's publishComposed/publishForeignBase
+// split exactly, the two halves of the same contract.
+func PullImage(ctx context.Context, opts ImagePullOptions) (ImagePullResult, error) {
+	if opts.Registry == "" {
+		return ImagePullResult{}, fmt.Errorf("%w: no source registry recorded for the install", ErrImagePullFailed)
+	}
+	if opts.Pin.Digest == "" {
+		return ImagePullResult{}, fmt.Errorf("%w: the signed lock pins no image digest", ErrImageDigestMismatch)
+	}
+
+	src := opts.Source
+	if src == nil {
+		repo, err := ociremote.NewRepository(opts.Registry)
+		if err != nil {
+			return ImagePullResult{}, fmt.Errorf("%w: source registry %q: %w", ErrImagePullFailed, opts.Registry, err)
+		}
+		src = repo
+	}
+
+	switch freeze.BindingKind(opts.Pin) {
+	case freeze.BindingConfigDigest:
+		return pullComposedImage(ctx, src, opts)
+	default:
+		return pullManifestDigestImage(ctx, src, opts)
+	}
+}
+
+// pullComposedImage resolves the composed image by its published tag, reads its
+// manifest's config digest (mirroring publish's imageConfigDigest read
+// semantics), and requires it to equal the signed lock pin. The bootable
+// reference is content-addressed to the resolved MANIFEST digest
+// ("<registry>@<manifest-digest>"), not the mutable tag: the config-digest check
+// proved this exact manifest carries the attested config, so anchoring the boot
+// to that manifest digest closes the TOCTOU window a tag would leave open (the
+// tag could be repointed between this verification and the runner's boot). The
+// runner boots the same manifest bytes verified here, and the daemon re-checks
+// the digest itself on pull.
+func pullComposedImage(ctx context.Context, src oras.ReadOnlyTarget, opts ImagePullOptions) (ImagePullResult, error) {
+	imageTag := freeze.ComposedImageTag(opts.VersionTag)
+	desc, err := src.Resolve(ctx, imageTag)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return ImagePullResult{}, fmt.Errorf("%w: composed image tag %q in %q", ErrImageMissing, imageTag, opts.Registry)
+		}
+		return ImagePullResult{}, fmt.Errorf("%w: resolve composed image %q: %w", ErrImagePullFailed, imageTag, err)
+	}
+	if desc.Digest == "" {
+		return ImagePullResult{}, fmt.Errorf("%w: composed image %q resolved to an empty manifest digest", ErrImagePullFailed, imageTag)
+	}
+
+	config, err := imageConfigDigest(ctx, src, desc)
+	if err != nil {
+		return ImagePullResult{}, fmt.Errorf("%w: read composed image config: %w", ErrImagePullFailed, err)
+	}
+	if config != opts.Pin.Digest {
+		return ImagePullResult{}, fmt.Errorf("%w: composed image config %s, lock attested %s", ErrImageDigestMismatch, config, opts.Pin.Digest)
+	}
+
+	return ImagePullResult{
+		// Boot by the verified manifest digest, not the tag: content-addressed so
+		// the runner cannot boot a repointed tag, while the config-digest check
+		// above is the identity binding to the signed lock.
+		BootRef:     opts.Registry + "@" + desc.Digest.String(),
+		BindingKind: freeze.BindingConfigDigest,
+		ImageDigest: config,
+	}, nil
+}
+
+// pullManifestDigestImage resolves the published image by the attested manifest
+// digest and requires the resolved descriptor's digest to equal the signed lock
+// pin (publish copied the exact bytes with oras.Copy, which preserves the
+// manifest digest). The bootable reference is the content-addressed
+// "<registry>@<digest>", which the daemon resolves and verifies itself.
+func pullManifestDigestImage(ctx context.Context, src oras.ReadOnlyTarget, opts ImagePullOptions) (ImagePullResult, error) {
+	desc, err := src.Resolve(ctx, opts.Pin.Digest)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return ImagePullResult{}, fmt.Errorf("%w: image %s@%s", ErrImageMissing, opts.Registry, opts.Pin.Digest)
+		}
+		return ImagePullResult{}, fmt.Errorf("%w: resolve image %s@%s: %w", ErrImagePullFailed, opts.Registry, opts.Pin.Digest, err)
+	}
+	// A registry that resolves a digest reference to a divergent descriptor is
+	// misbehaving; assert to fail closed rather than boot the served bytes.
+	if desc.Digest.String() != opts.Pin.Digest {
+		return ImagePullResult{}, fmt.Errorf("%w: resolved manifest %s, lock attested %s", ErrImageDigestMismatch, desc.Digest, opts.Pin.Digest)
+	}
+
+	return ImagePullResult{
+		BootRef:     opts.Registry + "@" + opts.Pin.Digest,
+		BindingKind: freeze.BindingManifestDigest,
+		ImageDigest: opts.Pin.Digest,
+	}, nil
+}
+
+// imageConfigDigest fetches an image manifest and returns its config blob digest
+// (a composed pin's attested identity). It mirrors publish's imageConfigDigest so
+// the read and write halves compute the same value.
+func imageConfigDigest(ctx context.Context, fetcher content.Fetcher, manifest ocispec.Descriptor) (string, error) {
+	raw, err := content.FetchAll(ctx, fetcher, manifest)
+	if err != nil {
+		return "", err
+	}
+	var m ocispec.Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", fmt.Errorf("decode image manifest: %w", err)
+	}
+	if m.Config.Digest == "" {
+		return "", fmt.Errorf("image manifest has no config digest")
+	}
+	return m.Config.Digest.String(), nil
+}

--- a/internal/flightplan/pull/image_test.go
+++ b/internal/flightplan/pull/image_test.go
@@ -1,0 +1,357 @@
+package pull
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// seedImage pushes a minimal single-config, single-layer OCI image into st and
+// returns the image manifest descriptor and its config blob descriptor, the same
+// harness publish_test uses. A composed pin binds by the config digest; a
+// foreign-base pin by the manifest digest.
+func seedImage(t *testing.T, st content.Storage, configBody string) (manifest, config ocispec.Descriptor) {
+	t.Helper()
+	ctx := context.Background()
+	cfg := content.NewDescriptorFromBytes(ocispec.MediaTypeImageConfig, []byte(configBody))
+	if err := st.Push(ctx, cfg, bytes.NewReader([]byte(configBody))); err != nil {
+		t.Fatalf("push config: %v", err)
+	}
+	layer := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayerGzip, []byte("layer-bytes"))
+	if err := st.Push(ctx, layer, bytes.NewReader([]byte("layer-bytes"))); err != nil {
+		t.Fatalf("push layer: %v", err)
+	}
+	m := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    cfg,
+		Layers:    []ocispec.Descriptor{layer},
+	}
+	mb, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	md := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, mb)
+	if err := st.Push(ctx, md, bytes.NewReader(mb)); err != nil {
+		t.Fatalf("push manifest: %v", err)
+	}
+	// A real registry resolves a pushed manifest by its digest (a HEAD on the
+	// manifest); the in-memory store only resolves references it was tagged with,
+	// so tag the manifest under its own digest to mirror registry behavior for
+	// the manifest-digest binding's Resolve(pin.Digest) lookup.
+	if tagger, ok := st.(interface {
+		Tag(context.Context, ocispec.Descriptor, string) error
+	}); ok {
+		if err := tagger.Tag(ctx, md, md.Digest.String()); err != nil {
+			t.Fatalf("tag manifest by digest: %v", err)
+		}
+	}
+	return md, cfg
+}
+
+const testRegistry = "example.com/acme/plan"
+
+// composedPin builds a composed-tools pin: LocalTag set, Digest = the config
+// digest. seedComposed tags the image where PullImage's composed branch resolves
+// it (freeze.ComposedImageTag).
+func seedComposed(t *testing.T, st *memory.Store, versionTag, configBody string) (freeze.ImagePin, ocispec.Descriptor) {
+	t.Helper()
+	manifest, cfg := seedImage(t, st, configBody)
+	if err := st.Tag(context.Background(), manifest, freeze.ComposedImageTag(versionTag)); err != nil {
+		t.Fatalf("tag composed image: %v", err)
+	}
+	pin := freeze.ImagePin{
+		Ref:      "aileron/sandbox-tools+tools(gh)",
+		Digest:   cfg.Digest.String(),
+		LocalTag: "aileron/sandbox-tools:abc123",
+	}
+	return pin, manifest
+}
+
+func TestPullImage_ComposedMatchReturnsBootableRef(t *testing.T) {
+	st := memory.New()
+	pin, manifest := seedComposed(t, st, "v1abc", "composed-config-bytes")
+
+	got, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if err != nil {
+		t.Fatalf("PullImage: %v", err)
+	}
+	if got.BindingKind != freeze.BindingConfigDigest {
+		t.Errorf("binding = %q, want %q", got.BindingKind, freeze.BindingConfigDigest)
+	}
+	// The boot ref is content-addressed to the resolved MANIFEST digest, not the
+	// mutable tag: this closes the TOCTOU a tag would leave between verification
+	// and boot. The config-digest binding is still the identity check.
+	wantRef := testRegistry + "@" + manifest.Digest.String()
+	if got.BootRef != wantRef {
+		t.Errorf("boot ref = %q, want the content-addressed manifest ref %q", got.BootRef, wantRef)
+	}
+	if got.ImageDigest != pin.Digest {
+		t.Errorf("image digest = %q, want the config digest %q", got.ImageDigest, pin.Digest)
+	}
+}
+
+func TestPullImage_ComposedMismatchFailsClosed(t *testing.T) {
+	st := memory.New()
+	pin, _ := seedComposed(t, st, "v1abc", "composed-config-bytes")
+	// The lock attests a DIFFERENT config digest than the seeded image carries.
+	pin.Digest = "sha256:" + strings.Repeat("f", 64)
+
+	got, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if !errors.Is(err, ErrImageDigestMismatch) {
+		t.Fatalf("err = %v, want ErrImageDigestMismatch", err)
+	}
+	if got.BootRef != "" {
+		t.Errorf("a mismatch must return no bootable ref, got %q", got.BootRef)
+	}
+}
+
+func TestPullImage_ComposedMissingIsErrImageMissing(t *testing.T) {
+	st := memory.New() // nothing seeded under the composed tag
+	pin := freeze.ImagePin{
+		Ref:      "aileron/sandbox-tools",
+		Digest:   "sha256:" + strings.Repeat("a", 64),
+		LocalTag: "aileron/sandbox-tools:abc",
+	}
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if !errors.Is(err, ErrImageMissing) {
+		t.Fatalf("err = %v, want ErrImageMissing", err)
+	}
+}
+
+func TestPullImage_ManifestDigestMatchReturnsContentAddressedRef(t *testing.T) {
+	st := memory.New()
+	manifest, _ := seedImage(t, st, "foreign-base-config")
+	// An image-only/foreign-base pin: no LocalTag, Digest = the manifest digest.
+	pin := freeze.ImagePin{Ref: "registry.example.com/runner:1.4", Digest: manifest.Digest.String()}
+
+	got, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if err != nil {
+		t.Fatalf("PullImage: %v", err)
+	}
+	if got.BindingKind != freeze.BindingManifestDigest {
+		t.Errorf("binding = %q, want %q", got.BindingKind, freeze.BindingManifestDigest)
+	}
+	wantRef := testRegistry + "@" + manifest.Digest.String()
+	if got.BootRef != wantRef {
+		t.Errorf("boot ref = %q, want %q", got.BootRef, wantRef)
+	}
+}
+
+func TestPullImage_ManifestDigestMissingIsErrImageMissing(t *testing.T) {
+	st := memory.New() // nothing seeded
+	pin := freeze.ImagePin{
+		Ref:    "registry.example.com/runner:1.4",
+		Digest: "sha256:" + strings.Repeat("b", 64),
+	}
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if !errors.Is(err, ErrImageMissing) {
+		t.Fatalf("err = %v, want ErrImageMissing", err)
+	}
+}
+
+// TestPullImage_BindingDerivedFromPinNotAnnotation proves the verification path
+// is governed by freeze.BindingKind(pin), never any registry annotation: a
+// composed pin (LocalTag set) always verifies by config digest even though the
+// image manifest carries no binding annotation at all, and an image-only pin
+// (LocalTag empty) always verifies by manifest digest. Tampering with the
+// annotation cannot flip the binding because the binding is a function of the
+// signed pin, which the tests here supply directly.
+func TestPullImage_BindingDerivedFromPinNotAnnotation(t *testing.T) {
+	// Composed pin over a store whose image manifest has NO annotation.
+	stComposed := memory.New()
+	composedPin, _ := seedComposed(t, stComposed, "v1abc", "cfg")
+	if freeze.BindingKind(composedPin) != freeze.BindingConfigDigest {
+		t.Fatalf("composed pin binding = %q", freeze.BindingKind(composedPin))
+	}
+	got, err := PullImage(context.Background(), ImagePullOptions{
+		Source: stComposed, Registry: testRegistry, VersionTag: "v1abc", Pin: composedPin,
+	})
+	if err != nil {
+		t.Fatalf("composed PullImage: %v", err)
+	}
+	if got.BindingKind != freeze.BindingConfigDigest {
+		t.Errorf("composed binding = %q, want config-digest regardless of annotation", got.BindingKind)
+	}
+
+	// Image-only pin (LocalTag empty): must bind by manifest digest, even though
+	// the exact same underlying image bytes were used above.
+	stForeign := memory.New()
+	manifest, _ := seedImage(t, stForeign, "cfg")
+	foreignPin := freeze.ImagePin{Ref: "registry.example.com/runner:1.4", Digest: manifest.Digest.String()}
+	if freeze.BindingKind(foreignPin) != freeze.BindingManifestDigest {
+		t.Fatalf("foreign pin binding = %q", freeze.BindingKind(foreignPin))
+	}
+	got, err = PullImage(context.Background(), ImagePullOptions{
+		Source: stForeign, Registry: testRegistry, VersionTag: "v1abc", Pin: foreignPin,
+	})
+	if err != nil {
+		t.Fatalf("foreign PullImage: %v", err)
+	}
+	if got.BindingKind != freeze.BindingManifestDigest {
+		t.Errorf("foreign binding = %q, want manifest-digest", got.BindingKind)
+	}
+}
+
+func TestPullImage_NoDigestFailsClosed(t *testing.T) {
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     memory.New(),
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        freeze.ImagePin{Ref: "r", LocalTag: "t"}, // no Digest
+	})
+	if !errors.Is(err, ErrImageDigestMismatch) {
+		t.Fatalf("err = %v, want ErrImageDigestMismatch for a digest-less pin", err)
+	}
+}
+
+func TestPullImage_NoRegistryFailsClosed(t *testing.T) {
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     memory.New(),
+		Registry:   "",
+		VersionTag: "v1abc",
+		Pin:        freeze.ImagePin{Digest: "sha256:x", LocalTag: "t"},
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed for a missing registry", err)
+	}
+}
+
+// resolveErrTarget resolves every reference with a non-not-found error, standing
+// in for an unreachable/unauthenticated registry (NOT a missing image).
+type resolveErrTarget struct {
+	*memory.Store
+	err error
+}
+
+func (r resolveErrTarget) Resolve(context.Context, string) (ocispec.Descriptor, error) {
+	return ocispec.Descriptor{}, r.err
+}
+
+func TestPullImage_ComposedResolveErrorIsPullFailed(t *testing.T) {
+	boom := errors.New("dial tcp: connection refused")
+	src := resolveErrTarget{Store: memory.New(), err: boom}
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:" + strings.Repeat("a", 64), LocalTag: "t"}
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source: src, Registry: testRegistry, VersionTag: "v1abc", Pin: pin,
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed", err)
+	}
+	if errors.Is(err, ErrImageMissing) {
+		t.Errorf("a network error must NOT be classified as ErrImageMissing: %v", err)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want the underlying resolve error inspectable", err)
+	}
+}
+
+// composedFetchFailTarget resolves the composed tag but fails to fetch the
+// manifest bytes, standing in for a registry that serves a descriptor it then
+// cannot back with content.
+type composedFetchFailTarget struct {
+	*memory.Store
+	err error
+}
+
+func (c composedFetchFailTarget) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
+	return nil, c.err
+}
+
+func TestPullImage_ComposedConfigReadErrorIsPullFailed(t *testing.T) {
+	inner := memory.New()
+	pin, _ := seedComposed(t, inner, "v1abc", "cfg")
+	boom := errors.New("manifest read reset")
+	src := composedFetchFailTarget{Store: inner, err: boom}
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source: src, Registry: testRegistry, VersionTag: "v1abc", Pin: pin,
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed", err)
+	}
+	if !strings.Contains(err.Error(), "config") {
+		t.Errorf("err = %v, want a config-read message", err)
+	}
+}
+
+func TestPullImage_ComposedManifestWithoutConfigDigestFailsClosed(t *testing.T) {
+	// A composed image tag pointing at a manifest with an empty config digest
+	// cannot be verified by config digest; the read fails closed rather than
+	// booting an unverifiable image.
+	st := memory.New()
+	ctx := context.Background()
+	m := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		// Config left zero: no digest.
+	}
+	mb, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	md := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, mb)
+	if err := st.Push(ctx, md, bytes.NewReader(mb)); err != nil {
+		t.Fatalf("push manifest: %v", err)
+	}
+	if err := st.Tag(ctx, md, freeze.ComposedImageTag("v1abc")); err != nil {
+		t.Fatalf("tag: %v", err)
+	}
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:" + strings.Repeat("a", 64), LocalTag: "t"}
+	_, err = PullImage(ctx, ImagePullOptions{
+		Source: st, Registry: testRegistry, VersionTag: "v1abc", Pin: pin,
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed for a config-less manifest", err)
+	}
+}
+
+func TestPullImage_ManifestResolveErrorIsPullFailed(t *testing.T) {
+	boom := errors.New("registry 500")
+	src := resolveErrTarget{Store: memory.New(), err: boom}
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:" + strings.Repeat("a", 64)}
+	_, err := PullImage(context.Background(), ImagePullOptions{
+		Source: src, Registry: testRegistry, VersionTag: "v1abc", Pin: pin,
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed", err)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want the underlying resolve error inspectable", err)
+	}
+}

--- a/internal/flightplan/pull/pull.go
+++ b/internal/flightplan/pull/pull.go
@@ -104,6 +104,15 @@ type Result struct {
 	// signer identity). The trust gate has already passed by the time Run
 	// returns.
 	Verified freeze.VerifiedFrozen
+	// SourceRegistry is the parsed registry+repository the artifact was pulled
+	// from (registry.ParseReference over opts.Ref, e.g. "ghcr.io/acme/plan"),
+	// without tag or digest. The CLI persists it as the install origin so launch
+	// (#1903) knows where to pull the published image; it is a fetch coordinate,
+	// never a verification trust anchor.
+	SourceRegistry string
+	// SourceTag is the version tag the artifact resolved under (the freeze slug
+	// that is also the store version id). Persisted alongside SourceRegistry.
+	SourceTag string
 }
 
 // Run resolves the signed artifact at opts.Ref, pulls its four layers, verifies
@@ -159,7 +168,14 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		}
 	}
 
-	return Result{Frozen: fv, Lock: lock, Name: name, Verified: verified}, nil
+	return Result{
+		Frozen:         fv,
+		Lock:           lock,
+		Name:           name,
+		Verified:       verified,
+		SourceRegistry: ref.Registry + "/" + ref.Repository,
+		SourceTag:      tag,
+	}, nil
 }
 
 // fetchArtifact resolves the referrers manifest at tag, asserts it is a Flight

--- a/internal/flightplan/pull/pull_e2e_test.go
+++ b/internal/flightplan/pull/pull_e2e_test.go
@@ -14,6 +14,7 @@ package pull
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -189,5 +190,90 @@ func TestPullE2ERoundTrip(t *testing.T) {
 	}
 	if _, err := repo.Resolve(ctx, versionID); err != nil {
 		t.Fatalf("resolve published artifact tag: %v", err)
+	}
+
+	// Cross-machine launch (#1903): pull and verify the PUBLISHED composed image
+	// against the signed lock pin and confirm PullImage returns a bootable ref.
+	// This is the read side the clean-machine launch takes after WriteOrigin.
+	imgRes, err := PullImage(ctx, ImagePullOptions{
+		Registry:   registry,
+		VersionTag: versionID,
+		Pin:        pin,
+	})
+	if err != nil {
+		t.Fatalf("PullImage (composed): %v", err)
+	}
+	if imgRes.BindingKind != freeze.BindingConfigDigest {
+		t.Errorf("binding = %q, want %q", imgRes.BindingKind, freeze.BindingConfigDigest)
+	}
+	// The boot ref is content-addressed to the composed image's MANIFEST digest
+	// (TOCTOU-closing), not the mutable tag. Resolve the published tag to learn
+	// the manifest digest and assert the boot ref matches.
+	composedDesc, err := repo.Resolve(ctx, freeze.ComposedImageTag(versionID))
+	if err != nil {
+		t.Fatalf("resolve published composed image tag: %v", err)
+	}
+	wantRef := registry + "@" + composedDesc.Digest.String()
+	if imgRes.BootRef != wantRef {
+		t.Errorf("boot ref = %q, want the content-addressed manifest ref %q", imgRes.BootRef, wantRef)
+	}
+	if imgRes.ImageDigest != pin.Digest {
+		t.Errorf("verified image digest = %q, want the config digest %q", imgRes.ImageDigest, pin.Digest)
+	}
+	// The daemon must be able to boot the returned reference: pull it and confirm
+	// the local config digest still equals the attested pin (the same identity
+	// launch's runner relies on).
+	docker(t, "pull", imgRes.BootRef)
+	t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", "-f", imgRes.BootRef).Run() })
+	pulledID := docker(t, "image", "inspect", "--format", "{{.Id}}", imgRes.BootRef)
+	if pulledID != pin.Digest {
+		t.Errorf("pulled image Id = %q, want the attested config digest %q", pulledID, pin.Digest)
+	}
+}
+
+// TestPullImageE2ERefusesTamperedImage proves the fail-closed property against a
+// real registry: publishing a mismatched image under the composed tag and then
+// pulling with a pin that attests a different config digest is refused, never
+// booted. Here the "tamper" is a lock pin that attests a config digest the
+// published image does not carry; PullImage must return ErrImageDigestMismatch.
+func TestPullImageE2ERefusesTamperedImage(t *testing.T) {
+	ctx := e2eContext(t)
+	host := registryHost(t)
+
+	// Publish a real composed image + artifact honestly, then pull with a pin
+	// whose Digest is a config digest the pushed image does NOT carry: the
+	// registry served the honest image, but the signed lock attests a different
+	// identity, so the binding check must refuse.
+	tag, configID := buildLocalImage(t, "aileron/sandbox-tools:e2e-tamper")
+	res, versionID := e2eFrozen(t)
+	registry := host + "/e2e/tamper-plan"
+	honestPin := freeze.ImagePin{Ref: "aileron/sandbox-tools", Digest: configID, LocalTag: tag}
+
+	if _, err := publish.Run(ctx, publish.Options{
+		Name: "e2e-plan", VersionID: versionID, Registry: registry,
+		Frozen: store.FrozenVersion{
+			ID:        versionID,
+			SkillMD:   res.FrozenManifest,
+			Lockfile:  res.Lockfile,
+			Signature: res.Signature,
+			PublicKey: res.PublicKey,
+		},
+		Lock: freeze.Lockfile{ResolvedImages: []freeze.ImagePin{honestPin}},
+	}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	tamperedPin := honestPin
+	tamperedPin.Digest = "sha256:" + strings.Repeat("f", 64)
+	_, err := PullImage(ctx, ImagePullOptions{
+		Registry:   registry,
+		VersionTag: versionID,
+		Pin:        tamperedPin,
+	})
+	if err == nil {
+		t.Fatal("a pin attesting a different config digest must be refused")
+	}
+	if !errors.Is(err, ErrImageDigestMismatch) {
+		t.Fatalf("err = %v, want ErrImageDigestMismatch", err)
 	}
 }

--- a/internal/flightplan/pull/pull_test.go
+++ b/internal/flightplan/pull/pull_test.go
@@ -178,6 +178,14 @@ func TestRunHappyPath(t *testing.T) {
 	if !bytes.Equal(got.Frozen.PublicKey, res.PublicKey) {
 		t.Error("PublicKey bytes differ from published artifact")
 	}
+	// The Result carries the parsed source coordinate so the CLI can persist the
+	// install origin for launch (#1903).
+	if got.SourceRegistry != "localhost:5000/demo" {
+		t.Errorf("source registry = %q, want localhost:5000/demo", got.SourceRegistry)
+	}
+	if got.SourceTag != tag {
+		t.Errorf("source tag = %q, want %q", got.SourceTag, tag)
+	}
 }
 
 func TestRunMissingReferrerIsMissingArtifact(t *testing.T) {

--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -37,6 +37,39 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 		return RunResult{}, fmt.Errorf(
 			"flightplan: frozen unit pins image %q but no image runner is configured", pin.Ref)
 	}
+
+	// Registry-origin boot path (#1903): a plan installed by OCI reference has no
+	// local build, so its bootable image lives in the recorded registry, not the
+	// local daemon. Pull it and verify it against the signed lock pin per the
+	// pin's binding kind (config digest for a composed pin, manifest digest for a
+	// foreign-base pin) through the RegistryImageResolver seam, then boot the
+	// returned reference. This bypasses the local-tag imageRef/#1863 local-daemon
+	// guard, which does not apply to a registry pull: the resolver already
+	// verified the pulled bytes against the signature-covered pin, which is the
+	// same fail-closed property the local guard provides for a locally-built tag.
+	// A registry-origin plan with no resolver is a fail-closed error (there is no
+	// local tag to boot instead), mirroring the nil-ImageRunner discipline.
+	if lp.ImageOrigin.Present {
+		if opts.RegistryImageResolver == nil {
+			return RunResult{}, fmt.Errorf(
+				"flightplan: plan was installed from registry %q but no registry image resolver is configured; cannot pull the published image to boot",
+				lp.ImageOrigin.Registry)
+		}
+		bootRef, err := opts.RegistryImageResolver.Resolve(ctx, lp.ImageOrigin, pin)
+		if err != nil {
+			return RunResult{}, fmt.Errorf(
+				"flightplan: refusing to boot: cannot pull and verify the published image for plan installed from %q: %w",
+				lp.ImageOrigin.Registry, err)
+		}
+		return runBooted(ctx, opts, ImageRunSpec{
+			Image:   bootRef,
+			Name:    opts.Name,
+			Version: opts.Version,
+			Inputs:  opts.Inputs,
+			OutDir:  opts.OutDir,
+		})
+	}
+
 	spec := ImageRunSpec{
 		Image:   imageRef(pin.Ref, pin.Digest, pin.LocalTag),
 		Name:    opts.Name,
@@ -79,6 +112,14 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 				pin.LocalTag, observed, pin.Digest)
 		}
 	}
+	return runBooted(ctx, opts, spec)
+}
+
+// runBooted hands the resolved boot spec to the ImageRunner and maps its result
+// onto the public RunResult. Both the local-tag path and the registry-origin
+// path funnel through here so the runner contract (boot spec.Image verbatim) and
+// the result mapping live in exactly one place.
+func runBooted(ctx context.Context, opts Options, spec ImageRunSpec) (RunResult, error) {
 	res, err := opts.ImageRunner.Run(ctx, spec)
 	if err != nil {
 		return RunResult{}, err

--- a/internal/flightplan/runtime/image_guard_test.go
+++ b/internal/flightplan/runtime/image_guard_test.go
@@ -175,6 +175,72 @@ func TestRunInImage_ComposedPinBootsWhenResolverAbsent(t *testing.T) {
 	}
 }
 
+func TestRunInImage_LocallyFrozenPlanTakesLocalPathNotRegistry(t *testing.T) {
+	// Regression: a locally-frozen composed plan (no origin sidecar, so
+	// ImageOrigin.Present == false) must still take the local-tag #1863 boot
+	// path unchanged and must NEVER consult a wired RegistryImageResolver. This
+	// is the coexistence guarantee: adding the registry-pull branch (#1903) does
+	// not change how a plan frozen on this machine boots.
+	localTag := "aileron/sandbox-tools:0123456789abcdef"
+	imageID := "sha256:" + strings.Repeat("b", 64)
+	lp := composedPin(localTag, imageID) // composedPin leaves ImageOrigin zero
+	if lp.ImageOrigin.Present {
+		t.Fatal("test precondition: a locally-frozen plan must have no registry origin")
+	}
+	runner := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+	localGuard := &fakeImageDigestResolver{digest: imageID} // matches → boots
+	registryResolver := &fakeRegistryImageResolver{bootRef: "should-never-be-used"}
+
+	if _, err := runInImage(context.Background(), lp, Options{
+		Name:                  "tools-plan",
+		Version:               "1.0.0",
+		ImageRunner:           runner,
+		ImageDigestResolver:   localGuard,
+		RegistryImageResolver: registryResolver,
+	}); err != nil {
+		t.Fatalf("runInImage: %v", err)
+	}
+	if registryResolver.called {
+		t.Fatal("a locally-frozen plan must NOT consult the registry resolver")
+	}
+	if !localGuard.called {
+		t.Fatal("a locally-frozen composed plan must take the local-tag #1863 guard path")
+	}
+	if !runner.called || runner.spec.Image != localTag {
+		t.Errorf("booted image = %q, want the local tag %q", runner.spec.Image, localTag)
+	}
+}
+
+func TestRunInImage_LocallyFrozenPlanGuardMismatchStillFailsClosed(t *testing.T) {
+	// Coexistence + fail-closed: a locally-frozen plan whose local tag resolves
+	// to a different digest still fails closed on the local path even when a
+	// registry resolver is wired (the registry path is never entered).
+	localTag := "aileron/sandbox-tools:0123456789abcdef"
+	attested := "sha256:" + strings.Repeat("b", 64)
+	observed := "sha256:" + strings.Repeat("c", 64)
+	lp := composedPin(localTag, attested)
+	runner := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+	localGuard := &fakeImageDigestResolver{digest: observed}
+	registryResolver := &fakeRegistryImageResolver{bootRef: "should-never-be-used"}
+
+	_, err := runInImage(context.Background(), lp, Options{
+		Name:                  "tools-plan",
+		Version:               "1.0.0",
+		ImageRunner:           runner,
+		ImageDigestResolver:   localGuard,
+		RegistryImageResolver: registryResolver,
+	})
+	if err == nil {
+		t.Fatal("a locally-frozen plan with a mismatched local tag must fail closed")
+	}
+	if registryResolver.called {
+		t.Fatal("the registry resolver must not be consulted for a locally-frozen plan")
+	}
+	if runner.called {
+		t.Fatal("a mismatched local guard must not boot")
+	}
+}
+
 func TestRunInImage_GuardSkippedForNonComposedPin(t *testing.T) {
 	// The guard is scoped to composed pins: an image-only / custom-base pin
 	// (LocalTag == "") is booted content-addressed as `ref@digest` and the

--- a/internal/flightplan/runtime/image_test.go
+++ b/internal/flightplan/runtime/image_test.go
@@ -176,6 +176,145 @@ func TestHasWholePlanImage(t *testing.T) {
 	}
 }
 
+// fakeRegistryImageResolver records the origin+pin it was handed and returns a
+// canned bootRef or error, so the registry-origin boot path is testable with no
+// live registry.
+type fakeRegistryImageResolver struct {
+	bootRef   string
+	err       error
+	called    bool
+	gotOrigin RegistryImageOrigin
+	gotPin    freeze.ImagePin
+}
+
+func (f *fakeRegistryImageResolver) Resolve(_ context.Context, origin RegistryImageOrigin, pin freeze.ImagePin) (string, error) {
+	f.called = true
+	f.gotOrigin = origin
+	f.gotPin = pin
+	return f.bootRef, f.err
+}
+
+// registryOriginPlan builds a composed-tools LoadedPlan carrying a registry
+// origin, the shape LoadVerified produces for an OCI-installed plan.
+func registryOriginPlan() LoadedPlan {
+	return LoadedPlan{
+		ContentHash: "sha256:content",
+		ResolvedImages: []freeze.ImagePin{{
+			Ref:      "aileron/sandbox-tools+tools(gh)",
+			Digest:   "sha256:" + strings.Repeat("c", 64),
+			LocalTag: "aileron/sandbox-tools:abc123",
+		}},
+		ImageOrigin: RegistryImageOrigin{
+			Registry:   "ghcr.io/acme/plan",
+			VersionTag: "v1abc",
+			Present:    true,
+		},
+	}
+}
+
+func TestRunInImage_RegistryOriginBootsResolvedRef(t *testing.T) {
+	// A registry-origin plan pulls+verifies the published image through the
+	// RegistryImageResolver seam and boots the returned reference verbatim. The
+	// local-tag imageRef/#1863 guard path is NOT taken: the resolver already
+	// verified the pulled bytes against the signed pin.
+	lp := registryOriginPlan()
+	bootRef := "ghcr.io/acme/plan:v1abc-image"
+	resolver := &fakeRegistryImageResolver{bootRef: bootRef}
+	runner := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+	// A local resolver is also wired to prove it is NOT consulted on this path.
+	localGuard := &fakeImageDigestResolver{digest: "sha256:" + strings.Repeat("z", 64)}
+
+	res, err := runInImage(context.Background(), lp, Options{
+		Name:                  "tools-plan",
+		Version:               "1.0.0",
+		ImageRunner:           runner,
+		RegistryImageResolver: resolver,
+		ImageDigestResolver:   localGuard,
+	})
+	if err != nil {
+		t.Fatalf("runInImage: %v", err)
+	}
+	if !resolver.called {
+		t.Fatal("the registry resolver was never consulted for a registry-origin plan")
+	}
+	if resolver.gotOrigin.Registry != "ghcr.io/acme/plan" || resolver.gotOrigin.VersionTag != "v1abc" {
+		t.Errorf("resolver origin = %+v, want the recorded install origin", resolver.gotOrigin)
+	}
+	if resolver.gotPin.Digest != lp.ResolvedImages[0].Digest {
+		t.Errorf("resolver pin digest = %q, want the signed lock pin", resolver.gotPin.Digest)
+	}
+	if localGuard.called {
+		t.Error("the local-tag #1863 guard must NOT run on the registry-origin path")
+	}
+	if !runner.called {
+		t.Fatal("a verified registry pull must boot: the image runner was never called")
+	}
+	if runner.spec.Image != bootRef {
+		t.Errorf("booted image = %q, want the resolver's returned ref %q", runner.spec.Image, bootRef)
+	}
+	if res.ContentHash != "sha256:content" {
+		t.Errorf("RunResult not mapped from the boot, got %+v", res)
+	}
+}
+
+func TestRunInImage_RegistryOriginResolverErrorRefusesBoot(t *testing.T) {
+	// A pull/verify failure from the resolver refuses the boot with a precise
+	// message and never calls the runner.
+	lp := registryOriginPlan()
+	boom := errors.New("pull: pulled image does not match the signed lock digest")
+	resolver := &fakeRegistryImageResolver{err: boom}
+	runner := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+
+	res, err := runInImage(context.Background(), lp, Options{
+		Name:                  "tools-plan",
+		Version:               "1.0.0",
+		ImageRunner:           runner,
+		RegistryImageResolver: resolver,
+	})
+	if err == nil {
+		t.Fatal("a resolver pull/verify failure must refuse the boot")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error = %v, want the wrapped resolver error", err)
+	}
+	if !strings.Contains(err.Error(), "ghcr.io/acme/plan") {
+		t.Errorf("error = %q, want the registry named", err.Error())
+	}
+	if runner.called {
+		t.Fatal("a refused registry pull must NOT boot the image runner")
+	}
+	if res.ContentHash != "" {
+		t.Errorf("a refused boot must produce a zero RunResult, got %+v", res)
+	}
+}
+
+func TestRunInImage_RegistryOriginNilResolverFailsClosed(t *testing.T) {
+	// A registry-origin plan with no RegistryImageResolver is a fail-closed
+	// error: there is no local tag to boot instead, so the runtime must refuse
+	// rather than fall through to the local-tag path.
+	lp := registryOriginPlan()
+	runner := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:content"}}
+
+	res, err := runInImage(context.Background(), lp, Options{
+		Name:        "tools-plan",
+		Version:     "1.0.0",
+		ImageRunner: runner,
+		// RegistryImageResolver intentionally nil.
+	})
+	if err == nil {
+		t.Fatal("a registry-origin plan with no registry resolver must fail closed")
+	}
+	if !strings.Contains(err.Error(), "no registry image resolver is configured") {
+		t.Errorf("error = %q, want a no-resolver-configured message", err.Error())
+	}
+	if runner.called {
+		t.Fatal("a fail-closed registry-origin boot must NOT call the image runner")
+	}
+	if res.ContentHash != "" {
+		t.Errorf("a refused boot must produce a zero RunResult, got %+v", res)
+	}
+}
+
 func TestImageRef_JoinsRefAndDigest(t *testing.T) {
 	got := imageRef("registry.example.com/runner:1.4", "sha256:abc", "")
 	if got != "registry.example.com/runner:1.4@sha256:abc" {

--- a/internal/flightplan/runtime/load.go
+++ b/internal/flightplan/runtime/load.go
@@ -52,6 +52,14 @@ type LoadedPlan struct {
 	// membership in the keyring for the declared Publisher. Populated only on
 	// the verified path.
 	SignerKey ed25519.PublicKey
+	// ImageOrigin is the recorded install source for a plan installed by OCI
+	// reference (#1902/#1903), read from the store's non-signed origin sidecar.
+	// Present is true only when the version directory carries the sidecar (an
+	// OCI install); a locally-frozen plan leaves it zero, which is exactly the
+	// signal runInImage uses to stay on the local-tag boot path. The origin is
+	// a fetch coordinate, NOT a verification trust anchor: the pulled image is
+	// still verified against the signature-covered ResolvedImages pin.
+	ImageOrigin RegistryImageOrigin
 }
 
 // LoadVerified loads a frozen skill version from the store, verifies it
@@ -71,7 +79,28 @@ func LoadVerified(s *store.Store, name, id string) (LoadedPlan, error) {
 	if err != nil {
 		return LoadedPlan{}, &LoadError{Reason: fmt.Sprintf("read frozen version %s/%s: %v", name, id, err)}
 	}
-	return verifyAndDecode(fv)
+	lp, err := verifyAndDecode(fv)
+	if err != nil {
+		return LoadedPlan{}, err
+	}
+	// Read the non-signed install-origin sidecar so runInImage can pull and
+	// verify the published image for an OCI-installed plan (#1903). A locally
+	// frozen version has no sidecar (ok=false) and stays on the local-tag boot
+	// path. A malformed sidecar is a hard error rather than a silent local-path
+	// fallback: a version that recorded an origin but cannot report it must not
+	// boot down the wrong path.
+	origin, ok, err := s.ReadOrigin(name, id)
+	if err != nil {
+		return LoadedPlan{}, &LoadError{Reason: fmt.Sprintf("read install origin %s/%s: %v", name, id, err)}
+	}
+	if ok {
+		lp.ImageOrigin = RegistryImageOrigin{
+			Registry:   origin.Registry,
+			VersionTag: origin.VersionTag,
+			Present:    true,
+		}
+	}
+	return lp, nil
 }
 
 // verifyAndDecode is the verify→parse→decode core, factored out so tests can

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -278,3 +278,46 @@ func TestLoadVerified_UnknownVersionRefuses(t *testing.T) {
 		t.Fatal("an unknown version must refuse to load")
 	}
 }
+
+func TestLoadVerified_LocallyFrozenHasNoImageOrigin(t *testing.T) {
+	// A version written without an origin sidecar (a local freeze) loads with a
+	// zero ImageOrigin, the signal runInImage uses to stay on the local-tag path.
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	lp, err := LoadVerified(s, "weekly-metrics-digest", "test")
+	if err != nil {
+		t.Fatalf("LoadVerified: %v", err)
+	}
+	if lp.ImageOrigin.Present {
+		t.Errorf("locally-frozen plan has ImageOrigin.Present = true; want false")
+	}
+}
+
+func TestLoadVerified_OCIInstalledCarriesImageOrigin(t *testing.T) {
+	// A version with an origin sidecar (an OCI install) loads with the recorded
+	// registry origin, so runInImage takes the registry-pull boot path.
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	if err := s.WriteOrigin("weekly-metrics-digest", "test", store.Origin{
+		Registry:   "ghcr.io/acme/plan",
+		VersionTag: "test",
+	}); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+	lp, err := LoadVerified(s, "weekly-metrics-digest", "test")
+	if err != nil {
+		t.Fatalf("LoadVerified: %v", err)
+	}
+	if !lp.ImageOrigin.Present {
+		t.Fatal("OCI-installed plan has ImageOrigin.Present = false; want true")
+	}
+	if lp.ImageOrigin.Registry != "ghcr.io/acme/plan" || lp.ImageOrigin.VersionTag != "test" {
+		t.Errorf("ImageOrigin = %+v, want the recorded origin", lp.ImageOrigin)
+	}
+}

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -57,6 +57,19 @@ type Options struct {
 	// attested image is absent). Nil (the zero value) skips the guard and boots as
 	// before (backward-compatible), mirroring the ImageRunner nil-guard discipline.
 	ImageDigestResolver LocalImageDigestResolver
+	// RegistryImageResolver pulls and verifies the published image for a plan
+	// installed by OCI reference (#1903). It is consulted ONLY when the loaded
+	// plan carries a registry origin (LoadedPlan.ImageOrigin.Present): such a
+	// plan has no local build, so runInImage pulls the published image from the
+	// recorded registry, verifies it against the signed lock pin per the pin's
+	// binding kind, and boots the returned reference. When the plan needs this
+	// seam (a registry origin) but it is nil, the boot is a fail-closed error,
+	// never a silent fall-through to the local-tag path (a plan installed from a
+	// registry has no local tag to boot). A locally-frozen plan (no origin)
+	// never touches this seam and boots by its local tag as before. The CLI
+	// wires the production impl over pull.PullImage and nils it on the image-boot
+	// re-entry (the sentinel routes in-process before any boot).
+	RegistryImageResolver RegistryImageResolver
 	// ToolRunner executes a `kind: tool` step as a deterministic subprocess in
 	// the current pinned environment (#1829). Unlike ImageRunner, the plan
 	// orchestration stays in-process (runPlan); the tool step never dispatches

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "context"
+import (
+	"context"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+)
 
 // The SPIs in this file are the thin seams the runtime core depends on so it
 // stays unit-testable with fakes. The CLI (cmd/aileron) wires each one to the
@@ -273,6 +277,44 @@ type ToolStepResult struct {
 // is not present, so the boot must refuse rather than boot an unverified tag.
 type LocalImageDigestResolver interface {
 	Resolve(ctx context.Context, image string) (string, error)
+}
+
+// RegistryImageOrigin is the recorded install source of a plan installed by OCI
+// reference (#1902/#1903): the registry+repository the signed artifact was
+// pulled from and the version tag it was published under. Present is false for a
+// locally-frozen plan, which has no origin sidecar and boots by its local tag.
+// It answers only WHERE to pull the published image; the signed lock pin answers
+// WHAT to verify, so this carries no trust anchor.
+type RegistryImageOrigin struct {
+	// Registry is the registry+repository the published image lives in (e.g.
+	// "ghcr.io/acme/plan"), without tag or digest.
+	Registry string
+	// VersionTag is the store version id (freeze slug) the artifact was published
+	// under; the composed image was published under a tag derived from it.
+	VersionTag string
+	// Present reports whether the loaded plan carries a registry origin. When
+	// false, the runtime stays on the local-tag boot path; when true, the runtime
+	// pulls and verifies the published image via RegistryImageResolver.
+	Present bool
+}
+
+// RegistryImageResolver pulls a published composed (or foreign-base) image from
+// the recorded registry origin and verifies it against the signed lock pin under
+// the pin's binding kind (freeze.BindingKind), returning a bootable reference
+// (#1903). The runtime core depends only on this seam; the CLI (cmd/aileron)
+// wires the production implementation over pull.PullImage, so the runtime never
+// imports oras/registry code (mirroring the ImageRunner discipline).
+//
+// Its contract, consumed ONLY when a loaded plan carries a registry origin
+// (RegistryImageOrigin.Present): pull the published image the origin points at,
+// verify it equals the signature-covered pin.Digest per the pin's binding, and
+// return a content-addressed bootable "ref@manifest-digest" (both binding kinds
+// anchor the boot to a manifest digest so a mutable tag is never booted after
+// verification). Any mismatch, missing image, or pull failure is a fail-closed
+// error and no reference: a registry-origin plan must never boot an unverified
+// image.
+type RegistryImageResolver interface {
+	Resolve(ctx context.Context, origin RegistryImageOrigin, pin freeze.ImagePin) (bootRef string, err error)
 }
 
 // ToolStepRunner executes a single `kind: tool` step as a subprocess in the

--- a/internal/flightplan/store/origin.go
+++ b/internal/flightplan/store/origin.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// originFile is the non-signed sidecar recording where an OCI-installed frozen
+// version was pulled from. It lives in the version directory alongside the four
+// signed artifacts but is deliberately NOT part of them: it is never covered by
+// the signature and never trusted for verification. It only records WHERE to
+// fetch the published image at launch (#1903); every fetched byte is still
+// verified against the signed lock's pin digest. A locally-frozen version has
+// no origin sidecar, which is exactly the signal launch uses to stay on the
+// local-tag boot path.
+const originFile = "origin.json"
+
+// Origin records the install source of an OCI-installed frozen version: the
+// registry+repository the signed artifact was pulled from and the version tag it
+// was published under. Launch derives the published composed image tag from the
+// version id (freeze.ComposedImageTag) and pulls it from Registry, then verifies
+// the pulled bytes against the signed lock pin. Neither field is a trust anchor
+// for verification; they answer only "where to fetch".
+type Origin struct {
+	// Registry is the source registry+repository the signed artifact was pulled
+	// from (e.g. "ghcr.io/acme/plan"), without tag or digest. Launch resolves the
+	// published image in this repository.
+	Registry string `json:"registry"`
+	// VersionTag is the tag the signed artifact was published under (the freeze
+	// slug that is also the store version id). Recorded for provenance and so a
+	// future consumer that needs the artifact tag has it without re-deriving.
+	VersionTag string `json:"versionTag"`
+}
+
+// WriteOrigin writes the install-origin sidecar for a frozen version into its
+// version directory. It is idempotent: an identical rewrite is a no-op, and a
+// differing rewrite overwrites the sidecar (the origin is non-signed provenance,
+// not immutable content, so re-installing the same version from a different
+// registry legitimately updates where launch pulls from). The write is atomic
+// (temp file + rename) so a crash never leaves a partially written sidecar a
+// later launch would misparse.
+//
+// WriteOrigin does NOT participate in the signed-artifact immutability check
+// (verifyFrozenIdentical): re-installing or re-freezing a version stays a
+// verified no-op on the signed files while the sidecar tracks the latest source.
+func (s *Store) WriteOrigin(name, id string, o Origin) error {
+	if name == "" {
+		return fmt.Errorf("store: origin write needs a skill name")
+	}
+	if err := validVersionID(id); err != nil {
+		return err
+	}
+	dir := s.FrozenDir(name, id)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("store: cannot write origin for missing frozen version %s/%s", name, id)
+		}
+		return fmt.Errorf("store: stat frozen version dir: %w", err)
+	}
+
+	data, err := json.Marshal(o)
+	if err != nil {
+		return fmt.Errorf("store: encode origin: %w", err)
+	}
+	dst := filepath.Join(dir, originFile)
+	// An identical rewrite is a no-op so a re-install of the same version from
+	// the same source does not churn the file (and its mtime).
+	if existing, err := os.ReadFile(dst); err == nil && bytes.Equal(existing, data) {
+		return nil
+	}
+
+	tmp, err := os.CreateTemp(dir, originFile+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("store: create temp origin file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("store: write origin: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("store: close origin: %w", err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return fmt.Errorf("store: finalize origin: %w", err)
+	}
+	return nil
+}
+
+// ReadOrigin returns the install-origin sidecar for a frozen version. ok is
+// false with a nil error when the version has no sidecar (a locally-frozen
+// version), which is the signal launch uses to stay on the local-tag boot path.
+// A malformed sidecar is a hard error rather than a silent local-path fallback:
+// a version that recorded an origin but cannot report it must not be treated as
+// locally frozen.
+func (s *Store) ReadOrigin(name, id string) (Origin, bool, error) {
+	if err := validVersionID(id); err != nil {
+		return Origin{}, false, err
+	}
+	data, err := os.ReadFile(filepath.Join(s.FrozenDir(name, id), originFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Origin{}, false, nil
+		}
+		return Origin{}, false, fmt.Errorf("store: read origin %s/%s: %w", name, id, err)
+	}
+	var o Origin
+	if err := json.Unmarshal(data, &o); err != nil {
+		return Origin{}, false, fmt.Errorf("store: decode origin %s/%s: %w", name, id, err)
+	}
+	return o, true, nil
+}

--- a/internal/flightplan/store/origin_test.go
+++ b/internal/flightplan/store/origin_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadOrigin_RoundTrip(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1abc")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	want := Origin{Registry: "ghcr.io/acme/plan", VersionTag: "v1abc"}
+	if err := s.WriteOrigin("demo", "v1abc", want); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+	got, ok, err := s.ReadOrigin("demo", "v1abc")
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReadOrigin ok = false, want a recorded origin")
+	}
+	if got != want {
+		t.Errorf("origin = %+v, want %+v", got, want)
+	}
+}
+
+func TestReadOrigin_AbsentSidecarIsNotOK(t *testing.T) {
+	// A locally-frozen version has no sidecar: ReadOrigin returns ok=false with
+	// no error, the signal launch uses to stay on the local-tag boot path.
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1abc")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	_, ok, err := s.ReadOrigin("demo", "v1abc")
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if ok {
+		t.Fatal("ReadOrigin ok = true for a version with no sidecar; want false")
+	}
+}
+
+func TestWriteOrigin_IdenticalRewriteIsNoOp(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1abc")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	o := Origin{Registry: "ghcr.io/acme/plan", VersionTag: "v1abc"}
+	if err := s.WriteOrigin("demo", "v1abc", o); err != nil {
+		t.Fatalf("WriteOrigin (first): %v", err)
+	}
+	path := filepath.Join(s.FrozenDir("demo", "v1abc"), originFile)
+	fi1, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat origin: %v", err)
+	}
+	if err := s.WriteOrigin("demo", "v1abc", o); err != nil {
+		t.Fatalf("WriteOrigin (identical rewrite): %v", err)
+	}
+	fi2, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat origin after rewrite: %v", err)
+	}
+	if !fi1.ModTime().Equal(fi2.ModTime()) {
+		t.Errorf("identical rewrite changed mtime %v -> %v; want a no-op", fi1.ModTime(), fi2.ModTime())
+	}
+}
+
+func TestWriteOrigin_DifferingRewriteUpdatesSource(t *testing.T) {
+	// The origin is non-signed provenance, not immutable content: re-installing
+	// the same version from a different registry updates where launch pulls from.
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1abc")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	if err := s.WriteOrigin("demo", "v1abc", Origin{Registry: "ghcr.io/acme/plan", VersionTag: "v1abc"}); err != nil {
+		t.Fatalf("WriteOrigin (first): %v", err)
+	}
+	updated := Origin{Registry: "registry.internal/mirror/plan", VersionTag: "v1abc"}
+	if err := s.WriteOrigin("demo", "v1abc", updated); err != nil {
+		t.Fatalf("WriteOrigin (update): %v", err)
+	}
+	got, ok, err := s.ReadOrigin("demo", "v1abc")
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if !ok || got != updated {
+		t.Errorf("origin = %+v ok=%v, want %+v", got, ok, updated)
+	}
+}
+
+func TestWriteOrigin_MissingVersionErrors(t *testing.T) {
+	s := New(t.TempDir())
+	err := s.WriteOrigin("demo", "v1abc", Origin{Registry: "ghcr.io/acme/plan", VersionTag: "v1abc"})
+	if err == nil {
+		t.Fatal("WriteOrigin on a missing frozen version must error")
+	}
+}
+
+func TestReadOrigin_MalformedSidecarErrors(t *testing.T) {
+	// A malformed sidecar is a hard error, not a silent local-path fallback: a
+	// version that recorded an origin but cannot report it must not be mistaken
+	// for locally frozen.
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1abc")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	path := filepath.Join(s.FrozenDir("demo", "v1abc"), originFile)
+	if err := os.WriteFile(path, []byte("{ not json"), 0o644); err != nil {
+		t.Fatalf("write malformed sidecar: %v", err)
+	}
+	_, ok, err := s.ReadOrigin("demo", "v1abc")
+	if err == nil {
+		t.Fatal("ReadOrigin on a malformed sidecar must error")
+	}
+	if ok {
+		t.Error("ReadOrigin ok = true on a malformed sidecar; want false")
+	}
+}
+
+func TestWriteOrigin_InvalidVersionIDRejected(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteOrigin("demo", "../escape", Origin{Registry: "r", VersionTag: "t"}); err == nil {
+		t.Fatal("WriteOrigin must reject a version id that is not a single path segment")
+	}
+}


### PR DESCRIPTION
## Summary

`aileron skill launch <name>` can now boot a **published** plan's image on a machine that never froze it. Before this change, the composed-tools boot path only knew how to boot a `LocalTag` present in the local daemon and failed closed when it was absent. For a plan installed by OCI reference (#1950) there is no local build, so launch now pulls the published image from the registry, verifies the pulled bytes against the signed lock using the **pin-type-correct** digest binding (`freeze.BindingKind`), and boots it. The local-build path (locally-frozen plans + the #1863 guard) is untouched.

The registry coordinate is not recoverable from what install persists, so install now records a small **non-signed** `origin.json` sidecar (`{registry, versionTag}`) in the version directory. It says only *where* to fetch; every fetched byte is still verified against the signature-covered `pin.Digest`. Its presence is exactly the signal launch uses to take the registry-pull path — locally-frozen versions have no sidecar and stay on the local-tag path.

### Key design properties
- **Boot-straight-from-the-verified-lock, TOCTOU-closed.** Both binding kinds return a **content-addressed** `ref@manifest-digest` boot reference. For a composed pin the resolved manifest is config-digest-verified against the signed lock, then the boot is anchored to that manifest digest so a mutable tag can never be booted after verification.
- **Binding is authoritative from `freeze.BindingKind(pin)`**, never the `ai.aileron.binding-kind` annotation (explicitly tested with an annotation-independent case).
- **Fail closed:** mismatch, missing image, or pull failure returns a typed error (`ErrImageMissing`/`ErrImageDigestMismatch`/`ErrImagePullFailed`) and never boots.
- **Coexistence:** locally-frozen plans keep the existing local-tag boot + #1863 guard (regression-tested).
- **Multi-identity unchanged:** the pulled image holds no credential; the daemon proxy injects the launcher's vault credential at egress; audit stamps `operatorActorID`.
- All oras/registry code stays in `internal/flightplan/pull`; `cmd/aileron` and `internal/flightplan/runtime` stay oras-free.

### Scope
No OpenAPI/daemon-endpoint change: the pull is a direct registry operation from the CLI (like install), so `openapi.yaml` / `task generate:api` are out of scope.

## Test plan
- `go test ./internal/flightplan/store/...` — origin sidecar write/read round-trip, `ok=false` when absent, idempotent identical rewrite (no mtime churn), differing-content update, malformed-sidecar hard error, invalid version id rejected.
- `go test ./internal/flightplan/pull/...` — `PullImage` composed match → content-addressed ref, composed mismatch → `ErrImageDigestMismatch`, manifest-digest match/mismatch, missing image → `ErrImageMissing`, binding derived from pin not annotation, config-read/resolve failure paths; `Result` carries parsed source registry/tag.
- `go test ./internal/flightplan/runtime/...` — registry-origin plan boots the resolver's verified ref; resolver error refuses boot; nil resolver on a registry-origin plan fails closed; **local-tag regression**: a locally-frozen plan still takes the #1863 path and never consults the registry resolver; `LoadVerified` populates `ImageOrigin` only when the sidecar is present.
- `go test ./cmd/aileron/...` — install writes the origin sidecar; registry-origin launch invokes the resolver seam and boots its ref; resolver error and nil resolver exit 1 with precise messages; attribution stays `operatorActorID`.
- `go test -tags integration_publish ./internal/flightplan/pull/...` (real `registry:2` + docker) — publish a composed image, pull+verify it back to a content-addressed boot ref, `docker pull` it and confirm the local config digest equals the attested pin; plus a tampered-pin refusal case.
- CodeRabbit review clean (0 findings) after addressing a TOCTOU finding on the composed boot ref.

Closes #1903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
