### PR TITLE
test(inject): pin preceding-label rule for multi-label AWS hosts

### DIFF
--- a/internal/credential/inject/awshost_test.go
+++ b/internal/credential/inject/awshost_test.go
@@ -24,6 +24,7 @@ func TestParseAWSEndpointHostVectors(t *testing.T) {
 		{"dualstack", "s3.dualstack.us-west-2.amazonaws.com", "s3", "us-west-2"},
 		{"fips", "s3-fips.us-east-1.amazonaws.com", "s3", "us-east-1"},
 		{"fips-dualstack", "s3-fips.dualstack.us-east-1.amazonaws.com", "s3", "us-east-1"},
+		{"api-ecr", "api.ecr.us-east-1.amazonaws.com", "ecr", "us-east-1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a pinning vector to `TestParseAWSEndpointHostVectors` in
`internal/credential/inject/awshost_test.go`:

```
{"api-ecr", "api.ecr.us-east-1.amazonaws.com", "ecr", "us-east-1"}
```

The existing vectors cover the modifier-skipping cases (`dualstack`,
`fips`, `fips-dualstack`) but none pin the plain rule that the SigV4
service is the label **immediately preceding** the region label for a
non-modifier multi-label host. The shipped `ParseAWSEndpointHost`
already resolves `api.ecr.us-east-1.amazonaws.com` to `("ecr",
"us-east-1")` correctly; this only adds the missing regression guard so
a future parser change that broke multi-label service extraction would
fail here. Test-only, no production change.

## Test plan

- `go test ./internal/credential/inject/ -run TestParseAWSEndpointHost -v` — all vectors pass, including the new `api-ecr` case.

Relates to #1984
