### PR TITLE
fix(proxy): select the SigV4 credential by identity, not host, at egress

### DIFF
--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -525,6 +525,17 @@ const (
 	hostBindingRejectLockedVault           = "binding_locked_vault"
 	hostBindingRejectCredentialUnavailable = "binding_credential_unavailable"
 	hostBindingRejectUnsupportedScheme     = "binding_unsupported_scheme"
+	// hostBindingRejectIdentityIncomplete is emitted when a step scope
+	// carries a credential kind but an empty identity label. Identity is
+	// definitionally the (kind, label) pair; a half-identity is malformed and
+	// fails closed at egress rather than degrading to a host match (#1978).
+	// Defensive: the mint already rejects a half-identity with a 400 (#1980).
+	hostBindingRejectIdentityIncomplete = "binding_identity_incomplete"
+	// hostBindingRejectIdentityUnbound is emitted when a step scope's complete
+	// (kind, label) identity resolves to no bound credential. It fails closed:
+	// never a fallback to a host match, never a passthrough of a
+	// bound-but-unavailable credential (#1978).
+	hostBindingRejectIdentityUnbound = "binding_identity_unbound"
 )
 
 // injectSandboxProxyHostBindingCredential resolves the credential a

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/sandbox/discovery"
 )
 
@@ -236,6 +237,17 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn net.Conn, decrypted 
 // target host. It is called only when no unique connector spec matched,
 // so the precedence is connector-spec -> host-binding -> passthrough.
 //
+// Binding selection has two modes (#1978). When the connection's step scope
+// declares a credential identity (a non-empty kind), the binding is selected
+// by the manifest (kind, label) pair via MatchIdentity, and selection fails
+// closed: a half-identity (kind without label) or an identity with no bound
+// credential is a 403 denial, never a fallback to a host match and never a
+// passthrough. Otherwise the binding is selected by host via Match, exactly
+// as before, and a host miss returns handled=false so the caller falls
+// through to passthrough. Everything after selection (the private-IP refusal,
+// the trust-contract gate, sentinel-swap, injection, dial, and audit) is
+// identical for both modes.
+//
 // On a binding match it resolves the bound credential daemon-side
 // (through the vault), injects it onto a fresh upstream request per the
 // binding's scheme, re-issues the request, and streams the response
@@ -255,9 +267,39 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 	if h, _, err := net.SplitHostPort(targetHost); err == nil {
 		hostForMatch = h
 	}
-	hb, ok := s.hostBindings.Match(hostForMatch)
-	if !ok {
-		return false
+
+	var hb binding.HostBinding
+	var ok bool
+	// Identity path (#1978): a step scope that declares a credential kind
+	// selects WHICH credential to inject by its manifest (kind, label) pair,
+	// not by the upstream host. It fails closed — never a fallback to a host
+	// match, never a passthrough of a bound-but-unavailable credential — so a
+	// scoped request can only ever egress with the exact credential its
+	// manifest identity names.
+	if auth.StepScope != nil && auth.StepScope.CredentialKind != "" {
+		if auth.StepScope.IdentityLabel == "" {
+			// A present kind with an empty label is a malformed half-identity.
+			// The mint already 400s this (#1980); fail closed defensively here
+			// rather than degrade to a host match.
+			s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, hostBindingRejectIdentityIncomplete)
+			writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy denied egress: the step's credential identity is incomplete")
+			return true
+		}
+		hb, ok = s.hostBindings.MatchIdentity(auth.StepScope.CredentialKind, auth.StepScope.IdentityLabel)
+		if !ok {
+			// The declared identity has no bound credential. Fail closed: no
+			// fallthrough to Match(host), no passthrough.
+			s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, hostBindingRejectIdentityUnbound)
+			writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy denied egress: the step's credential identity is not bound to a credential")
+			return true
+		}
+	} else {
+		// Host path: today's behavior. On a miss, return false so the caller
+		// falls through to passthrough (unchanged).
+		hb, ok = s.hostBindings.Match(hostForMatch)
+		if !ok {
+			return false
+		}
 	}
 
 	if sandboxForwardProxyTargetIsPrivateIPLiteral(targetHost) {

--- a/internal/app/sandbox_forward_proxy_identity_selection_test.go
+++ b/internal/app/sandbox_forward_proxy_identity_selection_test.go
@@ -1,0 +1,374 @@
+package app
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+const identityTargetHost = "athena.us-east-1.amazonaws.test"
+
+// setupIdentityProxyServer wires the server's proxy state (session CA,
+// daemon token) and returns a proxy client whose CONNECT presents the given
+// step-scope token, so the request authenticates as a scoped CONNECT and
+// carries the scope's credential identity to egress.
+func setupIdentityProxyServer(t *testing.T, srv *apiServer, sessionID, scopeToken string) *http.Client {
+	t.Helper()
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, sessionID)
+	srv.localDaemonToken = "daemon-token"
+	srv.sandboxProxyStateDir = stateDir
+
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	t.Cleanup(proxy.Close)
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("append CA cert")
+	}
+	client := newSandboxForwardProxyClientFromProxyURL(t, proxyURL, roots)
+	client.Transport.(*http.Transport).ProxyConnectHeader = http.Header{
+		"Proxy-Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(sessionID+":"+scopeToken))},
+	}
+	return client
+}
+
+// registerStepScope stores a live step scope directly on the server registry
+// (bypassing the mint) so a test can drive a scoped CONNECT, including the
+// malformed half-identity a well-behaved mint would reject — the proxy must
+// still fail closed defensively. It returns the scope's CONNECT token.
+func registerStepScope(srv *apiServer, sessionID, stepID string, hosts []string, kind, label string) string {
+	token := "scope-token-" + stepID
+	srv.stepScopesMu.Lock()
+	if srv.stepScopes == nil {
+		srv.stepScopes = map[string]sandboxProxyStepScope{}
+	}
+	srv.stepScopes["scope-"+stepID] = sandboxProxyStepScope{
+		SessionID:      sessionID,
+		StepID:         stepID,
+		Hosts:          hosts,
+		Token:          token,
+		ExpiresAt:      time.Now().Add(15 * time.Minute),
+		CredentialKind: kind,
+		IdentityLabel:  label,
+	}
+	srv.stepScopesMu.Unlock()
+	return token
+}
+
+// credentialFromAuthHeader extracts the access key id from a SigV4
+// Authorization header's Credential= field: it is the first slash-delimited
+// segment. Empty when the header is not a SigV4 signature.
+func credentialFromAuthHeader(auth string) string {
+	for _, part := range strings.Split(auth, ", ") {
+		part = strings.TrimPrefix(part, "AWS4-HMAC-SHA256 ")
+		if cred := strings.TrimPrefix(part, "Credential="); cred != part {
+			if i := strings.IndexByte(cred, '/'); i >= 0 {
+				return cred[:i]
+			}
+			return cred
+		}
+	}
+	return ""
+}
+
+// assertProxyReason asserts the single audit event has the given type and
+// reject_reason (reason "" skips the reject_reason check).
+func assertProxyReason(t *testing.T, store *audit.MemStore, wantType model.EventType, wantReason string) {
+	t.Helper()
+	events, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != wantType {
+		t.Fatalf("event type = %q, want %q", evt.EventType, wantType)
+	}
+	if wantReason != "" {
+		if got := evt.Payload["aileron.proxy.reject_reason"]; got != wantReason {
+			t.Errorf("reject_reason = %v, want %q", got, wantReason)
+		}
+	}
+}
+
+func mustSigV4IdentityBinding(t *testing.T, ref, label, accessKeyID string) binding.HostBinding {
+	t.Helper()
+	hb, err := binding.NewHostBinding("", ref, "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", label),
+		binding.WithSigV4Resign(accessKeyID, "", ""))
+	if err != nil {
+		t.Fatalf("NewHostBinding identity %q: %v", label, err)
+	}
+	return hb
+}
+
+// TestSandboxForwardProxy_IdentitySelectsCredentialHappyPath is the happy
+// path: a scoped CONNECT whose step scope carries {aws-sigv4, metrics-reader},
+// a host-less identity binding for that pair (access key AKIDEXAMPLE, no host
+// or region on the binding) → the request is injected with that credential and
+// a host-derived SigV4 scope, and a binding_injected audit event is emitted.
+func TestSandboxForwardProxy_IdentitySelectsCredentialHappyPath(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-identity" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		hostBindings:  binding.HostBindings{mustSigV4IdentityBinding(t, "user/aws", "metrics-reader", "AKIDEXAMPLE")},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "metrics-reader")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if got := credentialFromAuthHeader(upstreamAuth); got != "AKIDEXAMPLE" {
+		t.Fatalf("injected access key id = %q (auth=%q), want AKIDEXAMPLE", got, upstreamAuth)
+	}
+	// The signing scope is host-derived (region us-east-1, service athena).
+	if !strings.Contains(upstreamAuth, "/us-east-1/athena/aws4_request") {
+		t.Errorf("Authorization = %q, want a host-derived us-east-1/athena scope", upstreamAuth)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyBindingInjected, "")
+}
+
+// TestSandboxForwardProxy_IdentityUnboundFailsClosed is the required
+// fail-closed regression: a scoped request carries {aws-sigv4, X} but NO
+// identity binding for X exists, while a host-match binding for the SAME host
+// DOES exist. The request must fail closed (403), the host-match binding must
+// NOT be used, and no upstream dial may occur.
+func TestSandboxForwardProxy_IdentityUnboundFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	// A host-match binding for the target host exists (a decoy). It must never
+	// be selected for an identity-carrying scope.
+	hostBinding, err := binding.NewHostBinding(identityTargetHost, "user/aws", "sigv4-resign",
+		binding.WithSigV4Resign("AKIAHOSTMATCHDECOY00", "us-east-1", "athena"))
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-unbound" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		hostBindings:  binding.HostBindings{hostBinding},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed for an unbound identity; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "unbound-label")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 fail-closed", resp.StatusCode)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyRejected, hostBindingRejectIdentityUnbound)
+}
+
+// TestSandboxForwardProxy_IdentityIncompleteFailsClosed defends the
+// half-identity: a scope with a kind but an empty label (which a well-behaved
+// mint rejects, but the proxy must still fail closed) never degrades to a host
+// match. A host-match binding exists as a decoy; it must not be dialed.
+func TestSandboxForwardProxy_IdentityIncompleteFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	hostBinding, err := binding.NewHostBinding(identityTargetHost, "user/aws", "sigv4-resign",
+		binding.WithSigV4Resign("AKIAHOSTMATCHDECOY00", "us-east-1", "athena"))
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-incomplete" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("secret")),
+		hostBindings:  binding.HostBindings{hostBinding},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed for a half-identity; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 fail-closed", resp.StatusCode)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyRejected, hostBindingRejectIdentityIncomplete)
+}
+
+// TestSandboxForwardProxy_NoIdentityScopePreservesHostMatch is the regression
+// that the host path is untouched: a scoped request whose scope declares NO
+// credential identity selects by host exactly as before and injects.
+func TestSandboxForwardProxy_NoIdentityScopePreservesHostMatch(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	hostBinding, err := binding.NewHostBinding(identityTargetHost, "user/aws", "sigv4-resign",
+		binding.WithSigV4Resign("AKIAHOSTPATHKEY00000", "us-east-1", "athena"))
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-hostpath" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		hostBindings:  binding.HostBindings{hostBinding},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	// A scope with an empty credential identity: the host path applies.
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "", "")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := credentialFromAuthHeader(upstreamAuth); got != "AKIAHOSTPATHKEY00000" {
+		t.Fatalf("injected access key id = %q, want the host-match binding's key", got)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyBindingInjected, "")
+}
+
+// TestSandboxForwardProxy_TwoIdentitiesDisambiguate proves selection is by the
+// exact pair: with bindings for {aws-sigv4, metrics-reader} and
+// {aws-sigv4, admin} loaded, a scope for admin selects admin's access key id,
+// not metrics-reader's.
+func TestSandboxForwardProxy_TwoIdentitiesDisambiguate(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+
+	v := mustVaultWith(t, "user/aws-reader", "user", []byte("READERSECRETKEYAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	if err := v.Put(context.Background(), "user/aws-admin", []byte("ADMINSECRETKEYBBBBBBBBBBBBBBBBBBBBBBBBBBB"), vault.Metadata{Type: "user"}); err != nil {
+		t.Fatalf("vault put admin: %v", err)
+	}
+
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-two" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings: binding.HostBindings{
+			mustSigV4IdentityBinding(t, "user/aws-reader", "metrics-reader", "AKIAREADERKEY0000000"),
+			mustSigV4IdentityBinding(t, "user/aws-admin", "admin", "AKIAADMINKEY00000000"),
+		},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "admin")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := credentialFromAuthHeader(upstreamAuth); got != "AKIAADMINKEY00000000" {
+		t.Fatalf("injected access key id = %q, want admin's AKIAADMINKEY00000000", got)
+	}
+}
+
+// TestSandboxForwardProxy_IdentityBindingTrustGateUnchanged proves the
+// per-step trust-contract gate runs identically on an identity-selected
+// binding: a `read`-effect binding still denies a mutating method at
+// enforceHostBindingTrust, before any credential is injected or upstream
+// dialed. The selection change only alters WHICH binding is chosen; the gate
+// after it is untouched.
+func TestSandboxForwardProxy_IdentityBindingTrustGateUnchanged(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	idBinding, err := binding.NewHostBinding("", "user/aws", "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", "metrics-reader"),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", ""),
+		binding.WithTrustContract(binding.EffectRead, nil))
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-gate" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		hostBindings:  binding.HostBindings{idBinding},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed when the read-effect gate denies; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "metrics-reader")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	// A POST is a mutating method; the read-effect gate denies it.
+	resp, err := client.Post("https://"+identityTargetHost+"/", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("POST through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (read-effect denies POST)", resp.StatusCode)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyTrustDenied, trustRejectEffectNotAllowed)
+}

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -266,6 +266,21 @@ type HostBinding struct {
 	PlanID   string
 	StepID   string
 	ToolName string
+
+	// IdentityKind and IdentityLabel are the non-secret manifest
+	// credential-identity pair a step scope carries (#1978): the credential
+	// `kind` (e.g. `aws-sigv4`) and the manifest `identityLabel` that names
+	// which credential of that kind to inject at egress. Together they are the
+	// canonical key by which the proxy selects THIS binding for a scoped
+	// request, distinct from [HostBinding.HostPattern] (which host to reach)
+	// and [HostBinding.Scheme] (how to inject once selected). A binding may be
+	// keyed by this pair instead of (or in addition to) a host pattern: an
+	// identity binding may declare an empty [HostBinding.HostPattern] because
+	// its selection key is the identity, not the host. The pair is canonical:
+	// both must be non-empty together or neither is set. Set via
+	// [WithIdentity]. Non-secret, never the credential bytes.
+	IdentityKind  string
+	IdentityLabel string
 }
 
 // userRefRe matches the user-level credential namespace `user/<service>`
@@ -382,6 +397,23 @@ func WithToolIdentity(planID, stepID, toolName string) HostBindingOption {
 	}
 }
 
+// WithIdentity sets the non-secret credential-identity pair
+// [HostBinding.IdentityKind] and [HostBinding.IdentityLabel] the proxy uses
+// to select this binding for a step-scoped request (#1978). The pair is
+// canonical: pass both a non-empty kind and a non-empty label, or neither.
+// A half-identity (exactly one non-empty) is rejected at construction because
+// the pair, not either half alone, is the selection key. Declaring a complete
+// identity makes the binding's host pattern optional: an identity binding may
+// carry an empty host because it is selected by identity, not by host. The
+// values are non-secret; they name the manifest credential the step declared,
+// never the credential bytes.
+func WithIdentity(kind, label string) HostBindingOption {
+	return func(hb *HostBinding) {
+		hb.IdentityKind = strings.TrimSpace(kind)
+		hb.IdentityLabel = strings.TrimSpace(label)
+	}
+}
+
 // normalizeAllowedHosts trims and lowercases each allowlist entry, dropping
 // empties. It reuses the schema's host vocabulary (host or host:port form)
 // so the allowlist and the matcher agree on casing.
@@ -403,8 +435,8 @@ func normalizeAllowedHosts(hosts []string) []string {
 	return out
 }
 
-// NewHostBinding validates and constructs a HostBinding. It rejects an
-// empty or malformed host pattern, a credential-ref that is neither a
+// NewHostBinding validates and constructs a HostBinding. It rejects a
+// malformed host pattern, a credential-ref that is neither a
 // connector binding name (`<kind>/<service>/<identity>`) nor a
 // user-level ref (`user/<service>`), and a scheme outside
 // [HostBindingSchemes]. When the scheme is [SchemeBasic] a non-empty
@@ -414,13 +446,18 @@ func normalizeAllowedHosts(hosts []string) []string {
 // egress. The validation is the construction-time guard the issue's
 // acceptance criterion requires: no invalid binding ever reaches the
 // matcher.
+//
+// An empty host pattern is legal ONLY when the binding declares a complete
+// credential identity via [WithIdentity] (#1978): such a binding is selected
+// by its (kind, label) pair at egress, not by host. A binding with neither a
+// host pattern nor a complete identity, or with a half-identity, fails
+// construction.
 func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindingOption) (HostBinding, error) {
 	hp := strings.TrimSpace(strings.ToLower(hostPattern))
-	if hp == "" {
-		return HostBinding{}, fmt.Errorf("host binding: empty host pattern")
-	}
-	if err := validateHostPattern(hp); err != nil {
-		return HostBinding{}, err
+	if hp != "" {
+		if err := validateHostPattern(hp); err != nil {
+			return HostBinding{}, err
+		}
 	}
 	if !nameRe.MatchString(credentialRef) && !userRefRe.MatchString(credentialRef) {
 		return HostBinding{}, fmt.Errorf("host binding: invalid credential ref %q: must match <kind>/<service>/<identity> or user/<service>", credentialRef)
@@ -431,6 +468,18 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme, EmitMechanism: EmitMechanismInject}
 	for _, opt := range opts {
 		opt(&hb)
+	}
+	// A binding is keyed by a host pattern, a credential identity, or both.
+	// The identity pair is canonical: a half-identity (exactly one of kind or
+	// label set) fails closed because the pair, not either half, is the
+	// selection key. A binding with neither a host pattern nor a complete
+	// identity has no key at all and is rejected.
+	hasIdentity := hb.IdentityKind != "" && hb.IdentityLabel != ""
+	if (hb.IdentityKind != "") != (hb.IdentityLabel != "") {
+		return HostBinding{}, fmt.Errorf("host binding: credential identity requires both a kind and a label (WithIdentity); a half-identity is invalid")
+	}
+	if hp == "" && !hasIdentity {
+		return HostBinding{}, fmt.Errorf("host binding: a binding requires a host pattern or a complete credential identity (WithIdentity)")
 	}
 	if scheme == SchemeBasic && hb.BasicUsername == "" {
 		return HostBinding{}, fmt.Errorf("host binding: basic scheme requires a username (WithBasicUsername)")
@@ -534,6 +583,32 @@ func (h HostBindings) Match(host string) (HostBinding, bool) {
 	}
 	if bestWildcard != nil {
 		return *bestWildcard, true
+	}
+	return HostBinding{}, false
+}
+
+// MatchIdentity returns the HostBinding whose credential-identity pair
+// ([HostBinding.IdentityKind], [HostBinding.IdentityLabel]) equals the given
+// (kind, label), and true, or the zero binding and false when none match.
+//
+// It is the selection key for a step-scoped request that carries a credential
+// identity: the proxy resolves WHICH credential to inject by the manifest
+// identity the scope declared, not by the upstream host. The pair is
+// canonical, so an empty kind or an empty label never matches (defensive:
+// the mint already rejects a half-identity, but selection fails closed rather
+// than degrading to a fuzzy match). Inputs are trimmed before comparison. The
+// loader guarantees the table holds at most one binding per identity pair, so
+// this returns the first (and only) match deterministically.
+func (h HostBindings) MatchIdentity(kind, label string) (HostBinding, bool) {
+	kind = strings.TrimSpace(kind)
+	label = strings.TrimSpace(label)
+	if kind == "" || label == "" {
+		return HostBinding{}, false
+	}
+	for i := range h {
+		if h[i].IdentityKind == kind && h[i].IdentityLabel == label {
+			return h[i], true
+		}
 	}
 	return HostBinding{}, false
 }

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -436,3 +436,163 @@ func TestHostBindings_Match_CaseInsensitiveHost(t *testing.T) {
 		t.Error("host match must be case-insensitive")
 	}
 }
+
+func TestNewHostBinding_HostlessIdentityBindingConstructs(t *testing.T) {
+	// An identity binding declares an empty host pattern but a complete
+	// (kind, label) pair. It is selected by identity at egress, not by host.
+	hb, err := binding.NewHostBinding("", "user/aws", "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", "metrics-reader"),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", ""))
+	if err != nil {
+		t.Fatalf("unexpected error for host-less identity binding: %v", err)
+	}
+	if hb.HostPattern != "" {
+		t.Errorf("HostPattern = %q, want empty for identity binding", hb.HostPattern)
+	}
+	if hb.IdentityKind != "aws-sigv4" || hb.IdentityLabel != "metrics-reader" {
+		t.Errorf("identity = (%q,%q), want (aws-sigv4,metrics-reader)", hb.IdentityKind, hb.IdentityLabel)
+	}
+}
+
+func TestNewHostBinding_IdentityTrimmed(t *testing.T) {
+	hb, err := binding.NewHostBinding("", "user/aws", "sigv4-resign",
+		binding.WithIdentity("  aws-sigv4 ", " metrics-reader "),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.IdentityKind != "aws-sigv4" || hb.IdentityLabel != "metrics-reader" {
+		t.Errorf("identity = (%q,%q), want trimmed (aws-sigv4,metrics-reader)", hb.IdentityKind, hb.IdentityLabel)
+	}
+}
+
+func TestNewHostBinding_EmptyHostNoIdentityRejected(t *testing.T) {
+	// Neither a host pattern nor a complete identity: the binding has no
+	// selection key and fails construction.
+	if _, err := binding.NewHostBinding("", "user/aws", "sigv4-resign",
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", "")); err == nil {
+		t.Fatal("expected error for a binding with neither host nor identity, got nil")
+	}
+}
+
+func TestNewHostBinding_PartialIdentityRejected(t *testing.T) {
+	// The (kind, label) pair is canonical; a half-identity is never legal,
+	// even alongside a host pattern.
+	if _, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", ""),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", "")); err == nil {
+		t.Fatal("expected error for kind-only identity, got nil")
+	}
+	if _, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign",
+		binding.WithIdentity("", "metrics-reader"),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", "")); err == nil {
+		t.Fatal("expected error for label-only identity, got nil")
+	}
+	// Host-less with a half-identity is also rejected (no valid key at all).
+	if _, err := binding.NewHostBinding("", "user/aws", "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", ""),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", "")); err == nil {
+		t.Fatal("expected error for host-less kind-only identity, got nil")
+	}
+}
+
+func TestNewHostBinding_HostBindingWithoutIdentityStillConstructs(t *testing.T) {
+	// Regression: today's host-only binding (no identity) is unchanged.
+	hb, err := binding.NewHostBinding("api.example.com", "oauth2/github/octocat", "bearer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.IdentityKind != "" || hb.IdentityLabel != "" {
+		t.Errorf("identity = (%q,%q), want empty for a host-only binding", hb.IdentityKind, hb.IdentityLabel)
+	}
+}
+
+func TestNewHostBinding_HostAndIdentityCoexist(t *testing.T) {
+	// A binding may carry both a host pattern and a complete identity.
+	hb, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign",
+		binding.WithIdentity("aws-sigv4", "admin"),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.HostPattern != "s3.amazonaws.com" || hb.IdentityKind != "aws-sigv4" || hb.IdentityLabel != "admin" {
+		t.Errorf("got host=%q identity=(%q,%q)", hb.HostPattern, hb.IdentityKind, hb.IdentityLabel)
+	}
+}
+
+func mustIdentityBinding(t *testing.T, kind, label, ref string) binding.HostBinding {
+	t.Helper()
+	hb, err := binding.NewHostBinding("", ref, "sigv4-resign",
+		binding.WithIdentity(kind, label),
+		binding.WithSigV4Resign("AKIDEXAMPLE", "", ""))
+	if err != nil {
+		t.Fatalf("NewHostBinding identity (%q,%q): %v", kind, label, err)
+	}
+	return hb
+}
+
+func TestHostBindings_MatchIdentity_HitsExactPair(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustIdentityBinding(t, "aws-sigv4", "metrics-reader", "user/aws"),
+	}
+	hb, ok := tbl.MatchIdentity("aws-sigv4", "metrics-reader")
+	if !ok {
+		t.Fatal("MatchIdentity must hit the exact (kind, label) pair")
+	}
+	if hb.CredentialRef != "user/aws" {
+		t.Errorf("CredentialRef = %q, want user/aws", hb.CredentialRef)
+	}
+}
+
+func TestHostBindings_MatchIdentity_Misses(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustIdentityBinding(t, "aws-sigv4", "metrics-reader", "user/aws"),
+	}
+	cases := []struct{ kind, label string }{
+		{"aws-sigv4", "admin"},       // wrong label
+		{"gcp-sa", "metrics-reader"}, // wrong kind
+		{"aws-sigv4", ""},            // empty label (defensive)
+		{"", "metrics-reader"},       // empty kind (defensive)
+		{"", ""},                     // both empty
+	}
+	for _, c := range cases {
+		if _, ok := tbl.MatchIdentity(c.kind, c.label); ok {
+			t.Errorf("MatchIdentity(%q,%q) matched, want miss", c.kind, c.label)
+		}
+	}
+}
+
+func TestHostBindings_MatchIdentity_TrimsInput(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustIdentityBinding(t, "aws-sigv4", "metrics-reader", "user/aws"),
+	}
+	if _, ok := tbl.MatchIdentity(" aws-sigv4 ", "  metrics-reader "); !ok {
+		t.Error("MatchIdentity must trim inputs before comparison")
+	}
+}
+
+func TestHostBindings_HostAndIdentityCoexistInOneTable(t *testing.T) {
+	// A host binding and an identity binding in the same table: Match(host)
+	// finds only the host one; MatchIdentity(pair) finds only the identity one.
+	hostBinding := mustHostBinding(t, "api.example.com", "oauth2/github/octocat", "bearer")
+	idBinding := mustIdentityBinding(t, "aws-sigv4", "metrics-reader", "user/aws")
+	tbl := binding.HostBindings{hostBinding, idBinding}
+
+	hb, ok := tbl.Match("api.example.com")
+	if !ok || hb.CredentialRef != "oauth2/github/octocat" {
+		t.Errorf("Match(host) = (%+v, %v), want the host binding", hb, ok)
+	}
+	// The identity binding has an empty host pattern, so it never matches by host.
+	if _, ok := tbl.Match(""); ok {
+		t.Error("Match must never match an empty host (identity binding is host-less)")
+	}
+
+	idHB, ok := tbl.MatchIdentity("aws-sigv4", "metrics-reader")
+	if !ok || idHB.CredentialRef != "user/aws" {
+		t.Errorf("MatchIdentity = (%+v, %v), want the identity binding", idHB, ok)
+	}
+	// The host binding declares no identity, so it never matches by identity.
+	if _, ok := tbl.MatchIdentity("", ""); ok {
+		t.Error("MatchIdentity must never match a host binding with no identity")
+	}
+}

--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -39,6 +39,15 @@ func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
 		opts = append(opts, binding.WithTrustContract(e.Effect, e.AllowedHosts))
 	}
 
+	// Carry the optional credential identity (#1978). When declared, the
+	// binding is selectable by its (kind, identity_label) pair at egress and
+	// its host may be empty. The constructor enforces the pair-is-canonical
+	// and host-or-identity rules, the single source of truth for legality, so
+	// a malformed identity entry that reached here fails construction below.
+	if e.Kind != "" || e.IdentityLabel != "" {
+		opts = append(opts, binding.WithIdentity(e.Kind, e.IdentityLabel))
+	}
+
 	if e.EmitMechanism == string(binding.EmitMechanismSentinelSwap) {
 		opts = append(opts, binding.WithEmitMechanismSentinelSwap())
 		// A sentinel-swap entry carries the sentinel shape (value + env) it

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -40,6 +40,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -123,7 +124,23 @@ type Entry struct {
 	// form ("*.example.com"), mirroring internal/binding.HostBinding's
 	// match semantics rather than inventing a second matcher. Ports are
 	// not part of the pattern.
+	//
+	// Host is optional when the entry declares a complete credential
+	// identity ([Entry.Kind] + [Entry.IdentityLabel]): such an identity
+	// binding is selected at egress by its (kind, label) pair, not by host
+	// (#1978). An entry with neither a host nor a complete identity is a
+	// load-time error.
 	Host string `yaml:"host"`
+
+	// Kind and IdentityLabel are the non-secret manifest credential-identity
+	// pair (#1978): the credential `kind` (e.g. "aws-sigv4") and the manifest
+	// `identity_label` naming which credential of that kind to inject. When
+	// both are set, the entry is a host-less-permitted identity binding the
+	// proxy selects by identity at egress. The pair is canonical: declare both
+	// or neither. A half-identity (exactly one set) is a load-time error. Maps
+	// onto internal/binding.HostBinding via [binding.WithIdentity].
+	Kind          string `yaml:"kind"`
+	IdentityLabel string `yaml:"identity_label"`
 
 	// CredentialRef is a vault credential reference resolved daemon-side
 	// at injection time, never to the container. It is a connector-style
@@ -268,13 +285,39 @@ func Parse(data []byte) (Descriptor, error) {
 		if err := e.Validate(); err != nil {
 			return Descriptor{}, fmt.Errorf("proxybinding: binding %d (%q): %w", i, e.Host, err)
 		}
-		if _, dup := seen[e.Host]; dup {
-			return Descriptor{}, fmt.Errorf("proxybinding: duplicate host %q within a single descriptor", e.Host)
+		key := e.dedupKey()
+		if _, dup := seen[key]; dup {
+			return Descriptor{}, fmt.Errorf("proxybinding: duplicate binding %s within a single descriptor", e.dedupLabel())
 		}
-		seen[e.Host] = struct{}{}
+		seen[key] = struct{}{}
 	}
 
 	return d, nil
+}
+
+// dedupKey is the uniqueness/override key for an entry. A host entry keys on
+// its lowercased host; a host-less identity entry keys on its (kind, label)
+// pair. Keying host-less entries on the identity pair (not on host == "")
+// lets two identity bindings with different labels coexist without a spurious
+// `duplicate host ""` collision, and lets a later layer override an earlier
+// identity binding with the same pair (matching the per-host override
+// semantics). The two namespaces are prefix-disjoint so a host can never
+// collide with an identity. An entry carrying both a host and an identity keys
+// on the host: it is still primarily a host binding, and its identity is an
+// additional selection key rather than its uniqueness key.
+func (e *Entry) dedupKey() string {
+	if e.Host != "" {
+		return "host:" + strings.ToLower(e.Host)
+	}
+	return "id:" + e.Kind + "\x00" + e.IdentityLabel
+}
+
+// dedupLabel is the human-readable form of the dedup key for error messages.
+func (e *Entry) dedupLabel() string {
+	if e.Host != "" {
+		return fmt.Sprintf("host %q", e.Host)
+	}
+	return fmt.Sprintf("identity (kind %q, identity_label %q)", e.Kind, e.IdentityLabel)
 }
 
 // Validate checks that an Entry's required fields are present and
@@ -296,8 +339,18 @@ func (e *Entry) Validate() error {
 		return err
 	}
 
-	if e.Host == "" {
-		return fmt.Errorf("missing required field: host")
+	// An entry is keyed by a host, a credential identity, or both. The
+	// identity pair is canonical: a half-identity (exactly one of kind or
+	// identity_label set) fails closed, and an entry with neither a host nor
+	// a complete identity has no selection key at all. The constructor
+	// (ToHostBinding, called at the end of Validate) is the single source of
+	// truth, but naming the failure here yields a clearer descriptor error.
+	hasIdentity := e.Kind != "" && e.IdentityLabel != ""
+	if (e.Kind != "") != (e.IdentityLabel != "") {
+		return fmt.Errorf("credential identity requires both kind and identity_label; a half-identity is invalid")
+	}
+	if e.Host == "" && !hasIdentity {
+		return fmt.Errorf("missing required field: host (or a complete credential identity: kind + identity_label)")
 	}
 	if e.CredentialRef == "" {
 		return fmt.Errorf("missing required field: credential_ref")
@@ -390,6 +443,8 @@ func (e *Entry) rejectPlaceholders() error {
 	}
 	fields := []namedField{
 		{"host", e.Host},
+		{"kind", e.Kind},
+		{"identity_label", e.IdentityLabel},
 		{"credential_ref", e.CredentialRef},
 		{"scheme", e.Scheme},
 		{"emit_mechanism", e.EmitMechanism},

--- a/internal/proxybinding/identity_test.go
+++ b/internal/proxybinding/identity_test.go
@@ -1,0 +1,218 @@
+package proxybinding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// TestParse_HostlessIdentityEntry pins the host-less identity binding: a
+// sigv4-resign entry that declares kind + identity_label but no host loads,
+// and its ToHostBinding is selectable by MatchIdentity.
+func TestParse_HostlessIdentityEntry(t *testing.T) {
+	const yaml = `
+version: v1
+bindings:
+  - kind: aws-sigv4
+    identity_label: metrics-reader
+    credential_ref: user/aws
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+`
+	d, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.Bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1", len(d.Bindings))
+	}
+	e := d.Bindings[0]
+	if e.Host != "" {
+		t.Errorf("host = %q, want empty for identity binding", e.Host)
+	}
+	if e.Kind != "aws-sigv4" || e.IdentityLabel != "metrics-reader" {
+		t.Errorf("identity = (%q,%q), want (aws-sigv4,metrics-reader)", e.Kind, e.IdentityLabel)
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	tbl := binding.HostBindings{hb}
+	if _, ok := tbl.MatchIdentity("aws-sigv4", "metrics-reader"); !ok {
+		t.Error("MatchIdentity must select the parsed host-less identity binding")
+	}
+}
+
+// TestParse_TwoIdentityEntriesDifferentLabels ensures two host-less identity
+// entries with different labels coexist in one document: they must NOT collide
+// as `duplicate host ""`.
+func TestParse_TwoIdentityEntriesDifferentLabels(t *testing.T) {
+	const yaml = `
+version: v1
+bindings:
+  - kind: aws-sigv4
+    identity_label: metrics-reader
+    credential_ref: user/aws
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+  - kind: aws-sigv4
+    identity_label: admin
+    credential_ref: user/aws
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+`
+	d, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.Bindings) != 2 {
+		t.Fatalf("bindings = %d, want 2", len(d.Bindings))
+	}
+}
+
+// TestParse_DuplicateIdentityPair rejects two entries with the same
+// (kind, identity_label) pair, naming the pair in the error.
+func TestParse_DuplicateIdentityPair(t *testing.T) {
+	const yaml = `
+version: v1
+bindings:
+  - kind: aws-sigv4
+    identity_label: metrics-reader
+    credential_ref: user/aws
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+  - kind: aws-sigv4
+    identity_label: metrics-reader
+    credential_ref: user/other
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected duplicate-identity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "identity") || !strings.Contains(err.Error(), "metrics-reader") {
+		t.Errorf("error = %q, want it to name the duplicate identity pair", err.Error())
+	}
+}
+
+// TestParse_NeitherHostNorIdentity rejects an entry with no host and no
+// identity: it has no selection key.
+func TestParse_NeitherHostNorIdentity(t *testing.T) {
+	const yaml = `
+version: v1
+bindings:
+  - credential_ref: user/aws
+    scheme: sigv4-resign
+    access_key_id: AKIDEXAMPLE
+`
+	if _, err := Parse([]byte(yaml)); err == nil {
+		t.Fatal("expected error for entry with neither host nor identity, got nil")
+	}
+}
+
+// TestParse_PartialIdentity rejects a half-identity (exactly one of kind or
+// identity_label) whether or not a host is present.
+func TestParse_PartialIdentity(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "kind only, host-less",
+			yaml: "version: v1\nbindings:\n  - kind: aws-sigv4\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n",
+		},
+		{
+			name: "label only, host-less",
+			yaml: "version: v1\nbindings:\n  - identity_label: metrics-reader\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n",
+		},
+		{
+			name: "kind only, with host",
+			yaml: "version: v1\nbindings:\n  - host: s3.amazonaws.com\n    kind: aws-sigv4\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse([]byte(tc.yaml)); err == nil {
+				t.Fatalf("Parse(%s) = nil error, want error", tc.name)
+			}
+		})
+	}
+}
+
+// TestParse_PlaceholderScanCoversIdentityFields ensures the placeholder guard
+// catches an un-substituted "<...>" span in kind or identity_label.
+func TestParse_PlaceholderScanCoversIdentityFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		yaml  string
+		field string
+	}{
+		{
+			name:  "placeholder in kind",
+			yaml:  "version: v1\nbindings:\n  - kind: \"<kind>\"\n    identity_label: metrics-reader\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n",
+			field: "kind",
+		},
+		{
+			name:  "placeholder in identity_label",
+			yaml:  "version: v1\nbindings:\n  - kind: aws-sigv4\n    identity_label: \"<label>\"\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n",
+			field: "identity_label",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected placeholder error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error = %q, want it to name field %q", err.Error(), tc.field)
+			}
+		})
+	}
+}
+
+// TestLoad_UserLayerOverridesIdentityBinding pins that a user-layer identity
+// entry overrides a built-in one with the same (kind, label) pair, and that
+// host entries still override per host, with deterministic ordering.
+func TestLoad_UserLayerOverridesIdentityBinding(t *testing.T) {
+	builtin := Entry{
+		Kind:          "aws-sigv4",
+		IdentityLabel: "metrics-reader",
+		CredentialRef: "user/aws",
+		Scheme:        "sigv4-resign",
+		AccessKeyID:   "AKIDEXAMPLE",
+	}
+	// A different label => distinct dedup key; both survive.
+	otherLabel := Entry{
+		Kind:          "aws-sigv4",
+		IdentityLabel: "admin",
+		CredentialRef: "user/aws",
+		Scheme:        "sigv4-resign",
+		AccessKeyID:   "AKIDEXAMPLE",
+	}
+	// Same pair as builtin => overrides it (different credential_ref).
+	override := Entry{
+		Kind:          "aws-sigv4",
+		IdentityLabel: "metrics-reader",
+		CredentialRef: "oauth2/aws/metrics",
+		Scheme:        "sigv4-resign",
+		AccessKeyID:   "AKIDEXAMPLE",
+	}
+
+	// Emulate the merge via applyLayer directly (Load uses the same helper).
+	merged := map[string]Entry{}
+	applyLayer(merged, []Entry{builtin, otherLabel})
+	applyLayer(merged, []Entry{override})
+	if len(merged) != 2 {
+		t.Fatalf("merged entries = %d, want 2 (override collapses onto builtin)", len(merged))
+	}
+	got := merged[override.dedupKey()]
+	if got.CredentialRef != "oauth2/aws/metrics" {
+		t.Errorf("overridden credential_ref = %q, want oauth2/aws/metrics", got.CredentialRef)
+	}
+	if merged[otherLabel.dedupKey()].IdentityLabel != "admin" {
+		t.Error("the distinct-label identity binding must survive the merge")
+	}
+}

--- a/internal/proxybinding/loader.go
+++ b/internal/proxybinding/loader.go
@@ -74,16 +74,19 @@ func Load(opts LoadOptions) ([]Entry, error) {
 	for _, e := range merged {
 		out = append(out, e)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
+	sort.Slice(out, func(i, j int) bool { return out[i].dedupKey() < out[j].dedupKey() })
 	return out, nil
 }
 
-// applyLayer overlays a layer's entries onto the merged map, last-write-
-// wins per host. The map carries the override semantics; ordering is
-// re-derived deterministically by Load.
+// applyLayer overlays a layer's entries onto the merged map, last-write-wins
+// per dedup key. The key is the host for a host entry and the (kind, label)
+// pair for a host-less identity entry (see [Entry.dedupKey]), so a user layer
+// overrides a built-in entry with the same host OR the same identity pair. The
+// map carries the override semantics; ordering is re-derived deterministically
+// by Load.
 func applyLayer(merged map[string]Entry, layer []Entry) {
 	for _, e := range layer {
-		merged[e.Host] = e
+		merged[e.dedupKey()] = e
 	}
 }
 


### PR DESCRIPTION
## Summary

Step 3 of umbrella #1978. The forward proxy now consumes the step scope's carried credential identity `(kind, identityLabel)` to select **which** bound credential to inject at egress, instead of resolving purely by upstream host. A host-less identity binding is now a first-class binding, keyed by its identity pair.

Both dependencies had already landed on `main`: #1985 threads `kind`+`identityLabel` onto the step scope, and #1986 derives the SigV4 region/service from the resolved sealed host. This PR wires the consuming side.

### What changed

- **`internal/binding`** — `HostBinding` gains `IdentityKind`/`IdentityLabel`, a `WithIdentity(kind,label)` option, and a deterministic `MatchIdentity(kind,label)` lookup. `NewHostBinding` now accepts an empty host pattern **iff** a complete identity is declared; it rejects a keyless binding and a half-identity (exactly one of kind/label).
- **`internal/proxybinding`** — `Entry` gains `kind`/`identity_label`. `Validate` requires a host **or** a complete identity and rejects a half-identity. Descriptor dedup and loader merge/sort re-key on the identity pair for host-less entries (via `Entry.dedupKey()`), so two identity bindings load without a `duplicate host ""` collision and a user layer overrides a built-in identity binding on the pair. The identity is carried onto the `HostBinding`, and the placeholder scan covers the new fields.
- **`internal/app`** — In `routeSandboxForwardProxyHostBinding`, an identity-carrying scope (non-empty `CredentialKind`) selects via `MatchIdentity` and **fails closed**: a half-identity → 403 `binding_identity_incomplete`; an unbound identity → 403 `binding_identity_unbound`. **No** fallback to `Match(host)`, **no** passthrough. A scope with no identity keeps today's host-match path exactly. Everything after selection (private-IP refusal, `enforceHostBindingTrust`, sentinel-swap, injection, dial, audit) is untouched.

The sealed-reach CONNECT gate and the per-step trust-contract gate keep their code paths and behavior; this change only alters *which* `hb` is selected before those consumers run.

### Out of scope (other sub-issues)

Removing `host`/`region`/`service` from the binding surfaces (#1982); the mint-side credential-block plumbing and its 400 (#1985/#1980); region/service derivation (#1986). No OpenAPI change; `server.gen.go` untouched.

## Test plan

- `go test ./internal/binding/...` — identity construction (host-less, trimmed, half-identity rejected, host+identity coexist), `MatchIdentity` hit/miss/trim, host-and-identity table coexistence. Coverage 91.8%.
- `go test ./internal/proxybinding/...` — host-less identity entry parses and is `MatchIdentity`-selectable; two labels coexist; duplicate pair rejected naming the pair; neither-host-nor-identity and partial-identity rejected; placeholder scan covers `kind`/`identity_label`; user-layer override on the pair. Coverage 95.4%.
- `go test ./internal/app/... -run SandboxForwardProxy` — happy path (identity selects the credential + host-derived scope, `binding_injected`); **fail-closed regression** (unbound identity with a decoy host-match binding present → 403, host binding not used, no dial); half-identity defense (403, no dial); no-identity scope preserves host-match; two identities disambiguate by access key id; trust-gate-unchanged (read-effect denies POST on an identity binding).
- `go test ./internal/...` green; `go vet ./internal/...` clean; no generated-file drift.
- CodeRabbit review clean (one minor doc-comment mismatch fixed).

Closes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting bindings by credential identity as well as by host.
  * Hostless identity-based bindings are now allowed when identity is complete.

* **Bug Fixes**
  * Identity-based requests now fail closed on missing or incomplete identity information.
  * Binding selection now avoids accidental fallbacks when an identity match is expected.

* **Tests**
  * Added coverage for identity selection, duplicate handling, validation, and host/identity coexistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->