### PR TITLE
test(flightplan): cover OCI-ref Install guard; fix stale fetchArtifact doc

### DIFF
--- a/internal/flightplan/pull/pull.go
+++ b/internal/flightplan/pull/pull.go
@@ -178,9 +178,11 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	}, nil
 }
 
-// fetchArtifact resolves the referrers manifest at tag, asserts it is a Flight
-// Plan signed artifact with all four layers, and pulls each layer by media type
-// into a store.FrozenVersion (ID = tag). It does not touch the image subject.
+// fetchArtifact resolves the artifact manifest directly at the version tag,
+// asserts it is a Flight Plan signed artifact with all four layers, and pulls
+// each layer by media type into a store.FrozenVersion (ID = tag). The artifact
+// is a first-class tagged manifest, so this is a plain Resolve + FetchAll of the
+// tag; it does not walk the OCI Referrers API or touch any image subject.
 func fetchArtifact(ctx context.Context, src oras.ReadOnlyTarget, tag string) (store.FrozenVersion, freeze.Lockfile, error) {
 	desc, err := src.Resolve(ctx, tag)
 	if err != nil {

--- a/internal/flightplan/store/install_test.go
+++ b/internal/flightplan/store/install_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
@@ -292,5 +293,19 @@ func TestInstallSkillWithoutNameRejected(t *testing.T) {
 	src := writeSkill(t, "---\ndescription: no name here\n---\nbody\n")
 	if _, err := s.Install(context.Background(), src, InstallOptions{}); err == nil {
 		t.Error("expected error for a skill with no name")
+	}
+}
+
+// TestInstallOCIRefRejected drives Install with a source that classifies as an
+// OCI reference and asserts the fetchToDir SourceOCIRef guard fires with a clear
+// message. OCI refs must go through the frozen-version pull path, never Install.
+func TestInstallOCIRefRejected(t *testing.T) {
+	s := New(t.TempDir())
+	_, err := s.Install(context.Background(), "ghcr.io/acme/plan:v1", InstallOptions{})
+	if err == nil {
+		t.Fatal("expected an error installing an OCI reference, got nil")
+	}
+	if !strings.Contains(err.Error(), "is an OCI reference") {
+		t.Errorf("expected error to explain the OCI reference, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Two small, high-confidence cleanup fixes for cw-review-residual #1949 (sub-issue #1902), addressing the unmet halves of two plan findings:

1. **OCI-ref Install guard regression test.** The `SourceOCIRef` guard shipped in `store/source.go`/`fetchToDir`, but no store-level test drove `Store.Install` with an OCI ref to exercise it. Adds `TestInstallOCIRefRejected` in `internal/flightplan/store/install_test.go` calling `s.Install(ctx, "ghcr.io/acme/plan:v1", InstallOptions{})` and asserting the returned error contains `"is an OCI reference"`.

2. **Stale `fetchArtifact` doc comment.** `pull/pull.go` `fetchArtifact` does a plain `src.Resolve(ctx, tag)` + `content.FetchAll` of the version tag — a direct artifact-manifest resolve, never the OCI Referrers API on an image subject. The leading doc comment said "resolves the referrers manifest at tag"; corrected to describe the direct tagged-manifest resolve. Comment only, no behavior change.

## Test plan

- `go test ./internal/flightplan/store/... ./internal/flightplan/pull/...` — green.
- `go test -run TestInstallOCIRefRejected -v` — PASS; asserts the guard's `"is an OCI reference"` message.
- `go vet` clean; `go build ./internal/...` clean.

Relates to #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OCI-style artifact references by rejecting unsupported OCI references with a clear error message.
* **Tests**
  * Added coverage to verify installation fails when an OCI reference is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->