### PR TITLE
fix(skill): op-label publisher refusals so install path doesn't say 'launch'

### DIFF
--- a/cmd/aileron/skill_install_oci.go
+++ b/cmd/aileron/skill_install_oci.go
@@ -32,7 +32,7 @@ var skillPullRun = pull.Run
 // re-entry), so it always wires the real verifier; the pull path still skips
 // the gate for a plan that declares no publisher.
 var newInstallPublisherVerifier = func(diag io.Writer) pull.PublisherVerifier {
-	return keyringPublisherVerifier{path: cstore.DefaultKeyringPath(), diag: diag}
+	return keyringPublisherVerifier{path: cstore.DefaultKeyringPath(), op: "install", diag: diag}
 }
 
 // runSkillInstallOCI installs a published Flight Plan by OCI reference: it pulls

--- a/cmd/aileron/skill_launch_publisher.go
+++ b/cmd/aileron/skill_launch_publisher.go
@@ -25,8 +25,24 @@ type keyringPublisherVerifier struct {
 	// as a missing file (empty keyring), so an unresolvable path fails closed
 	// for a publisher-declaring plan rather than skipping the gate.
 	path string
+	// op labels the operation this verifier gates ("launch" or "install") so
+	// the fail-closed refusals read for the command the operator actually ran.
+	// The same keyringPublisherVerifier is wired on both the launch and install
+	// paths (#1900); only the message prefix and the trust-remediation tail
+	// differ by op. Empty defaults to "launch" so a zero-value struct (as some
+	// tests construct) keeps the historical launch wording.
+	op string
 	// diag receives the one-line trust/conflict diagnostic. Nil suppresses it.
 	diag io.Writer
+}
+
+// opLabel returns the operation label for the refusal prefix, defaulting an
+// empty op to "launch" so a zero-value verifier keeps the historical wording.
+func (v keyringPublisherVerifier) opLabel() string {
+	if v.op == "" {
+		return "launch"
+	}
+	return v.op
 }
 
 // VerifyPublisher implements runtime.PublisherVerifier. It loads the keyring,
@@ -40,16 +56,16 @@ func (v keyringPublisherVerifier) VerifyPublisher(publisher string, signingKey e
 		// A malformed keyring is surfaced rather than silently failing closed,
 		// so the operator sees the parse error instead of a misleading
 		// "publisher not trusted" for an authority they believe they trusted.
-		return fmt.Errorf("skill launch: load keyring %q: %w", v.path, err)
+		return fmt.Errorf("skill %s: load keyring %q: %w", v.opLabel(), v.path, err)
 	}
 	res, err := keyring.PublisherTrust(publisher, signingKey)
 	if err != nil {
-		return fmt.Errorf("skill launch: resolve publisher trust for %s: %w", publisher, err)
+		return fmt.Errorf("skill %s: resolve publisher trust for %s: %w", v.opLabel(), publisher, err)
 	}
 	if !res.Trusted {
 		return fmt.Errorf(
-			"skill launch: publisher %s is not trusted for this plan's signing key (%s); trust it with `aileron keyring trust %s` or launch a plan you trust",
-			publisher, fingerprint(signingKey), publisher)
+			"skill %s: publisher %s is not trusted for this plan's signing key (%s); trust it with `aileron keyring trust %s` or %s a plan you trust",
+			v.opLabel(), publisher, fingerprint(signingKey), publisher, v.opLabel())
 	}
 	if v.diag != nil {
 		if res.Conflict {
@@ -68,5 +84,5 @@ func (v keyringPublisherVerifier) VerifyPublisher(publisher string, signingKey e
 // plan that declares no publisher, so a publisher-less plan launches whether or
 // not this verifier is wired.
 var newLaunchPublisherVerifier = func(diag io.Writer) runtime.PublisherVerifier {
-	return keyringPublisherVerifier{path: cstore.DefaultKeyringPath(), diag: diag}
+	return keyringPublisherVerifier{path: cstore.DefaultKeyringPath(), op: "launch", diag: diag}
 }

--- a/cmd/aileron/skill_launch_publisher_test.go
+++ b/cmd/aileron/skill_launch_publisher_test.go
@@ -89,6 +89,50 @@ func TestKeyringPublisherVerifier_UntrustedFailsClosed(t *testing.T) {
 	}
 }
 
+// TestKeyringPublisherVerifier_RefusalPrefixByOp proves the fail-closed refusal
+// prefix and the trust-remediation tail read for the operation the verifier
+// gates: a launch verifier (or a zero-value op, the historical default) says
+// "skill launch:" and "... or launch a plan you trust", while an install
+// verifier says "skill install:" and "... or install a plan you trust". The
+// shared keyringPublisherVerifier is wired on both paths (#1900), so an install
+// refusal must not read with launch wording.
+func TestKeyringPublisherVerifier_RefusalPrefixByOp(t *testing.T) {
+	trusted, _ := genKeyPair(t)
+	planKey, _ := genKeyPair(t)
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	writeOwnerKeyring(t, path, "github://acme", trusted)
+
+	cases := []struct {
+		name       string
+		op         string
+		wantPrefix string
+		wantTail   string
+	}{
+		{name: "default op is launch", op: "", wantPrefix: "skill launch:", wantTail: "or launch a plan you trust"},
+		{name: "explicit launch", op: "launch", wantPrefix: "skill launch:", wantTail: "or launch a plan you trust"},
+		{name: "install", op: "install", wantPrefix: "skill install:", wantTail: "or install a plan you trust"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := keyringPublisherVerifier{path: path, op: tc.op}
+			err := v.VerifyPublisher("github://acme/plans", planKey)
+			if err == nil {
+				t.Fatal("an untrusted signing key must fail closed")
+			}
+			if !strings.HasPrefix(err.Error(), tc.wantPrefix) {
+				t.Errorf("error = %q, want prefix %q", err.Error(), tc.wantPrefix)
+			}
+			if !strings.Contains(err.Error(), tc.wantTail) {
+				t.Errorf("error = %q, want tail %q", err.Error(), tc.wantTail)
+			}
+			// The remediation hint is op-agnostic and must always be present.
+			if !strings.Contains(err.Error(), "aileron keyring trust github://acme/plans") {
+				t.Errorf("error = %q, want the keyring-trust remediation hint", err.Error())
+			}
+		})
+	}
+}
+
 // TestKeyringPublisherVerifier_RevokedFailsClosed proves that after the
 // trusted key is revoked (removed from the keyring on disk), a subsequent
 // verify fails closed because the verifier re-reads the keyring each call.


### PR DESCRIPTION
## Summary

The shared `keyringPublisherVerifier` (#1900) is wired verbatim on both the launch and install paths (`skill_install_oci.go` reuses the same seam as `skill_launch_publisher.go`). Its fail-closed refusals hardcoded `skill launch:` and `... or launch a plan you trust`, so `aileron skill install` emitted launch-worded refusals.

This parameterizes the verifier with an `op` field (values `"launch"`/`"install"`; empty defaults to `"launch"` so a zero-value struct keeps the historical wording) and threads it through the three `VerifyPublisher` refusals plus the trust-remediation tail. Trust-resolution logic is untouched; only the message prefix and tail vary by op.

- `newLaunchPublisherVerifier` sets `op:"launch"`.
- `newInstallPublisherVerifier` sets `op:"install"`.
- The op-agnostic `` `aileron keyring trust <publisher>` `` remediation hint is preserved on both paths.

## Test plan

- New table test `TestKeyringPublisherVerifier_RefusalPrefixByOp` asserts the refusal prefix and tail for the default (`launch`), explicit `launch`, and `install` ops, plus the shared remediation hint. It fails before this change on the `install` case (refusal read `skill launch:`).
- `go build ./cmd/aileron/...` clean.
- `go vet ./cmd/aileron/...` clean.
- `go test ./cmd/aileron/...` passes (full package, including all existing publisher-verifier and install/launch tests).

Closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trust-related error messages during skill install and launch so they clearly identify the operation being performed.
  * Clarified the guidance shown when a publisher is not trusted, making it easier to follow the recommended next step.
  * Kept default launch behavior intact while making install-specific messaging more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->