### PR TITLE
fix(flightplan): reject input tokens in per-action trustContract hosts

### DIFF
--- a/internal/flightplan/freeze/commandguard.go
+++ b/internal/flightplan/freeze/commandguard.go
@@ -88,10 +88,11 @@ func lintCommandInterpolation(m *manifest.Manifest) error {
 //
 // Scope: only `kind: tool` steps are walked. A per-action (connector
 // action-ref) trustContract is never instantiated (no plan-input substitution
-// path reaches it), so its hosts are not guarded here; the shared-def schema
-// relaxation admits a token there syntactically, but nothing substitutes it.
-// It reads the RAW manifest maps and shares the exact token grammar the runtime
-// uses via the leaf manifest package.
+// path reaches it), so an input token in one of its hosts would ride in inert
+// as the literal `{{ ... }}` string: a footgun, not a constrained-input axis.
+// lintActionHostLiterals guards that separately by hard-rejecting any token in
+// a per-action host. It reads the RAW manifest maps and shares the exact token
+// grammar the runtime uses via the leaf manifest package.
 func lintHostInterpolation(m *manifest.Manifest) error {
 	declared, constrained := inputConstraintSets(m)
 	for i, raw := range m.Aileron.Steps {
@@ -135,6 +136,47 @@ func lintHostInterpolation(m *manifest.Manifest) error {
 				if !constrained[ref] {
 					return &LintError{StepID: id, Reason: fmt.Sprintf("trustContract host references input %q which declares no constraint; an unconstrained input in a sealed host position is an injection surface (add an enum or pattern constraint)", ref)}
 				}
+			}
+		}
+	}
+	return nil
+}
+
+// lintActionHostLiterals is the freeze-time guard over `{{ inputs.<name> }}`
+// tokens embedded in a PER-ACTION (requires.actions[]) trustContract host
+// (#1965). Unlike a tool step's hosts, a per-action host is never instantiated:
+// no plan-input substitution path reaches it, so a token there rides in inert
+// as the literal `{{ ... }}` string and the declared reach it appears to grant
+// is silently wrong. The shared-def schema relaxation that lets tool-step hosts
+// carry a token also makes the token syntactically valid here, so freeze must
+// reject it explicitly rather than seal a footgun. Per-action hosts must be
+// literal.
+//
+// It reads the typed manifest.ActionRequirement.TrustContract map (freeze runs
+// on manifest.Manifest, not the runtime's typed Plan) and shares the exact
+// token grammar the runtime uses via the leaf manifest package.
+func lintActionHostLiterals(m *manifest.Manifest) error {
+	for _, a := range m.Aileron.Requires.Actions {
+		if a.TrustContract == nil {
+			continue
+		}
+		hosts, ok := a.TrustContract["hosts"].([]any)
+		if !ok {
+			// Missing/non-array hosts are a schema error caught at parse; this
+			// guard only inspects present host strings.
+			continue
+		}
+		for _, h := range hosts {
+			host, ok := h.(string)
+			if !ok {
+				continue
+			}
+			refs, err := manifest.CommandInputRefs(host)
+			if err != nil {
+				return &LintError{Reason: fmt.Sprintf("requires.actions[%q] trustContract host %q: %v", a.Ref, host, err)}
+			}
+			if len(refs) > 0 {
+				return &LintError{Reason: fmt.Sprintf("trustContract host references input token %q, but host interpolation is tool-step-only (per-action requires.actions[] trustContract hosts must be literal)", host)}
 			}
 		}
 	}

--- a/internal/flightplan/freeze/hostguard_test.go
+++ b/internal/flightplan/freeze/hostguard_test.go
@@ -231,3 +231,76 @@ func TestRun_SealsTemplateHostNotResolved(t *testing.T) {
 		t.Errorf("lock.stepTrust must seal the TEMPLATE host verbatim:\n%s", lock)
 	}
 }
+
+// manifestWithActions builds a manifest whose requires.actions carries the given
+// ActionRequirements directly (bypassing schema validation) so the per-action
+// host guard's own rule is exercised as the freeze-time backstop.
+func manifestWithActions(actions ...manifest.ActionRequirement) *manifest.Manifest {
+	return &manifest.Manifest{
+		Name: "actionhostguard",
+		Aileron: manifest.AileronBlock{
+			Requires: manifest.Requires{Actions: actions},
+		},
+	}
+}
+
+// actionWithHosts builds a per-action requirement whose trustContract declares
+// the given host entries (which may be templates).
+func actionWithHosts(ref string, hosts ...string) manifest.ActionRequirement {
+	hs := make([]any, len(hosts))
+	for i, h := range hosts {
+		hs[i] = h
+	}
+	return manifest.ActionRequirement{
+		Ref: ref,
+		TrustContract: map[string]any{
+			"credential":  map[string]any{"kind": "none"},
+			"hosts":       hs,
+			"effect":      "read",
+			"idempotency": map[string]any{"safeToRetry": true},
+			"audit":       map[string]any{"fields": []any{"result"}},
+		},
+	}
+}
+
+// TestLint_ActionHostInputTokenRejected proves an input token in a PER-ACTION
+// (requires.actions[]) trustContract host fails the freeze closed (#1965). Host
+// interpolation is tool-step-only, so such a token is never substituted and
+// would ride in inert as the literal `{{ ... }}` string, silently granting a
+// reach that is syntactically valid but wrong. Per-action hosts must be literal.
+func TestLint_ActionHostInputTokenRejected(t *testing.T) {
+	m := manifestWithActions(
+		actionWithHosts("aws/athena@1.0.0", "athena.{{ inputs.aws_region }}.amazonaws.com"),
+	)
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("a per-action host referencing an input token must be rejected")
+	}
+	if !strings.Contains(err.Error(), "tool-step-only") {
+		t.Errorf("error should explain host interpolation is tool-step-only, got: %v", err)
+	}
+}
+
+// TestLint_ActionHostLiteralAccepted proves a per-action trustContract host that
+// is a literal (no input token) lints clean — existing action-ref plans with
+// literal reach are unaffected.
+func TestLint_ActionHostLiteralAccepted(t *testing.T) {
+	m := manifestWithActions(
+		actionWithHosts("aws/athena@1.0.0", "athena.us-east-1.amazonaws.com"),
+	)
+	if err := Lint(m); err != nil {
+		t.Errorf("a literal per-action host must lint clean: %v", err)
+	}
+}
+
+// TestLint_ActionHostMalformedTokenRejected proves a malformed brace shape in a
+// per-action host is rejected by the shared token grammar, not silently sealed.
+func TestLint_ActionHostMalformedTokenRejected(t *testing.T) {
+	m := manifestWithActions(
+		actionWithHosts("aws/athena@1.0.0", "athena.{{ inputs.aws_region }.amazonaws.com"),
+	)
+	err := Lint(m)
+	if err == nil || !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("a malformed per-action host token must be rejected, got: %v", err)
+	}
+}

--- a/internal/flightplan/freeze/lint.go
+++ b/internal/flightplan/freeze/lint.go
@@ -117,6 +117,14 @@ func Lint(m *manifest.Manifest) error {
 	if err := lintHostInterpolation(m); err != nil {
 		return err
 	}
+	// Guard per-action (requires.actions[]) trustContract hosts (#1965): host
+	// interpolation is tool-step-only, so an input token in a per-action host is
+	// never substituted and would ride in inert as the literal `{{ ... }}`
+	// string. Reject it at freeze rather than seal a syntactically valid but
+	// inert host; per-action hosts must be literal.
+	if err := lintActionHostLiterals(m); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Host interpolation in a Flight Plan is **tool-step-only**: freeze seals a `kind: tool` step's TEMPLATE `trustContract.hosts` entry, and launch instantiates the concrete host before minting the step-scope proxy credential. A per-action (`requires.actions[]`) trustContract host is never instantiated — no plan-input substitution path reaches it — so a `{{ inputs.<name> }}` token there rides in **inert** as the literal `{{ ... }}` string, silently appearing to grant a reach that is syntactically valid but wrong.

The shared-def schema relaxation that admits input tokens in tool-step hosts makes them syntactically valid in per-action hosts too. Before this change, `lintHostInterpolation` walked only tool steps and explicitly left per-action trustContracts unguarded, so such a token froze in silently.

This adds `lintActionHostLiterals`, invoked from `Lint` after `lintHostInterpolation`, which iterates `m.Aileron.Requires.Actions` and hard-rejects any per-action `trustContract.hosts` entry that carries an input token (per-action hosts must be literal). The tool-step host grammar/constraint guard is unchanged and stays tool-only.

Bounded per operator decision 1 on the residual: hard-reject action-ref host tokens at freeze. No schema, runtime, or cross-subsystem change; typed access via `m.Aileron.Requires.Actions`.

## Test plan

- `TestLint_ActionHostInputTokenRejected` — a per-action host with `{{ inputs.aws_region }}` fails Lint with a "tool-step-only" message. Fails before the wiring, passes after (verified by stashing `lint.go`).
- `TestLint_ActionHostLiteralAccepted` — a literal per-action host lints clean (existing action-ref plans unaffected).
- `TestLint_ActionHostMalformedTokenRejected` — a malformed brace shape in a per-action host is rejected by the shared token grammar, not silently sealed.
- Full `./internal/flightplan/...` suite green; freeze coverage 88.8%.

Closes #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
