### PR TITLE
feat(flightplan): add enum/pattern resolution constraints on declared inputs

### DIFF
--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -328,8 +328,38 @@
           "type": "string",
           "description": "Human-readable semantics of the input."
         },
-        "resolution": { "$ref": "#/$defs/resolution" }
+        "resolution": { "$ref": "#/$defs/resolution" },
+        "constraint": { "$ref": "#/$defs/inputConstraint" }
       }
+    },
+    "inputConstraint": {
+      "type": "object",
+      "description": "OPTIONAL resolution constraint bounding the resolved value. Exactly one of enum or pattern. A bad shape (both present, an empty enum, an empty pattern) fails closed at freeze/decode; an out-of-constraint resolved value is rejected at the launch/resolution boundary. JSON Schema validates only the shape; RE2 compilability of a pattern is checked at decode.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["enum"],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "description": "The closed set of allowed values. The resolved value's string form must equal one entry.",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["pattern"],
+          "properties": {
+            "pattern": {
+              "type": "string",
+              "description": "An author-anchored Go RE2 regexp the resolved value's string form must match.",
+              "minLength": 1
+            }
+          }
+        }
+      ]
     },
     "resolution": {
       "type": "object",

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -137,6 +137,14 @@ The closed `audit.fields` set is `connector-hash`, `action-manifest-version`, `c
 | `type` | string | Yes | One of `string`, `number`, `boolean`, `timestamp`, `object`, `array`. |
 | `description` | string | No | Human-readable semantics. |
 | `resolution` | object | Yes | The resolution rule. One of `literal`, `dynamic`, or `source`. |
+| `constraint` | object | No | An optional bound on the resolved value. Exactly one of `enum` or `pattern`. |
+
+The optional `constraint` block:
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `enum` | array | Exactly one of `enum`/`pattern` | The closed set of allowed string values. The resolved value's string form must equal one entry. Non-empty. |
+| `pattern` | string | Exactly one of `enum`/`pattern` | An author-anchored Go RE2 regexp the resolved value's string form must match. Non-empty. |
 
 ### `outputs[]`
 
@@ -232,6 +240,8 @@ There are three resolution rules, discriminated by the `rule` field.
 | `literal` | none beyond `rule` | A value passed at launch. An optional `default` applies when no value is passed. |
 | `dynamic` | `value` | A launch-relative value resolved once at launch. `value` is `now` (the launch timestamp) or `today` (the launch date). |
 | `source` | `source` | A read from a live source. `source.actionRef` names the action whose result resolves the input, with an optional `source.select`. |
+
+An input may declare an optional `constraint` that bounds its resolved value. A constraint holds exactly one of two forms. An `enum` is a non-empty array of allowed string values, and the resolved value's string form must equal one entry. A `pattern` is a non-empty author-anchored Go RE2 regexp, and the resolved value's string form must match it. Declaring both forms, an empty `enum`, or an empty `pattern` is a bad shape that fails closed at freeze and at decode. A pattern that does not compile as a Go RE2 regexp is refused at decode, the one check the schema cannot express. The constraint applies regardless of the resolution rule, so a literal, a dynamic, or a source input can all be bounded. Enforcement happens once at the launch boundary. A resolved value that falls outside its constraint is rejected there and the launch fails closed. The comparison is over the value's string form, so a number or timestamp input stays checkable.
 
 ## Outputs contract versus file-map transport
 

--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -123,6 +123,7 @@ Every input the plan depends on is declared in `inputs[]`, each with a resolutio
 - `type` is one of `string`, `number`, `boolean`, `timestamp`, `object`, `array`.
 - `description` is optional human-readable semantics.
 - `resolution` is the resolution rule, discriminated by its `rule` field.
+- `constraint` is an optional bound on the resolved value.
 
 There are three resolution rules.
 
@@ -131,6 +132,26 @@ There are three resolution rules.
 - `source` reads from a live source. Its `source.actionRef` names the action whose result resolves the input, with an optional `source.select`.
 
 Inputs resolve once, at the launch boundary, into a concrete resolved-input set. Two steps that read the same dynamic input see one value. A `source` read happens in the resolution phase, before the step graph walks, so it is not a graph edge.
+
+An input can carry an optional `constraint` that bounds its resolved value. A constraint holds exactly one of two forms. An `enum` is a non-empty array of allowed string values, and the resolved value's string form must equal one entry. A `pattern` is a non-empty author-anchored Go RE2 regexp, and the resolved value's string form must match it. Declaring both forms at once, an empty `enum`, an empty `pattern`, or a pattern that does not compile is a bad shape rejected at freeze and at decode. A resolved value that falls outside its constraint is rejected at launch and the launch fails closed. The constraint applies to any resolution rule, and the check is over the value's string form, so a number or timestamp input stays bounded.
+
+```yaml
+  inputs:
+    - name: environment
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        enum:
+          - prod
+          - staging
+    - name: aws_region
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        pattern: "^[a-z]{2}-[a-z]+-[0-9]$"
+```
 
 ## Outputs
 

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -328,8 +328,38 @@
           "type": "string",
           "description": "Human-readable semantics of the input."
         },
-        "resolution": { "$ref": "#/$defs/resolution" }
+        "resolution": { "$ref": "#/$defs/resolution" },
+        "constraint": { "$ref": "#/$defs/inputConstraint" }
       }
+    },
+    "inputConstraint": {
+      "type": "object",
+      "description": "OPTIONAL resolution constraint bounding the resolved value. Exactly one of enum or pattern. A bad shape (both present, an empty enum, an empty pattern) fails closed at freeze/decode; an out-of-constraint resolved value is rejected at the launch/resolution boundary. JSON Schema validates only the shape; RE2 compilability of a pattern is checked at decode.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["enum"],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "description": "The closed set of allowed values. The resolved value's string form must equal one entry.",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["pattern"],
+          "properties": {
+            "pattern": {
+              "type": "string",
+              "description": "An author-anchored Go RE2 regexp the resolved value's string form must match.",
+              "minLength": 1
+            }
+          }
+        }
+      ]
     },
     "resolution": {
       "type": "object",

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -86,6 +86,117 @@ body
 	}
 }
 
+// inputConstraintFrontmatter wraps a single input's YAML into a complete,
+// otherwise-valid aileron frontmatter so a test exercises only the input
+// constraint validity rules. inputBlock is the YAML for one inputs array item,
+// indented to sit under `inputs:`.
+func inputConstraintFrontmatter(inputBlock string) []byte {
+	return []byte(`name: s
+description: d
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  inputs:
+` + inputBlock + `
+  outputs: []
+`)
+}
+
+// TestInputConstraintValidity locks the input constraint at the schema
+// boundary (#1957). A declared constraint holds exactly one of a non-empty
+// enum (string array) or a non-empty pattern. Both present matches neither
+// oneOf branch and is rejected; an empty enum fails minItems; an empty pattern
+// fails minLength. A constraint is optional, so an input with none validates.
+func TestInputConstraintValidity(t *testing.T) {
+	valid := map[string]string{
+		"enum": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        enum:
+          - prod
+          - staging`,
+		"pattern": `    - name: region
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        pattern: "^us-[a-z]+-[0-9]$"`,
+		"no constraint": `    - name: window
+      type: number
+      resolution:
+        rule: literal`,
+	}
+	for name, in := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := validateFrontmatter(inputConstraintFrontmatter(in)); err != nil {
+				t.Fatalf("expected valid, got: %v", err)
+			}
+		})
+	}
+
+	invalid := map[string]string{
+		"both enum and pattern": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        enum:
+          - prod
+        pattern: "^prod$"`,
+		"empty enum": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        enum: []`,
+		"empty pattern": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        pattern: ""`,
+		"non-string enum entry": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        enum:
+          - 7`,
+		"unknown constraint key": `    - name: env
+      type: string
+      resolution:
+        rule: literal
+      constraint:
+        regex: "^prod$"`,
+	}
+	for name, in := range invalid {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			err := validateFrontmatter(inputConstraintFrontmatter(in))
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "schema validation") {
+				t.Errorf("error should cite schema validation, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestParseToolOnlyPlanNeedsNoActions is the #1932 regression: a tool-only
 // plan whose every effectful step is an in-container tool step dispatches no
 // connector action, so it must not be forced to declare a dummy

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -392,6 +392,30 @@ func TestDecode_ConstraintPatternCompiled(t *testing.T) {
 	}
 }
 
+// A YAML block scalar can append a trailing newline to a pattern. The decoder
+// must normalize it so the enforced regexp is the author's anchored pattern,
+// not one that also requires a literal trailing newline.
+func TestDecode_ConstraintPatternWhitespaceNormalized(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("region", map[string]any{"pattern": "^us-east-1$\n"})},
+		nil, oneStep(),
+	)
+	p, err := Decode(m)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	c := p.Inputs[0].Constraint
+	if c == nil || c.Pattern == nil {
+		t.Fatal("pattern constraint must compile a regexp")
+	}
+	if !c.Pattern.MatchString("us-east-1") {
+		t.Error("a trailing newline in the pattern must be normalized away, so the anchored value still matches")
+	}
+	if c.Pattern.String() != "^us-east-1$" {
+		t.Errorf("stored pattern = %q, want the trimmed ^us-east-1$", c.Pattern.String())
+	}
+}
+
 func TestDecode_ConstraintUncompilablePatternRefused(t *testing.T) {
 	// A pattern the schema cannot catch (ECMA-valid shape, RE2-invalid): an
 	// unclosed group. This is the fail-closed case only decode enforces.

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -333,6 +333,111 @@ func TestDecode_SourceInputIsNotAStepEdge(t *testing.T) {
 	}
 }
 
+// constrainedInput builds a raw literal input map carrying a constraint block,
+// the shape the manifest carries (map[string]any), so the runtime decoder's own
+// constraint guards run on inputs the schema would otherwise reject upstream.
+func constrainedInput(name string, constraint map[string]any) any {
+	return map[string]any{
+		"name": name, "type": "string",
+		"resolution": map[string]any{"rule": "literal"},
+		"constraint": constraint,
+	}
+}
+
+// oneStep is a trivial valid step so Decode reaches the input decode and, on
+// valid inputs, completes with a non-empty step graph.
+func oneStep() []any {
+	return []any{step(map[string]any{"id": "s1", "kind": "transform", "outputs": []any{"x"}})}
+}
+
+func TestDecode_ConstraintEnumPopulated(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("env", map[string]any{"enum": []any{"prod", "staging"}})},
+		nil, oneStep(),
+	)
+	p, err := Decode(m)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	c := p.Inputs[0].Constraint
+	if c == nil {
+		t.Fatal("constraint must be populated")
+	}
+	if c.Pattern != nil {
+		t.Error("an enum constraint must not compile a pattern")
+	}
+	if len(c.Enum) != 2 || c.Enum[0] != "prod" || c.Enum[1] != "staging" {
+		t.Errorf("enum = %v", c.Enum)
+	}
+}
+
+func TestDecode_ConstraintPatternCompiled(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("region", map[string]any{"pattern": "^us-[a-z]+-[0-9]$"})},
+		nil, oneStep(),
+	)
+	p, err := Decode(m)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	c := p.Inputs[0].Constraint
+	if c == nil || c.Pattern == nil {
+		t.Fatal("pattern constraint must compile a regexp")
+	}
+	if len(c.Enum) != 0 {
+		t.Error("a pattern constraint must carry no enum")
+	}
+	if !c.Pattern.MatchString("us-east-1") {
+		t.Error("compiled pattern must match a valid region")
+	}
+}
+
+func TestDecode_ConstraintUncompilablePatternRefused(t *testing.T) {
+	// A pattern the schema cannot catch (ECMA-valid shape, RE2-invalid): an
+	// unclosed group. This is the fail-closed case only decode enforces.
+	m := rawManifest(
+		[]any{constrainedInput("bad", map[string]any{"pattern": "([a-z"})},
+		nil, oneStep(),
+	)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an uncompilable RE2 pattern must be refused at decode")
+	} else if !strings.Contains(err.Error(), "compile") {
+		t.Errorf("error = %v, want a compile rejection", err)
+	}
+}
+
+func TestDecode_ConstraintBothEnumAndPatternRefused(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("env", map[string]any{"enum": []any{"prod"}, "pattern": "^prod$"})},
+		nil, oneStep(),
+	)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a constraint declaring both enum and pattern must be refused")
+	} else if !strings.Contains(err.Error(), "both") {
+		t.Errorf("error = %v, want a both-present rejection", err)
+	}
+}
+
+func TestDecode_ConstraintEmptyEnumRefused(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("env", map[string]any{"enum": []any{}})},
+		nil, oneStep(),
+	)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a constraint with neither a non-empty enum nor a pattern must be refused")
+	}
+}
+
+func TestDecode_ConstraintEmptyEnumEntryRefused(t *testing.T) {
+	m := rawManifest(
+		[]any{constrainedInput("env", map[string]any{"enum": []any{"prod", ""}})},
+		nil, oneStep(),
+	)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a constraint enum carrying an empty value must be refused")
+	}
+}
+
 func TestDecode_DuplicateStepID(t *testing.T) {
 	m := rawManifest(nil, nil, []any{
 		step(map[string]any{"id": "dup", "kind": "transform", "outputs": []any{"x"}}),

--- a/internal/flightplan/runtime/dto.go
+++ b/internal/flightplan/runtime/dto.go
@@ -180,7 +180,14 @@ func (d inputDTO) toConstraint() (*Constraint, error) {
 		return nil, nil
 	}
 	hasEnum := len(d.Constraint.Enum) > 0
-	hasPattern := strings.TrimSpace(d.Constraint.Pattern) != ""
+	// Surrounding whitespace on a pattern is not significant: a YAML block
+	// scalar can append a trailing newline that would otherwise silently change
+	// the enforced regexp (an anchored "^x$" would become "^x$\n"). Trim once
+	// and use the trimmed text for both the presence check and the compile, so
+	// detection and enforcement never disagree and a whitespace-only pattern is
+	// refused as the plan requires.
+	pattern := strings.TrimSpace(d.Constraint.Pattern)
+	hasPattern := pattern != ""
 	switch {
 	case hasEnum && hasPattern:
 		return nil, decodeErrf("input %q: constraint declares both enum and pattern (exactly one is allowed)", d.Name)
@@ -192,9 +199,9 @@ func (d inputDTO) toConstraint() (*Constraint, error) {
 		}
 		return &Constraint{Enum: d.Constraint.Enum}, nil
 	case hasPattern:
-		re, err := regexp.Compile(d.Constraint.Pattern)
+		re, err := regexp.Compile(pattern)
 		if err != nil {
-			return nil, decodeErrf("input %q: constraint pattern %q does not compile as a Go RE2 regexp: %v", d.Name, d.Constraint.Pattern, err)
+			return nil, decodeErrf("input %q: constraint pattern %q does not compile as a Go RE2 regexp: %v", d.Name, pattern, err)
 		}
 		return &Constraint{Pattern: re}, nil
 	default:

--- a/internal/flightplan/runtime/dto.go
+++ b/internal/flightplan/runtime/dto.go
@@ -1,5 +1,10 @@
 package runtime
 
+import (
+	"regexp"
+	"strings"
+)
+
 // The DTOs in this file mirror the manifest schema wire shapes. They are the
 // strict-decode boundary: the loosely-typed manifest `[]any`/`map[string]any`
 // elements round-trip through these structs (via remarshal) and the toX
@@ -109,6 +114,15 @@ type inputDTO struct {
 			Select    string `yaml:"select"`
 		} `yaml:"source"`
 	} `yaml:"resolution"`
+	// Constraint is the optional resolution constraint. A pointer distinguishes
+	// an absent constraint from an empty one; the strict KnownFields decoder
+	// requires the field to exist on the DTO or a manifest carrying it is
+	// refused. Exactly one of Enum/Pattern is populated; toInput enforces that
+	// as defense-in-depth over the schema oneOf.
+	Constraint *struct {
+		Enum    []string `yaml:"enum"`
+		Pattern string   `yaml:"pattern"`
+	} `yaml:"constraint"`
 }
 
 var validInputTypes = map[string]InputType{
@@ -148,7 +162,46 @@ func (d inputDTO) toInput() (Input, error) {
 	default:
 		return Input{}, decodeErrf("input %q: unknown resolution rule %q", d.Name, d.Resolution.Rule)
 	}
-	return Input{Name: d.Name, Type: it, Description: d.Description, Resolution: res}, nil
+	con, err := d.toConstraint()
+	if err != nil {
+		return Input{}, err
+	}
+	return Input{Name: d.Name, Type: it, Description: d.Description, Resolution: res, Constraint: con}, nil
+}
+
+// toConstraint validates the optional input constraint and compiles a pattern
+// once. It is the fail-closed gate for the one thing the schema cannot check
+// (RE2 compilability) and re-checks the exactly-one-of-enum-or-pattern shape so
+// the typed path refuses a bad constraint even when a caller bypasses schema
+// validation. An absent constraint returns (nil, nil): unconstrained is the
+// default and today's behavior.
+func (d inputDTO) toConstraint() (*Constraint, error) {
+	if d.Constraint == nil {
+		return nil, nil
+	}
+	hasEnum := len(d.Constraint.Enum) > 0
+	hasPattern := strings.TrimSpace(d.Constraint.Pattern) != ""
+	switch {
+	case hasEnum && hasPattern:
+		return nil, decodeErrf("input %q: constraint declares both enum and pattern (exactly one is allowed)", d.Name)
+	case hasEnum:
+		for _, e := range d.Constraint.Enum {
+			if e == "" {
+				return nil, decodeErrf("input %q: constraint enum has an empty value", d.Name)
+			}
+		}
+		return &Constraint{Enum: d.Constraint.Enum}, nil
+	case hasPattern:
+		re, err := regexp.Compile(d.Constraint.Pattern)
+		if err != nil {
+			return nil, decodeErrf("input %q: constraint pattern %q does not compile as a Go RE2 regexp: %v", d.Name, d.Constraint.Pattern, err)
+		}
+		return &Constraint{Pattern: re}, nil
+	default:
+		// The constraint block is present but names neither enum nor pattern
+		// (or an empty enum with an absent pattern): a bad shape, refused.
+		return nil, decodeErrf("input %q: constraint declares neither a non-empty enum nor a pattern (exactly one is required)", d.Name)
+	}
 }
 
 // ---- output ----

--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -78,7 +78,42 @@ func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *
 			return ResolvedInputs{}, fmt.Errorf("input %q: unhandled resolution rule %q", in.Name, in.Resolution.Rule)
 		}
 	}
+
+	// Enforce declared constraints against the resolved values as a final pass,
+	// once every input has a value. This is the single launch/resolution
+	// boundary where a resolved value exists: an out-of-constraint value fails
+	// the launch closed here, with no permissive fallback. An input with no
+	// declared constraint is unchecked (today's behavior).
+	for _, in := range p.Inputs {
+		if in.Constraint == nil {
+			continue
+		}
+		if err := enforceConstraint(in.Name, ri.Values[in.Name], in.Constraint); err != nil {
+			return ResolvedInputs{}, err
+		}
+	}
 	return ri, nil
+}
+
+// enforceConstraint checks a resolved value against its declared constraint.
+// The comparison is over the value's string form (fmt.Sprintf("%v", v)), so a
+// number or timestamp input stays checkable: enum requires equality with one
+// allowed string, pattern requires the compiled regexp to match. A violation
+// names the input, the value, and the constraint so the failure is actionable.
+func enforceConstraint(name string, v any, c *Constraint) error {
+	s := fmt.Sprintf("%v", v)
+	if c.Pattern != nil {
+		if !c.Pattern.MatchString(s) {
+			return fmt.Errorf("input %q resolved to %q, which does not match the required pattern %q", name, s, c.Pattern.String())
+		}
+		return nil
+	}
+	for _, allowed := range c.Enum {
+		if s == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("input %q resolved to %q, which is not one of the allowed values %v", name, s, c.Enum)
 }
 
 // resolveLiteral resolves a literal input: the launch override wins, then the

--- a/internal/flightplan/runtime/inputs_test.go
+++ b/internal/flightplan/runtime/inputs_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -145,6 +146,88 @@ func TestResolveInputs_FrozenFromLaunchArgMutation(t *testing.T) {
 	got := ri.Values["obj"].(map[string]any)
 	if got["k"] != "v" {
 		t.Error("resolved inputs must be frozen against later launch-arg mutation")
+	}
+}
+
+func TestResolveInputs_EnumConstraintInBoundPasses(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "env", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Enum: []string{"prod", "staging"}}},
+	}, nil)
+	ri, err := resolveInputs(context.Background(), p, LaunchArgs{"env": "prod"}, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("an in-constraint enum value must resolve: %v", err)
+	}
+	if ri.Values["env"] != "prod" {
+		t.Errorf("env = %v", ri.Values["env"])
+	}
+}
+
+func TestResolveInputs_EnumConstraintOutOfBoundFailsClosed(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "env", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Enum: []string{"prod", "staging"}}},
+	}, nil)
+	if _, err := resolveInputs(context.Background(), p, LaunchArgs{"env": "dev"}, FixedClock{}, &enforcer{}); err == nil {
+		t.Fatal("an out-of-constraint enum value must fail the launch closed")
+	}
+}
+
+func TestResolveInputs_PatternConstraintInBoundPasses(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "region", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Pattern: regexp.MustCompile("^us-[a-z]+-[0-9]$")}},
+	}, nil)
+	ri, err := resolveInputs(context.Background(), p, LaunchArgs{"region": "us-east-1"}, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("an in-constraint pattern value must resolve: %v", err)
+	}
+	if ri.Values["region"] != "us-east-1" {
+		t.Errorf("region = %v", ri.Values["region"])
+	}
+}
+
+func TestResolveInputs_PatternConstraintOutOfBoundFailsClosed(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "region", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Pattern: regexp.MustCompile("^us-[a-z]+-[0-9]$")}},
+	}, nil)
+	if _, err := resolveInputs(context.Background(), p, LaunchArgs{"region": "moon-base-7"}, FixedClock{}, &enforcer{}); err == nil {
+		t.Fatal("an out-of-constraint pattern value must fail the launch closed")
+	}
+}
+
+// A number input's resolved value is checked by its string form, so a numeric
+// default can be enum-constrained. This locks the stringify-then-check contract.
+func TestResolveInputs_ConstraintChecksStringForm(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "days", Type: "number",
+			Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: 7},
+			Constraint: &Constraint{Enum: []string{"7", "30"}}},
+	}, nil)
+	if _, err := resolveInputs(context.Background(), p, nil, FixedClock{}, &enforcer{}); err != nil {
+		t.Fatalf("a number whose string form is allowed must resolve: %v", err)
+	}
+	if _, err := resolveInputs(context.Background(), p, LaunchArgs{"days": 90}, FixedClock{}, &enforcer{}); err == nil {
+		t.Fatal("a number whose string form is not allowed must fail closed")
+	}
+}
+
+// An input with no declared constraint is never checked (today's behavior).
+func TestResolveInputs_NoConstraintUnchecked(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "free", Type: "string", Resolution: Resolution{Rule: ResolutionLiteral}},
+	}, nil)
+	ri, err := resolveInputs(context.Background(), p, LaunchArgs{"free": "anything"}, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("an unconstrained input must resolve any value: %v", err)
+	}
+	if ri.Values["free"] != "anything" {
+		t.Errorf("free = %v", ri.Values["free"])
 	}
 }
 

--- a/internal/flightplan/runtime/plan.go
+++ b/internal/flightplan/runtime/plan.go
@@ -27,6 +27,8 @@
 // runtime.
 package runtime
 
+import "regexp"
+
 // Plan is the typed, validated model of a frozen plan's `aileron` block that
 // the executor walks. It is produced by Decode from a manifest.Manifest and
 // is the single in-memory shape the runtime reads; the loosely-typed `[]any`
@@ -132,6 +134,21 @@ type Input struct {
 	Type        InputType
 	Description string
 	Resolution  Resolution
+	// Constraint bounds the resolved value. Nil means unconstrained (today's
+	// behavior). When non-nil it holds exactly one of an Enum allow-set or a
+	// compiled Pattern; the launch/resolution boundary rejects a resolved
+	// value that falls outside it.
+	Constraint *Constraint
+}
+
+// Constraint bounds an input's resolved value. Exactly one field is set: Enum
+// is the closed set of allowed string forms, or Pattern is the compiled
+// author-anchored RE2 regexp the resolved value's string form must match. The
+// pattern is compiled once at decode and stored here so enforcement never
+// recompiles.
+type Constraint struct {
+	Enum    []string
+	Pattern *regexp.Regexp
 }
 
 // Resolution is a decoded input resolution rule. Exactly one of the three


### PR DESCRIPTION
## Summary

Foundation sub-issue of umbrella #1956. Adds an optional `constraint` to a declared Flight Plan input, holding **exactly one** of:

- `enum` — a non-empty array of allowed string values; the resolved value's string form must equal one entry.
- `pattern` — a non-empty author-anchored Go RE2 regexp the resolved value's string form must match.

The constraint lives on the input object (applies regardless of the resolution rule) and is independently valuable: validated launch inputs with no templating.

**Fail-closed at two boundaries:**
- A bad shape (both `enum` and `pattern`, an empty `enum`, an empty or uncompilable `pattern`, or neither) is rejected at freeze/decode. RE2 compilability is the one check JSON Schema cannot express, so decode compiles the pattern (once) and stores the compiled `*regexp.Regexp`.
- An out-of-constraint resolved value is rejected at the launch/resolution boundary (`resolveInputs`), so launch fails with no permissive fallback. The comparison is over the value's string form (`fmt.Sprintf("%v", v)`), keeping number/timestamp inputs checkable.

Freeze is not touched: constraint decode/validation flows through `Decode`, which both the launch and freeze/lint paths already invoke. The freeze-time guard that *requires* a constraint on sealed positions belongs to later umbrella sub-issues.

### Files
- `internal/flightplan/manifest/flight-plan-manifest.schema.json` + the byte-identical `docs/schema/flight-plan-manifest.schema.json` mirror: `constraint` on the input `$def` and a new `inputConstraint` `$def` (oneOf of two closed branches).
- `internal/flightplan/runtime/plan.go`: `Constraint` type + `Input.Constraint`.
- `internal/flightplan/runtime/dto.go`: strict-decode DTO field + `toConstraint` shape/compile validation.
- `internal/flightplan/runtime/inputs.go`: `enforceConstraint` final pass in `resolveInputs`.
- Docs: manifest spec + authoring guide.

## Test plan

- `internal/flightplan/manifest/validate_test.go` — schema-shape cases through the embedded schema: valid enum, valid pattern, both-present rejected, empty enum rejected, empty pattern rejected, non-string enum entry rejected, unknown constraint key rejected, and no-constraint valid.
- `internal/flightplan/runtime/decode_test.go` — decode-level cases: enum populated, pattern compiled, uncompilable pattern rejected (the case schema cannot catch), both-present rejected, empty enum rejected, empty enum entry rejected.
- `internal/flightplan/runtime/inputs_test.go` — the launch regression (fails before the enforcement pass, passes after): in-constraint enum/pattern resolve; out-of-constraint enum/pattern fail closed; number checked by string form; unconstrained input unchecked.
- Drift guard `internal/flightplan/spec` green (schema and worked example in sync); both schema JSON files verified byte-identical.
- `go test ./internal/flightplan/...` green; `toConstraint` and `enforceConstraint` at 100% statement coverage; package coverage runtime 91.9%, manifest 80.3%.

Closes #1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inputs in flight plans can now include optional value constraints.
  * Constraints support either an allowed list of values or a matching pattern.
  * Launches now validate resolved input values and reject ones outside the declared constraint.

* **Bug Fixes**
  * Constraint checks now fail closed for invalid or empty constraint definitions.
  * Validation applies consistently across different input resolution methods and uses the resolved value’s string form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->