### PR TITLE
test(flightplan): reject empty constraint block in freeze command guard

### DIFF
--- a/internal/flightplan/freeze/commandguard_test.go
+++ b/internal/flightplan/freeze/commandguard_test.go
@@ -132,6 +132,31 @@ func TestLint_CommandPatternConstraintAccepted(t *testing.T) {
 	}
 }
 
+// TestLint_CommandEmptyConstraintRejected proves a present-but-empty constraint
+// block (constraint: {}) never counts as constrained: it carries neither an
+// enum nor a pattern, so an input declaring it in a sealed command position is
+// still an injection surface and the freeze must fail closed. This pins the
+// guard's own presence test so it does not silently depend on schema-time
+// validation rejecting an empty constraint upstream.
+func TestLint_CommandEmptyConstraintRejected(t *testing.T) {
+	in := map[string]any{
+		"name": "region", "type": "string",
+		"resolution": map[string]any{"rule": "literal", "default": "us-east-1"},
+		"constraint": map[string]any{},
+	}
+	m := manifestWithInputsAndSteps(
+		[]any{in},
+		[]any{toolStepWithCommand("q", "query", "--region={{ inputs.region }}")},
+	)
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("a command referencing an input with an empty constraint block must be rejected")
+	}
+	if !strings.Contains(err.Error(), "declares no constraint") {
+		t.Errorf("error should explain the input declares no constraint, got: %v", err)
+	}
+}
+
 // interpToolStepMD is a full valid SKILL.md whose tool command interpolates a
 // constrained input, used to prove freeze seals the TEMPLATE argv verbatim.
 const interpToolStepMD = `---


### PR DESCRIPTION
## Summary

The freeze command guard rejects a tool command that interpolates an input
declaring no constraint, because an unconstrained value in a sealed exec
position is an injection surface. `inputDeclaresConstraint` treats a
present-but-empty `constraint: {}` block as unconstrained (neither an enum
with entries nor a non-whitespace pattern), so it must fail closed.

`commandguard_test.go` covered enum / pattern / unknown / malformed /
token-free cases but had no present-but-empty-constraint case. That left the
guard's constrained-detection silently reliant on schema-time validation
rejecting an empty constraint upstream. This adds the missing acceptance case
so the guard's own presence test is pinned at the freeze-time backstop.

Behavior is already correct, so this is a purely additive regression test.

## Test plan

- `go test ./internal/flightplan/freeze/ -run TestLint_Command -v` — all
  command-guard cases pass, including the new
  `TestLint_CommandEmptyConstraintRejected`.
- `go test ./internal/flightplan/freeze/` — package green.

Relates to #1963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
