### PR TITLE
feat(proxybinding): idempotent descriptor writer for the user file

### DIFF
--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -130,7 +130,7 @@ type Entry struct {
 	// binding is selected at egress by its (kind, label) pair, not by host
 	// (#1978). An entry with neither a host nor a complete identity is a
 	// load-time error.
-	Host string `yaml:"host"`
+	Host string `yaml:"host,omitempty"`
 
 	// Kind and IdentityLabel are the non-secret manifest credential-identity
 	// pair (#1978): the credential `kind` (e.g. "aws-sigv4") and the manifest
@@ -139,20 +139,20 @@ type Entry struct {
 	// proxy selects by identity at egress. The pair is canonical: declare both
 	// or neither. A half-identity (exactly one set) is a load-time error. Maps
 	// onto internal/binding.HostBinding via [binding.WithIdentity].
-	Kind          string `yaml:"kind"`
-	IdentityLabel string `yaml:"identity_label"`
+	Kind          string `yaml:"kind,omitempty"`
+	IdentityLabel string `yaml:"identity_label,omitempty"`
 
 	// CredentialRef is a vault credential reference resolved daemon-side
 	// at injection time, never to the container. It is a connector-style
 	// binding name ("<kind>/<service>/<identity>") or a user-level ref
 	// ("user/<service>"), the same name contract internal/binding
 	// enforces. It is never the credential bytes.
-	CredentialRef string `yaml:"credential_ref"`
+	CredentialRef string `yaml:"credential_ref,omitempty"`
 
 	// Scheme is one of the closed injection-scheme set (#1194):
 	// bearer | basic | header-template | query-param | sigv4-resign. An
 	// unknown scheme is a load-time error (fail closed, no silent skip).
-	Scheme string `yaml:"scheme"`
+	Scheme string `yaml:"scheme,omitempty"`
 
 	// EmitMechanism declares how the credential reaches egress: "inject"
 	// (inject at the proxy) or "sentinel-swap". Optional; empty defaults to
@@ -160,7 +160,7 @@ type Entry struct {
 	// [Entry.Sentinel] block; an inject binding (explicit or defaulted)
 	// must declare none. Any value outside the closed set is a load-time
 	// error.
-	EmitMechanism string `yaml:"emit_mechanism"`
+	EmitMechanism string `yaml:"emit_mechanism,omitempty"`
 
 	// Sentinel is the sentinel-swap placeholder declaration: the non-secret
 	// value the launcher plants inside the container and the env-var name it
@@ -169,26 +169,26 @@ type Entry struct {
 	// load-time error, since the field is meaningless without sentinel-swap).
 	// It is a pointer so an absent block is distinguishable from a present
 	// block with empty fields. See [Sentinel].
-	Sentinel *Sentinel `yaml:"sentinel"`
+	Sentinel *Sentinel `yaml:"sentinel,omitempty"`
 
 	// Username is the non-secret HTTP basic-auth username, required only
 	// for the basic scheme (e.g. "x-access-token" for git-over-HTTPS).
-	Username string `yaml:"username"`
+	Username string `yaml:"username,omitempty"`
 
 	// Header is the header name to set, required only for the
 	// header-template scheme (e.g. "Authorization" or a vendor header).
-	Header string `yaml:"header"`
+	Header string `yaml:"header,omitempty"`
 
 	// Template is the verbatim header value for the header-template
 	// scheme, with the "{token}" placeholder substituted with the secret
 	// at inject time. Required for header-template. To emit Linear's
 	// verbatim "Authorization: <key>" with no Bearer prefix, set
 	// Template to "{token}".
-	Template string `yaml:"template"`
+	Template string `yaml:"template,omitempty"`
 
 	// QueryParam is the query-parameter name to set, required only for the
 	// query-param scheme.
-	QueryParam string `yaml:"query_param"`
+	QueryParam string `yaml:"query_param,omitempty"`
 
 	// AccessKeyID is the non-secret AWS access key ID, required only for the
 	// sigv4-resign scheme. It appears verbatim in the signed request's
@@ -197,7 +197,7 @@ type Entry struct {
 	// service: the egress injector derives the SigV4 credential scope from the
 	// resolved upstream host (#1978), so there is no second, operator-supplied
 	// copy of the region that could drift from the host being signed for.
-	AccessKeyID string `yaml:"access_key_id"`
+	AccessKeyID string `yaml:"access_key_id,omitempty"`
 
 	// AllowedHosts is the optional per-binding trust-contract host
 	// allowlist. Empty means unconstrained: egress on the bound host stays
@@ -206,7 +206,7 @@ type Entry struct {
 	// match an entry (host or host:port form) or the request is denied and
 	// audited. Non-secret. Maps onto internal/binding.HostBinding via
 	// [binding.WithTrustContract].
-	AllowedHosts []string `yaml:"allowed_hosts"`
+	AllowedHosts []string `yaml:"allowed_hosts,omitempty"`
 
 	// Effect is the optional per-binding trust-contract effect, one of
 	// internal/binding.HostBindingEffects (read | write | delete | spend |
@@ -216,7 +216,7 @@ type Entry struct {
 	// effect admits all methods (the proxy cannot distinguish write from
 	// delete/spend/external-send on the wire). An unknown effect is a
 	// load-time error (fail closed). Non-secret.
-	Effect string `yaml:"effect"`
+	Effect string `yaml:"effect,omitempty"`
 }
 
 // Sentinel is the per-binding sentinel-swap placeholder declaration. It makes

--- a/internal/proxybinding/writer.go
+++ b/internal/proxybinding/writer.go
@@ -1,0 +1,132 @@
+package proxybinding
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Upsert idempotently merges entries into the user binding-descriptors file
+// at path, writing the result as a strict, human-editable v1 descriptor with
+// 0600 permissions. It is the programmatic counterpart to hand-editing
+// ~/.aileron/binding-descriptors.yaml: callers pass [DefaultUserPath] (tests
+// inject a temp path) and one or more entries to add or replace.
+//
+// The merge is order-preserving and last-write-wins per [Entry.dedupKey]: an
+// incoming entry whose key matches an existing entry replaces it in place, and
+// an incoming entry with a new key is appended. Existing entries the caller did
+// not name are never touched or reordered, so repeatedly upserting the same
+// entries is a no-op on the document's meaningful content. Among the incoming
+// entries themselves, a later entry overrides an earlier one with the same key.
+//
+// Validation happens entirely before any filesystem mutation. The merged
+// document is marshaled and re-parsed through [Parse] as the single pre-write
+// gate: this reuses [Entry.Validate], the strict-decode check, and the
+// duplicate-key check, and simultaneously proves the serialized bytes re-parse
+// clean. A document that fails validation returns a non-nil error and writes
+// nothing, so an invalid Upsert never leaves a partial or corrupt file (an
+// existing file is left byte-identical, an absent file is not created).
+//
+// A missing file (or an empty one) is treated as an empty v1 document, so the
+// first Upsert into a fresh path creates a valid descriptor. The parent
+// directory is created 0700 if absent.
+//
+// Upsert handles only [Entry] values, which carry a credential *reference*
+// (a vault path) and never credential bytes. It never resolves or logs secret
+// material, inheriting this package's secret-hygiene invariant.
+func Upsert(path string, entries ...Entry) error {
+	existing, err := readExisting(path)
+	if err != nil {
+		return fmt.Errorf("proxybinding: read existing descriptor %q: %w", path, err)
+	}
+
+	merged := mergeEntries(existing, entries)
+
+	doc := Descriptor{Version: SchemaVersion, Bindings: merged}
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("proxybinding: marshal descriptor: %w", err)
+	}
+
+	// Route the pre-write check through Parse so the serialized bytes must
+	// re-parse clean through the same validation the loader applies. This is
+	// the only mutation gate: nothing below runs if the document is invalid.
+	if _, err := Parse(data); err != nil {
+		return fmt.Errorf("proxybinding: merged descriptor is invalid: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("proxybinding: create descriptor dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("proxybinding: write descriptor %q: %w", path, err)
+	}
+	return nil
+}
+
+// readExisting reads the current descriptor entries at path for an upsert. It
+// tolerates two "empty document" cases that are legitimate starting points for
+// a write: an absent file and an existing file that is empty or whitespace-only
+// (both yield nil entries so the first Upsert seeds a fresh document). Unlike
+// [parseLayerFile] — the loader's read path, which treats a 0-byte file as a
+// parse error — the writer must be able to bootstrap an empty file into a valid
+// v1 document. A present file with real content is parsed strictly through
+// [Parse]; a malformed one is an error so an upsert never silently discards an
+// unreadable existing document.
+func readExisting(path string) ([]Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
+	d, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return d.Bindings, nil
+}
+
+// mergeEntries overlays incoming onto existing, preserving order and applying
+// last-write-wins per [Entry.dedupKey]. It is the pure, disk-free core of
+// [Upsert], factored out so the merge semantics are independently unit-testable.
+//
+// The result begins as a copy of existing in its original order. For each
+// incoming entry in order, if its dedup key matches a slot already in the
+// result the slot is replaced in place (so an override never duplicates or
+// reorders the entry); otherwise the entry is appended. Applying incoming in
+// order means a later incoming entry overrides an earlier one with the same
+// key, matching the loader's last-write-wins semantics while keeping the
+// document's existing entries in their original positions.
+func mergeEntries(existing, incoming []Entry) []Entry {
+	merged := make([]Entry, len(existing))
+	copy(merged, existing)
+
+	// index maps a dedup key to its slot in merged so an override lands in
+	// place rather than appending a duplicate. It is rebuilt from existing and
+	// extended as new keys are appended.
+	index := make(map[string]int, len(merged))
+	for i := range merged {
+		index[merged[i].dedupKey()] = i
+	}
+
+	for _, e := range incoming {
+		key := e.dedupKey()
+		if pos, ok := index[key]; ok {
+			merged[pos] = e
+			continue
+		}
+		index[key] = len(merged)
+		merged = append(merged, e)
+	}
+	return merged
+}

--- a/internal/proxybinding/writer_test.go
+++ b/internal/proxybinding/writer_test.go
@@ -1,0 +1,325 @@
+package proxybinding
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// bearerEntry is a minimal, valid bearer-scheme host entry for writer tests.
+func bearerEntry(host, ref string) Entry {
+	return Entry{Host: host, CredentialRef: ref, Scheme: "bearer"}
+}
+
+// parseFile reads and parses a descriptor file, failing the test on error.
+func parseFile(t *testing.T, path string) Descriptor {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	d, err := Parse(data)
+	if err != nil {
+		t.Fatalf("parse %s: %v\n%s", path, err, data)
+	}
+	return d
+}
+
+// entryByKey returns the entry with the given dedup key, or false.
+func entryByKey(entries []Entry, key string) (Entry, bool) {
+	for _, e := range entries {
+		if e.dedupKey() == key {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Round-trip: Upsert of multiple entries into a fresh path yields, on re-read,
+// exactly those entries with their fields intact.
+func TestUpsert_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	e1 := bearerEntry("api.example.com", "user/example")
+	e2 := Entry{
+		Host:          "api.linear.app",
+		CredentialRef: "user/linear",
+		Scheme:        "header-template",
+		Header:        "Authorization",
+		Template:      "{token}",
+	}
+
+	if err := Upsert(path, e1, e2); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	d := parseFile(t, path)
+	if d.Version != SchemaVersion {
+		t.Errorf("version = %q, want %q", d.Version, SchemaVersion)
+	}
+	if len(d.Bindings) != 2 {
+		t.Fatalf("bindings = %d, want 2", len(d.Bindings))
+	}
+	for _, want := range []Entry{e1, e2} {
+		got, ok := entryByKey(d.Bindings, want.dedupKey())
+		if !ok {
+			t.Fatalf("missing entry for key %q", want.dedupKey())
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("entry %q = %+v, want %+v", want.dedupKey(), got, want)
+		}
+	}
+}
+
+// Merge preserves unrelated entries: upserting a new entry onto a seeded file
+// leaves the existing entries in place, in order, with a new entry appended.
+func TestUpsert_PreservesUnrelatedEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	a := bearerEntry("a.example.com", "user/a")
+	b := bearerEntry("b.example.com", "user/b")
+	if err := Upsert(path, a, b); err != nil {
+		t.Fatalf("seed Upsert: %v", err)
+	}
+
+	c := bearerEntry("c.example.com", "user/c")
+	if err := Upsert(path, c); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	d := parseFile(t, path)
+	if len(d.Bindings) != 3 {
+		t.Fatalf("bindings = %d, want 3", len(d.Bindings))
+	}
+	// Original relative order preserved (a, b), c appended last.
+	wantOrder := []Entry{a, b, c}
+	for i, want := range wantOrder {
+		if !reflect.DeepEqual(d.Bindings[i], want) {
+			t.Errorf("bindings[%d] = %+v, want %+v", i, d.Bindings[i], want)
+		}
+	}
+}
+
+// Override by key: upserting an entry whose dedup key matches an existing one
+// replaces it in place with the new fields; no duplicate is produced.
+func TestUpsert_OverrideByKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	orig := Entry{
+		Host:          "api.example.com",
+		CredentialRef: "user/old",
+		Scheme:        "header-template",
+		Header:        "Authorization",
+		Template:      "Bearer {token}",
+	}
+	if err := Upsert(path, orig); err != nil {
+		t.Fatalf("seed Upsert: %v", err)
+	}
+
+	updated := Entry{
+		Host:          "api.example.com",
+		CredentialRef: "user/new",
+		Scheme:        "header-template",
+		Header:        "Authorization",
+		Template:      "{token}",
+	}
+	if err := Upsert(path, updated); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	d := parseFile(t, path)
+	if len(d.Bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1 (override, not duplicate)", len(d.Bindings))
+	}
+	if !reflect.DeepEqual(d.Bindings[0], updated) {
+		t.Errorf("entry = %+v, want %+v", d.Bindings[0], updated)
+	}
+}
+
+// Case-insensitive host override: a host differing only in case shares the
+// dedup key, so upserting it replaces rather than duplicates (guards the
+// strings.ToLower dedup contract, mirroring #1994).
+func TestUpsert_CaseInsensitiveHostOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	if err := Upsert(path, bearerEntry("api.linear.app", "user/lower")); err != nil {
+		t.Fatalf("seed Upsert: %v", err)
+	}
+
+	upper := bearerEntry("API.Linear.App", "user/upper")
+	if err := Upsert(path, upper); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	d := parseFile(t, path)
+	if len(d.Bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1 (case-insensitive override)", len(d.Bindings))
+	}
+	if !reflect.DeepEqual(d.Bindings[0], upper) {
+		t.Errorf("entry = %+v, want %+v", d.Bindings[0], upper)
+	}
+}
+
+// Reject invalid document: an entry that fails Entry.Validate makes Upsert
+// return an error and leaves the target file byte-identical (existing) or
+// never creates it (absent).
+func TestUpsert_RejectInvalidLeavesFileUnchanged(t *testing.T) {
+	t.Run("existing file untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+		if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err != nil {
+			t.Fatalf("seed Upsert: %v", err)
+		}
+		before, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+
+		// Missing credential_ref fails Entry.Validate.
+		invalid := Entry{Host: "bad.example.com", Scheme: "bearer"}
+		if err := Upsert(path, invalid); err == nil {
+			t.Fatal("Upsert accepted an invalid entry, want error")
+		}
+
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Errorf("file mutated on rejected Upsert:\nbefore=%q\nafter=%q", before, after)
+		}
+	})
+
+	t.Run("absent file not created", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+		// A sigv4-resign entry carrying a host is invalid per Entry.Validate.
+		invalid := Entry{
+			Host:          "s3.amazonaws.com",
+			Kind:          "aws-sigv4",
+			IdentityLabel: "default",
+			CredentialRef: "aws-sigv4/s3/default",
+			Scheme:        "sigv4-resign",
+			AccessKeyID:   "AKIDEXAMPLE",
+		}
+		if err := Upsert(path, invalid); err == nil {
+			t.Fatal("Upsert accepted an invalid entry, want error")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("target file exists after rejected Upsert; want absent (stat err = %v)", err)
+		}
+	})
+}
+
+// A malformed existing file (e.g. an operator hand-edited it into an invalid
+// state) makes Upsert error rather than clobbering it: the write must never
+// silently discard an unreadable existing document.
+func TestUpsert_MalformedExistingFileErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	// Wrong version fails Parse.
+	garbage := []byte("version: v99\nbindings: []\n")
+	if err := os.WriteFile(path, garbage, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err == nil {
+		t.Fatal("Upsert accepted a malformed existing file, want error")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(after) != string(garbage) {
+		t.Errorf("file mutated on error:\nbefore=%q\nafter=%q", garbage, after)
+	}
+}
+
+// File perms + dir creation: Upsert into a path whose parent dir is absent
+// creates the dir and writes the file 0600.
+func TestUpsert_CreatesDirAndPerms(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, ".aileron", "binding-descriptors.yaml")
+
+	if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %o, want 600", perm)
+	}
+}
+
+// New-file and empty-file creation both yield a valid v1 document.
+func TestUpsert_NewAndEmptyFile(t *testing.T) {
+	t.Run("new file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+		if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		d := parseFile(t, path)
+		if d.Version != SchemaVersion {
+			t.Errorf("version = %q, want %q", d.Version, SchemaVersion)
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("seed empty file: %v", err)
+		}
+		if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		d := parseFile(t, path)
+		if d.Version != SchemaVersion {
+			t.Errorf("version = %q, want %q", d.Version, SchemaVersion)
+		}
+		if len(d.Bindings) != 1 {
+			t.Fatalf("bindings = %d, want 1", len(d.Bindings))
+		}
+	})
+}
+
+// mergeEntries pure unit test: append, in-place override, self-dedup among
+// incoming (last wins), and order preservation, with no disk I/O.
+func TestMergeEntries(t *testing.T) {
+	a := bearerEntry("a.example.com", "user/a")
+	b := bearerEntry("b.example.com", "user/b")
+	c := bearerEntry("c.example.com", "user/c")
+
+	t.Run("append new key", func(t *testing.T) {
+		got := mergeEntries([]Entry{a, b}, []Entry{c})
+		want := []Entry{a, b, c}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("in-place override preserves order", func(t *testing.T) {
+		bNew := bearerEntry("b.example.com", "user/b-new")
+		got := mergeEntries([]Entry{a, b, c}, []Entry{bNew})
+		want := []Entry{a, bNew, c}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("self-dedup among incoming last wins", func(t *testing.T) {
+		aV1 := bearerEntry("dup.example.com", "user/v1")
+		aV2 := bearerEntry("dup.example.com", "user/v2")
+		got := mergeEntries(nil, []Entry{aV1, aV2})
+		want := []Entry{aV2}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("does not mutate existing input", func(t *testing.T) {
+		existing := []Entry{a, b}
+		bNew := bearerEntry("b.example.com", "user/b-new")
+		_ = mergeEntries(existing, []Entry{bNew})
+		if existing[1].CredentialRef != "user/b" {
+			t.Errorf("mergeEntries mutated its existing input: %+v", existing[1])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the first **write** path to `internal/proxybinding`, which was previously read-only (so `~/.aileron/binding-descriptors.yaml` had to be hand-edited). New exported `Upsert(path string, entries ...Entry) error` programmatically merges `Entry` values into the user descriptor file, validates the merged document, and writes it `0600`.

- `Upsert` reads the existing document (tolerating an absent *or* empty file as an empty v1 doc), merges via `mergeEntries`, marshals a `Descriptor{Version: "v1", ...}`, and routes the pre-write check through `Parse` as the single mutation gate. That reuse means the serialized bytes must re-parse clean through the same `Entry.Validate`, strict-decode, and duplicate-key checks the loader applies. Validation completes **before** any `MkdirAll`/`WriteFile`, so an invalid upsert writes nothing (existing file byte-identical, absent file not created).
- `mergeEntries(existing, incoming []Entry) []Entry` is a pure, disk-free helper keyed on `Entry.dedupKey()`: an incoming entry replaces a matching slot **in place**, otherwise appends; unrelated existing entries are never touched or reordered. Among incoming entries, last-write-wins per key. Factored out so the merge is independently unit-testable.
- Added `,omitempty` to `Entry`'s optional yaml tags in `descriptor.go` so the emitted YAML stays clean and human-editable. This is marshal-only: `KnownFields(true)` strict decoding, `Parse`, and `Load` behavior are unchanged, and there are no existing `yaml.Marshal` callers of `Entry` to break.

Idempotent by construction; no CLI/daemon wiring, no `Load`/precedence changes, no OpenAPI/HTTP surface (internal Go primitive). Part of #1995.

## Test plan

New `writer_test.go` covers the contract:
- Round-trip: `Upsert(path, e1, e2)` re-reads to the same entries.
- Merge preserves unrelated entries (original order kept, new entry appended).
- Override by dedup key replaces in place, no duplicate.
- Case-insensitive host override collapses to one entry (guards the `strings.ToLower` dedup contract, mirroring #1994).
- Reject invalid document (missing `credential_ref`; sigv4-resign carrying a host) → error, existing file unchanged / absent file never created.
- Malformed existing file → error, file not clobbered.
- Dir creation + `0600` perms.
- New-file and empty-file (0-byte) creation both yield a valid `v1` doc.
- `mergeEntries` pure table test: append, in-place override, self-dedup among incoming (last wins), order preservation, no mutation of the `existing` input.

Verification: `go test -cover ./internal/proxybinding/...` passes (93.5% package; `mergeEntries` 100%, `Upsert` 73%/`readExisting` 82% — uncovered lines are defensive `os.MkdirAll`/`os.WriteFile`/`yaml.Marshal` error branches that can't be triggered honestly in-process). `go vet` and `gofmt -l` clean.

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely updating binding descriptor files on disk.
  * Existing entries are preserved in order, while new values replace matching ones when needed.

* **Bug Fixes**
  * Improved YAML output so missing optional fields are omitted instead of written explicitly.
  * Prevents invalid updates from overwriting existing files.

* **Tests**
  * Added coverage for round-trip writing, merge behavior, file permissions, directory creation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->