### PR TITLE
fix(flightplan): cap resolved value at 256 chars in enforcement errors

### DIFF
--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -95,16 +95,35 @@ func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *
 	return ri, nil
 }
 
+// maxResolvedValueInError caps how much of a resolved value's string form is
+// embedded in an enforcement error. A resolved source or literal value can be
+// arbitrarily large (a fetched dataset, a long string), so the error message is
+// bounded here rather than echoing the whole value back to the operator.
+const maxResolvedValueInError = 256
+
+// capResolvedValue truncates s to maxResolvedValueInError characters, appending
+// a marker when it was longer so the truncation is visible. The comparison
+// against the constraint still uses the full string form; only the message is
+// capped.
+func capResolvedValue(s string) string {
+	if len(s) <= maxResolvedValueInError {
+		return s
+	}
+	return s[:maxResolvedValueInError] + "...(truncated)"
+}
+
 // enforceConstraint checks a resolved value against its declared constraint.
 // The comparison is over the value's string form (fmt.Sprintf("%v", v)), so a
 // number or timestamp input stays checkable: enum requires equality with one
 // allowed string, pattern requires the compiled regexp to match. A violation
-// names the input, the value, and the constraint so the failure is actionable.
+// names the input, the (capped) value, and the constraint so the failure is
+// actionable without echoing an unbounded resolved value back to the operator.
 func enforceConstraint(name string, v any, c *Constraint) error {
 	s := fmt.Sprintf("%v", v)
+	capped := capResolvedValue(s)
 	if c.Pattern != nil {
 		if !c.Pattern.MatchString(s) {
-			return fmt.Errorf("input %q resolved to %q, which does not match the required pattern %q", name, s, c.Pattern.String())
+			return fmt.Errorf("input %q resolved to %q, which does not match the required pattern %q", name, capped, c.Pattern.String())
 		}
 		return nil
 	}
@@ -113,7 +132,7 @@ func enforceConstraint(name string, v any, c *Constraint) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("input %q resolved to %q, which is not one of the allowed values %v", name, s, c.Enum)
+	return fmt.Errorf("input %q resolved to %q, which is not one of the allowed values %v", name, capped, c.Enum)
 }
 
 // resolveLiteral resolves a literal input: the launch override wins, then the

--- a/internal/flightplan/runtime/inputs_test.go
+++ b/internal/flightplan/runtime/inputs_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -198,6 +199,81 @@ func TestResolveInputs_PatternConstraintOutOfBoundFailsClosed(t *testing.T) {
 	}, nil)
 	if _, err := resolveInputs(context.Background(), p, LaunchArgs{"region": "moon-base-7"}, FixedClock{}, &enforcer{}); err == nil {
 		t.Fatal("an out-of-constraint pattern value must fail the launch closed")
+	}
+}
+
+// A resolved value longer than the 256-char cap must not be echoed in full in
+// the pattern-mismatch error. The message embeds only the capped value plus the
+// truncation marker, so an arbitrarily large resolved value cannot bloat the
+// operator-facing error.
+func TestResolveInputs_PatternErrorCapsLongResolvedValue(t *testing.T) {
+	long := strings.Repeat("a", 1000)
+	p := planWithInputs([]Input{
+		{Name: "blob", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Pattern: regexp.MustCompile("^short$")}},
+	}, nil)
+	_, err := resolveInputs(context.Background(), p, LaunchArgs{"blob": long}, FixedClock{}, &enforcer{})
+	if err == nil {
+		t.Fatal("an out-of-constraint pattern value must fail the launch closed")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, long) {
+		t.Errorf("error embeds the full %d-char resolved value; it must be capped: %q", len(long), msg)
+	}
+	if !strings.Contains(msg, "...(truncated)") {
+		t.Errorf("capped error must carry the truncation marker: %q", msg)
+	}
+	// The capped value is 256 chars of the original plus the marker; the full
+	// 1000-char run must not survive.
+	if strings.Contains(msg, strings.Repeat("a", 257)) {
+		t.Errorf("error embeds more than the 256-char cap of the resolved value: %q", msg)
+	}
+}
+
+// The same cap applies to the enum-mismatch error, proving the truncation is
+// uniform across resolution rules rather than pattern-only.
+func TestResolveInputs_EnumErrorCapsLongResolvedValue(t *testing.T) {
+	long := strings.Repeat("z", 1000)
+	p := planWithInputs([]Input{
+		{Name: "blob", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Enum: []string{"prod", "staging"}}},
+	}, nil)
+	_, err := resolveInputs(context.Background(), p, LaunchArgs{"blob": long}, FixedClock{}, &enforcer{})
+	if err == nil {
+		t.Fatal("an out-of-constraint enum value must fail the launch closed")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, long) {
+		t.Errorf("error embeds the full %d-char resolved value; it must be capped: %q", len(long), msg)
+	}
+	if !strings.Contains(msg, "...(truncated)") {
+		t.Errorf("capped error must carry the truncation marker: %q", msg)
+	}
+	if strings.Contains(msg, strings.Repeat("z", 257)) {
+		t.Errorf("error embeds more than the 256-char cap of the resolved value: %q", msg)
+	}
+}
+
+// A resolved value at or under the cap is embedded verbatim with no marker, so
+// the truncation never triggers on ordinary short values.
+func TestResolveInputs_ShortResolvedValueNotTruncated(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "env", Type: "string",
+			Resolution: Resolution{Rule: ResolutionLiteral},
+			Constraint: &Constraint{Enum: []string{"prod", "staging"}}},
+	}, nil)
+	_, err := resolveInputs(context.Background(), p, LaunchArgs{"env": "dev"}, FixedClock{}, &enforcer{})
+	if err == nil {
+		t.Fatal("an out-of-constraint enum value must fail the launch closed")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"dev"`) {
+		t.Errorf("a short resolved value must be embedded verbatim: %q", msg)
+	}
+	if strings.Contains(msg, "...(truncated)") {
+		t.Errorf("a short resolved value must not carry the truncation marker: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

`enforceConstraint` (internal/flightplan/runtime/inputs.go) embedded the full string form of a resolved input value into both the pattern-mismatch and enum-mismatch error messages with no cap. A resolved source or literal value can be arbitrarily large (a fetched dataset, a long string), so an out-of-constraint value bloated the operator-facing error with the entire value.

This caps the embedded value at a fixed 256-char limit uniformly for all resolution rules (literal / dynamic / source), appending a `...(truncated)` marker when the value is longer. The constraint comparison itself still runs against the full string form; only the message is bounded.

This lands the operator's answered park decision from cw-review-residual #1957 (cap the embedded resolved value at 256 chars for ALL inputs).

## Test plan

- `go build ./internal/flightplan/...` and `go vet ./internal/flightplan/runtime/` clean
- `go test ./internal/flightplan/runtime/` green
- New regression tests in inputs_test.go:
  - `TestResolveInputs_PatternErrorCapsLongResolvedValue` — a >256-char value yields a capped pattern-mismatch error carrying the marker, never the full value
  - `TestResolveInputs_EnumErrorCapsLongResolvedValue` — same cap on the enum path, proving uniformity across rules
  - `TestResolveInputs_ShortResolvedValueNotTruncated` — a short value is embedded verbatim with no marker

Closes #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Constraint validation errors now shorten overly long values in messages, making them easier to read and less noisy.
  * Pattern and list/enum validation failures now display a truncated value marker when the resolved value is too long.
  * Short values continue to appear in full.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->