### PR TITLE
test(proxybinding): pin case-insensitive host-entry dedup

### DIFF
--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -244,6 +244,18 @@ func TestParse_Errors(t *testing.T) {
 			name: "duplicate host in one descriptor",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n  - host: api.example.com\n    credential_ref: user/other\n    scheme: bearer\n",
 		},
+		{
+			// Host-entry dedup is case-insensitive: two hosts differing only
+			// in case (API.example.com vs api.example.com) collide on the
+			// lowercased dedupKey and are rejected as a duplicate binding
+			// within one descriptor. This pins Entry.dedupKey's ToLower(Host)
+			// so the host-entry dedup stays consistent with the already
+			// case-insensitive host Match (NewHostBinding lowercases
+			// HostPattern); two such entries must never silently coexist as
+			// separate bindings.
+			name: "duplicate host differing only in case",
+			yaml: "version: v1\nbindings:\n  - host: API.example.com\n    credential_ref: user/example\n    scheme: bearer\n  - host: api.example.com\n    credential_ref: user/other\n    scheme: bearer\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a regression test pinning the now case-insensitive host-entry dedup in `proxybinding.Parse`. `Entry.dedupKey()` returns `"host:" + strings.ToLower(e.Host)`, so two host entries that differ only in case collide on the lowercased key. This matches the pre-existing case-insensitive host `Match` (`NewHostBinding` lowercases `HostPattern`), but that behavior was previously unpinned by a test.

The new `TestParse_Errors` case (`duplicate host differing only in case`) asserts that a descriptor with `API.example.com` and `api.example.com` is rejected as a duplicate binding within one descriptor. It fails against a case-sensitive `seen[e.Host]` dedup and passes against the shipped `dedupKey()`, guarding a silent regression back to case-sensitive host dedup.

Test-only addition of already-shipped, self-consistent behavior. No production code changes.

## Test plan

- `go test ./internal/proxybinding/` passes.
- `go test ./internal/proxybinding/ -run TestParse_Errors -v` shows the new `duplicate_host_differing_only_in_case` subtest PASS.
- `go vet ./internal/proxybinding/` clean.

Relates to #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
