### PR TITLE
feat(flightplan): derive a plan's credential-binding requirements from its frozen trustContracts

### DIFF
--- a/internal/flightplan/credreq/credreq.go
+++ b/internal/flightplan/credreq/credreq.go
@@ -1,0 +1,296 @@
+package credreq
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// RequiredBinding is one credential an operator must supply before a plan can
+// run: the machine-readable requirement `aileron skill bind` (#1998) consumes.
+// It is derived from a single (or a set of deduplicated) tool-step trust
+// contract(s). It carries no credential value, only the non-secret declaration
+// of what to onboard and where its secret must live.
+type RequiredBinding struct {
+	// CredentialKind is the trust contract's credential.kind (for example
+	// "aws-sigv4"). One of the mapped kinds in scheme.go; `none` never appears.
+	CredentialKind string
+	// IdentityLabel is the trust contract's credential.identityLabel, the
+	// non-secret account/subject label. Empty when the contract declares none.
+	IdentityLabel string
+	// Scheme is the injection scheme mapped from CredentialKind, one of
+	// inject.AllSchemes() (for example "bearer" or "sigv4-resign").
+	Scheme string
+	// Hosts are the trust contract's declared upstream hosts, deduplicated
+	// (case-insensitively, since hosts are case-insensitive by DNS semantics)
+	// and lexically sorted for a stable representation. A retained entry keeps a
+	// verbatim original casing, never a synthesized lowercase form; an entry may
+	// carry a `{{ inputs.<name> }}` template token. For a host-less-identity
+	// binding these are audit context, not the selection key.
+	Hosts []string
+	// TemplatedHosts is the subset of Hosts that carry at least one
+	// `{{ inputs.<name> }}` interpolation token, deduplicated and sorted. The
+	// token is flagged, never resolved (resolution is out of scope). It lets
+	// #1998 decide how to surface a templated host to the operator.
+	TemplatedHosts []string
+	// HostShape records how the egress boundary selects this binding: by host
+	// (host-keyed) or by credential identity (host-less-identity). See
+	// HostShape and HostLessIdentity.
+	HostShape HostShape
+	// CredentialRef is the derived user-level vault path the operator's secret
+	// must live at (for example "user/prod-reader"). It always satisfies the
+	// user-ref grammar `user/[a-z0-9][a-z0-9_-]*`. See the package doc for the
+	// exact, stable derivation rule.
+	CredentialRef string
+}
+
+// HostLessIdentity reports whether the binding is selected by its (kind,
+// identityLabel) pair rather than by upstream host (the AWS SigV4 shape,
+// #1978). Tests and callers assert on this helper rather than on a bare field
+// so the semantic, not the representation, is the contract.
+func (r RequiredBinding) HostLessIdentity() bool {
+	return r.HostShape == HostShapeHostLessIdentity
+}
+
+// unnamedCredentialService is the stable fallback service segment used only
+// when neither the identity label nor the credential kind slugs to a non-empty
+// value (a pathological, directly-constructed contract). It keeps the derived
+// ref well-formed under the user-ref grammar in every case.
+const unnamedCredentialService = "credential"
+
+// slug normalizes an arbitrary label into a user-ref service segment. It
+// lowercases, replaces each maximal run of characters outside [a-z0-9] with a
+// single '-', and trims leading/trailing '-'. The result contains only
+// [a-z0-9-] (a subset of the grammar's [a-z0-9_-]) and, when non-empty, starts
+// with [a-z0-9], so it always satisfies the user-ref service grammar. Dots,
+// spaces, mixed case, and non-ASCII all collapse to '-' boundaries; the result
+// is empty only when the input carries no [a-z0-9] character at all.
+func slug(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+			continue
+		}
+		if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// deriveCredentialRef computes the deterministic, stable user-level vault path
+// the operator's secret must live at. The service segment is slug(identityLabel)
+// when a label is present, else slug(credentialKind), with a stable fallback
+// when both slug to empty. The result always satisfies the user-ref grammar.
+// See the package doc: this rule must not change without a migration.
+func deriveCredentialRef(kind, identityLabel string) string {
+	svc := ""
+	if identityLabel != "" {
+		svc = slug(identityLabel)
+	}
+	if svc == "" {
+		svc = slug(kind)
+	}
+	if svc == "" {
+		svc = unnamedCredentialService
+	}
+	return "user/" + svc
+}
+
+// templatedHosts returns the subset of hosts carrying at least one
+// `{{ inputs.<name> }}` token, using the manifest package's source-of-truth
+// grammar detector so this can never drift from the interpolation grammar.
+// The plan reached Derive through Decode, which already validated the token
+// grammar, so a scan error here is defensive; it is surfaced rather than
+// swallowed.
+func templatedHosts(hosts []string) ([]string, error) {
+	var out []string
+	for _, h := range hosts {
+		refs, err := manifest.CommandInputRefs(h)
+		if err != nil {
+			return nil, fmt.Errorf("credreq: host %q: %w", h, err)
+		}
+		if len(refs) > 0 {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+// dedupHostsSorted returns a stable host-list representation:
+// case-insensitively deduplicated and lexically sorted. Hosts are
+// case-insensitive by DNS semantics, and the host-keyed dedup key already
+// case-folds (see lowerJoin), so two entries differing only in case are one
+// logical host and collapse here too. The retained entry keeps a VERBATIM
+// casing (never a synthesized lowercase form): for a set of case-variants the
+// lexicographically smallest original is chosen, so the result is fully
+// deterministic regardless of input order across merged steps.
+func dedupHostsSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	best := make(map[string]string, len(in))
+	for _, s := range in {
+		k := strings.ToLower(s)
+		if cur, ok := best[k]; !ok || s < cur {
+			best[k] = s
+		}
+	}
+	out := make([]string, 0, len(best))
+	for _, v := range best {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// lowerJoin lowercases and sorts hosts, deduplicated, then joins them, for use
+// as the host-keyed dedup key. Lowercasing means two steps that declare the
+// same hosts in different case collapse to one binding.
+func lowerJoin(hosts []string) string {
+	seen := make(map[string]struct{}, len(hosts))
+	low := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		l := strings.ToLower(h)
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		low = append(low, l)
+	}
+	sort.Strings(low)
+	return strings.Join(low, ",")
+}
+
+// Derive turns a decoded plan's tool-step trust contracts into the
+// deduplicated, deterministically ordered set of credential-binding
+// requirements an operator must supply. It is pure: no I/O, and the same plan
+// always yields the same set.
+//
+// It considers only runtime.KindTool steps carrying a non-nil TrustContract
+// (action-level contracts are out of scope). A `none`-kind step onboards no
+// credential and is skipped. A contract whose credential.kind is outside the
+// closed scheme table is a hard error (fail closed): the derivation never
+// guesses a scheme for an unknown kind.
+//
+// Deduplication collapses requirements that are interchangeable for onboarding:
+//   - host-less-identity (sigv4): keyed by (kind, identityLabel, scheme); hosts
+//     are excluded from the key, so steps sharing one identity but reaching
+//     different (possibly templated) hosts collapse to a single binding whose
+//     Hosts is the union.
+//   - host-keyed: keyed by (kind, identityLabel, scheme, sorted-lowercased
+//     hosts), so distinct host sets stay distinct.
+//
+// The returned slice is sorted by (CredentialRef, CredentialKind, IdentityLabel,
+// Scheme, Hosts) so the result is stable and refactoring-proof.
+func Derive(plan *runtime.Plan) ([]RequiredBinding, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("credreq: nil plan")
+	}
+
+	byKey := map[string]*RequiredBinding{}
+	// order preserves first-seen key order only as a tie-safe intermediate;
+	// the final slice is sorted deterministically below.
+	var keys []string
+
+	for i := range plan.Steps {
+		s := plan.Steps[i]
+		if s.Kind != runtime.KindTool || s.TrustContract == nil {
+			continue
+		}
+		tc := s.TrustContract
+		scheme, shape, skip, err := schemeFor(tc.CredentialKind)
+		if err != nil {
+			return nil, err
+		}
+		if skip {
+			continue
+		}
+
+		templated, err := templatedHosts(tc.Hosts)
+		if err != nil {
+			return nil, err
+		}
+
+		var key string
+		if shape == HostShapeHostLessIdentity {
+			// Hosts excluded from the key: one identity collapses regardless of
+			// which (templated) hosts each step declares.
+			key = strings.Join([]string{"hli", tc.CredentialKind, tc.IdentityLabel, scheme}, "\x00")
+		} else {
+			key = strings.Join([]string{"hk", tc.CredentialKind, tc.IdentityLabel, scheme, lowerJoin(tc.Hosts)}, "\x00")
+		}
+
+		if existing, ok := byKey[key]; ok {
+			// Merge: union the hosts and templated hosts for a stable
+			// representation. For a host-keyed key the host sets are already
+			// equal (they are part of the key), so the union is a no-op there;
+			// for a host-less key it is the load-bearing merge.
+			existing.Hosts = dedupHostsSorted(append(existing.Hosts, tc.Hosts...))
+			existing.TemplatedHosts = dedupHostsSorted(append(existing.TemplatedHosts, templated...))
+			continue
+		}
+
+		rb := &RequiredBinding{
+			CredentialKind: tc.CredentialKind,
+			IdentityLabel:  tc.IdentityLabel,
+			Scheme:         scheme,
+			Hosts:          dedupHostsSorted(tc.Hosts),
+			TemplatedHosts: dedupHostsSorted(templated),
+			HostShape:      shape,
+			CredentialRef:  deriveCredentialRef(tc.CredentialKind, tc.IdentityLabel),
+		}
+		byKey[key] = rb
+		keys = append(keys, key)
+	}
+
+	out := make([]RequiredBinding, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, *byKey[k])
+	}
+	sort.Slice(out, func(a, b int) bool {
+		return less(out[a], out[b])
+	})
+	return out, nil
+}
+
+// less orders two requirements by (CredentialRef, CredentialKind,
+// IdentityLabel, Scheme, Hosts) so Derive's output is stable and independent of
+// step declaration order.
+func less(a, b RequiredBinding) bool {
+	if a.CredentialRef != b.CredentialRef {
+		return a.CredentialRef < b.CredentialRef
+	}
+	if a.CredentialKind != b.CredentialKind {
+		return a.CredentialKind < b.CredentialKind
+	}
+	if a.IdentityLabel != b.IdentityLabel {
+		return a.IdentityLabel < b.IdentityLabel
+	}
+	if a.Scheme != b.Scheme {
+		return a.Scheme < b.Scheme
+	}
+	return strings.Join(a.Hosts, ",") < strings.Join(b.Hosts, ",")
+}
+
+// DeriveFromFrozen reads and signature-verifies a frozen skill version from the
+// store, then derives its credential-binding requirements. It is a thin wrapper
+// over runtime.LoadVerified followed by Derive: the only I/O is the store read
+// the brief permits, and the requirements are derived from the verified,
+// decoded plan (so the derivation inherits signature + content-hash
+// verification for free). All derivation logic lives in the pure Derive.
+func DeriveFromFrozen(s *store.Store, name, id string) ([]RequiredBinding, error) {
+	lp, err := runtime.LoadVerified(s, name, id)
+	if err != nil {
+		return nil, err
+	}
+	return Derive(lp.Plan)
+}

--- a/internal/flightplan/credreq/credreq_test.go
+++ b/internal/flightplan/credreq/credreq_test.go
@@ -1,0 +1,560 @@
+package credreq
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+)
+
+// --- Unit B: slug + credential_ref derivation ---
+
+// assertValidUserRef proves a derived credential_ref is accepted by the real
+// credential-ref contract (internal/binding), so the derivation can never
+// produce a ref the binding layer would reject at construction.
+func assertValidUserRef(t *testing.T, ref string) {
+	t.Helper()
+	if _, err := binding.NewHostBinding("api.example.com", ref, binding.SchemeBearer); err != nil {
+		t.Fatalf("derived credential_ref %q is not a valid credential ref: %v", ref, err)
+	}
+}
+
+// TestDeriveCredentialRef_LabelPresent proves a contract with an identity label
+// derives user/<slug(label)>.
+func TestDeriveCredentialRef_LabelPresent(t *testing.T) {
+	got := deriveCredentialRef("aws-sigv4", "prod-reader")
+	if got != "user/prod-reader" {
+		t.Errorf("ref = %q, want user/prod-reader", got)
+	}
+	assertValidUserRef(t, got)
+}
+
+// TestDeriveCredentialRef_LabelAbsentFallsBackToKind proves a contract with no
+// identity label falls back to user/<slug(kind)>.
+func TestDeriveCredentialRef_LabelAbsentFallsBackToKind(t *testing.T) {
+	got := deriveCredentialRef("aws-sigv4", "")
+	if got != "user/aws-sigv4" {
+		t.Errorf("ref = %q, want user/aws-sigv4", got)
+	}
+	assertValidUserRef(t, got)
+}
+
+// TestDeriveCredentialRef_MessyLabelSlugsToValidRef proves a messy label
+// (spaces, dots, mixed case, unicode, leading/trailing punctuation) slugs to a
+// ref that is valid under the user-ref grammar (no dots, starts alnum).
+func TestDeriveCredentialRef_MessyLabelSlugsToValidRef(t *testing.T) {
+	cases := []struct {
+		label string
+		want  string
+	}{
+		{"Prod Reader", "user/prod-reader"},
+		{"acct.us-east-1.prod", "user/acct-us-east-1-prod"},
+		{"  Léon's Key!  ", "user/l-on-s-key"},
+		{"UPPER_snake", "user/upper-snake"},
+		{"...dots...", "user/dots"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			got := deriveCredentialRef("aws-sigv4", tc.label)
+			if got != tc.want {
+				t.Errorf("ref = %q, want %q", got, tc.want)
+			}
+			assertValidUserRef(t, got)
+		})
+	}
+}
+
+// TestDeriveCredentialRef_EmptySluggingLabelFallsThrough proves a label that
+// slugs to empty (no alnum) falls back to the kind slug, and a kind that also
+// slugs to empty falls back to the stable token, so the ref is always
+// well-formed.
+func TestDeriveCredentialRef_EmptySluggingLabelFallsThrough(t *testing.T) {
+	// Label "***" slugs to empty; kind "aws-sigv4" slugs to a valid segment.
+	got := deriveCredentialRef("aws-sigv4", "***")
+	if got != "user/aws-sigv4" {
+		t.Errorf("ref = %q, want user/aws-sigv4 (label slugs empty, fall back to kind)", got)
+	}
+	assertValidUserRef(t, got)
+
+	// Both label and kind slug to empty: the stable fallback keeps the ref valid.
+	got = deriveCredentialRef("***", "")
+	if got != "user/"+unnamedCredentialService {
+		t.Errorf("ref = %q, want user/%s (both slug empty)", got, unnamedCredentialService)
+	}
+	assertValidUserRef(t, got)
+}
+
+// TestDeriveCredentialRef_CollisionSurface documents that two distinct labels
+// that slug identically collapse to the same ref. This is the exact, stable
+// rule; the test pins the collision surface so a change to it is visible.
+func TestDeriveCredentialRef_CollisionSurface(t *testing.T) {
+	a := deriveCredentialRef("aws-sigv4", "Prod Reader")
+	b := deriveCredentialRef("aws-sigv4", "prod.reader")
+	if a != b {
+		t.Errorf("expected %q and %q to slug to the same ref (documented collision), got %q vs %q", "Prod Reader", "prod.reader", a, b)
+	}
+}
+
+// --- fixture helpers: SKILL.md -> manifest.Parse -> runtime.Decode ---
+
+// decodePlan renders an inline SKILL.md carrying the given inputs and steps
+// blocks, runs it through the real parse + decode path, and returns the decoded
+// plan. Exercising manifest.Parse + runtime.Decode (not a hand-built *Plan)
+// keeps the fixtures honest: the TrustContract values Derive sees are exactly
+// what the shared DTO validator produces.
+func decodePlan(t *testing.T, inputsItems, stepsItems string) *runtime.Plan {
+	t.Helper()
+	inputsBlock := "  inputs: []\n"
+	if inputsItems != "" {
+		inputsBlock = "  inputs:\n" + inputsItems
+	}
+	md := "---\n" +
+		"name: credreq-fixture\n" +
+		"description: credreq derivation fixture.\n" +
+		"aileron:\n" +
+		"  schemaVersion: aileron.flightplan.v1\n" +
+		"  environment:\n" +
+		"    tools: [aws-cli@2.x]\n" +
+		inputsBlock +
+		"  outputs: []\n" +
+		"  steps:\n" +
+		stepsItems +
+		"---\n# fixture\n"
+	m, err := manifest.Parse([]byte(md))
+	if err != nil {
+		t.Fatalf("manifest.Parse: %v\n---\n%s", err, md)
+	}
+	p, err := runtime.Decode(m)
+	if err != nil {
+		t.Fatalf("runtime.Decode: %v", err)
+	}
+	return p
+}
+
+// sigv4Step renders an aws-sigv4 tool step. An empty label omits identityLabel.
+func sigv4Step(id, label, host string) string {
+	cred := "{ kind: aws-sigv4, placement: signing"
+	if label != "" {
+		cred += ", identityLabel: " + label
+	}
+	cred += " }"
+	return "    - id: " + id + "\n" +
+		"      kind: tool\n" +
+		"      command: [tool]\n" +
+		"      outputs: [" + id + "_out]\n" +
+		"      trustContract:\n" +
+		"        credential: " + cred + "\n" +
+		"        hosts: [\"" + host + "\"]\n" +
+		"        effect: read\n" +
+		"        idempotency: { safeToRetry: true }\n" +
+		"        audit: { fields: [result] }\n"
+}
+
+// oauth2Step renders an oauth2 (host-keyed) tool step.
+func oauth2Step(id, label, host string) string {
+	return "    - id: " + id + "\n" +
+		"      kind: tool\n" +
+		"      command: [tool]\n" +
+		"      outputs: [" + id + "_out]\n" +
+		"      trustContract:\n" +
+		"        credential: { kind: oauth2, placement: header, identityLabel: " + label + " }\n" +
+		"        oauth: { scopes: [read] }\n" +
+		"        hosts: [\"" + host + "\"]\n" +
+		"        effect: read\n" +
+		"        idempotency: { safeToRetry: true }\n" +
+		"        audit: { fields: [result] }\n"
+}
+
+// noneStep renders an unauthenticated (kind: none) tool step.
+func noneStep(id, host string) string {
+	return "    - id: " + id + "\n" +
+		"      kind: tool\n" +
+		"      command: [tool]\n" +
+		"      outputs: [" + id + "_out]\n" +
+		"      trustContract:\n" +
+		"        credential: { kind: none }\n" +
+		"        hosts: [\"" + host + "\"]\n" +
+		"        effect: read\n" +
+		"        idempotency: { safeToRetry: true }\n" +
+		"        audit: { fields: [result] }\n"
+}
+
+// plainToolStep renders a tool step with no trust contract.
+func plainToolStep(id string) string {
+	return "    - id: " + id + "\n" +
+		"      kind: tool\n" +
+		"      command: [tool]\n" +
+		"      outputs: [" + id + "_out]\n"
+}
+
+// awsRegionInput declares a constrained aws_region input for templated-host
+// fixtures.
+const awsRegionInput = "    - name: aws_region\n" +
+	"      type: string\n" +
+	"      resolution: { rule: literal, default: us-east-1 }\n" +
+	"      constraint: { enum: [us-east-1, us-west-2] }\n"
+
+// --- Unit C: Derive core ---
+
+// TestDerive_SingleSigv4Step proves one aws-sigv4 tool step yields exactly one
+// binding: sigv4-resign scheme, host-less-identity, credential_ref
+// user/<slug(identityLabel)>, hosts carried.
+func TestDerive_SingleSigv4Step(t *testing.T) {
+	p := decodePlan(t, "", sigv4Step("q1", "prod-reader", "athena.us-east-1.amazonaws.com"))
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1: %+v", len(got), got)
+	}
+	rb := got[0]
+	if rb.CredentialKind != "aws-sigv4" {
+		t.Errorf("kind = %q, want aws-sigv4", rb.CredentialKind)
+	}
+	if rb.Scheme != "sigv4-resign" {
+		t.Errorf("scheme = %q, want sigv4-resign", rb.Scheme)
+	}
+	if !rb.HostLessIdentity() {
+		t.Errorf("shape = %q, want host-less-identity", rb.HostShape)
+	}
+	if rb.CredentialRef != "user/prod-reader" {
+		t.Errorf("ref = %q, want user/prod-reader", rb.CredentialRef)
+	}
+	if strings.Join(rb.Hosts, ",") != "athena.us-east-1.amazonaws.com" {
+		t.Errorf("hosts = %v, want the declared host", rb.Hosts)
+	}
+	if len(rb.TemplatedHosts) != 0 {
+		t.Errorf("templated hosts = %v, want none", rb.TemplatedHosts)
+	}
+	assertValidUserRef(t, rb.CredentialRef)
+}
+
+// TestDerive_TwoSigv4StepsSharedIdentityDeduplicate proves two aws-sigv4 steps
+// that share one identity label collapse to a single binding even when their
+// (templated) hosts differ; the merged binding's Hosts is the union.
+func TestDerive_TwoSigv4StepsSharedIdentityDeduplicate(t *testing.T) {
+	steps := sigv4Step("q1", "prod-reader", "athena.us-east-1.amazonaws.com") +
+		sigv4Step("q2", "prod-reader", "athena.{{ inputs.aws_region }}.amazonaws.com")
+	p := decodePlan(t, awsRegionInput, steps)
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1 (shared identity dedup): %+v", len(got), got)
+	}
+	rb := got[0]
+	// Union of both steps' hosts, sorted.
+	wantHosts := "athena.us-east-1.amazonaws.com,athena.{{ inputs.aws_region }}.amazonaws.com"
+	if strings.Join(rb.Hosts, ",") != wantHosts {
+		t.Errorf("hosts = %v, want the union %q", rb.Hosts, wantHosts)
+	}
+	// The templated host is flagged (present but harmless for sigv4).
+	if strings.Join(rb.TemplatedHosts, ",") != "athena.{{ inputs.aws_region }}.amazonaws.com" {
+		t.Errorf("templated hosts = %v, want the one templated host", rb.TemplatedHosts)
+	}
+}
+
+// TestDerive_OAuth2HostKeyedStep proves an oauth2 step yields one host-keyed
+// binding with the bearer scheme and the declared hosts populated.
+func TestDerive_OAuth2HostKeyedStep(t *testing.T) {
+	p := decodePlan(t, "", oauth2Step("s1", "workspace-a", "api.example.com"))
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1: %+v", len(got), got)
+	}
+	rb := got[0]
+	if rb.Scheme != "bearer" {
+		t.Errorf("scheme = %q, want bearer", rb.Scheme)
+	}
+	if rb.HostLessIdentity() {
+		t.Errorf("shape = %q, want host-keyed", rb.HostShape)
+	}
+	if strings.Join(rb.Hosts, ",") != "api.example.com" {
+		t.Errorf("hosts = %v, want the declared host", rb.Hosts)
+	}
+	if rb.CredentialRef != "user/workspace-a" {
+		t.Errorf("ref = %q, want user/workspace-a", rb.CredentialRef)
+	}
+}
+
+// TestDerive_HostKeyedDistinctHostSetsStayDistinct proves two host-keyed steps
+// with the same identity but different host sets remain two bindings (hosts are
+// part of the host-keyed dedup key).
+func TestDerive_HostKeyedDistinctHostSetsStayDistinct(t *testing.T) {
+	steps := oauth2Step("s1", "workspace-a", "api.one.example.com") +
+		oauth2Step("s2", "workspace-a", "api.two.example.com")
+	p := decodePlan(t, "", steps)
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d bindings, want 2 (distinct host sets): %+v", len(got), got)
+	}
+	// Deterministic order: sorted by hosts (same ref/kind/label/scheme).
+	if strings.Join(got[0].Hosts, ",") != "api.one.example.com" || strings.Join(got[1].Hosts, ",") != "api.two.example.com" {
+		t.Errorf("bindings not in deterministic host order: %v / %v", got[0].Hosts, got[1].Hosts)
+	}
+}
+
+// TestDerive_TemplatedHostFlaggedHostKeyed proves a host-keyed step's templated
+// host is represented in Hosts and listed in TemplatedHosts.
+func TestDerive_TemplatedHostFlaggedHostKeyed(t *testing.T) {
+	p := decodePlan(t, awsRegionInput, oauth2Step("s1", "workspace-a", "athena.{{ inputs.aws_region }}.amazonaws.com"))
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1: %+v", len(got), got)
+	}
+	rb := got[0]
+	host := "athena.{{ inputs.aws_region }}.amazonaws.com"
+	if strings.Join(rb.Hosts, ",") != host {
+		t.Errorf("hosts = %v, want %q", rb.Hosts, host)
+	}
+	if strings.Join(rb.TemplatedHosts, ",") != host {
+		t.Errorf("templated hosts = %v, want %q flagged", rb.TemplatedHosts, host)
+	}
+}
+
+// TestDerive_NoneStepProducesNoBinding proves a kind: none tool step onboards
+// no credential and yields no requirement.
+func TestDerive_NoneStepProducesNoBinding(t *testing.T) {
+	p := decodePlan(t, "", noneStep("s1", "api.example.com"))
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d bindings, want 0 for a none-kind step: %+v", len(got), got)
+	}
+}
+
+// TestDerive_IgnoresNonToolAndUncontractedSteps proves non-tool steps and tool
+// steps with no trust contract are ignored, leaving only the contracted tool
+// step's binding.
+func TestDerive_IgnoresNonToolAndUncontractedSteps(t *testing.T) {
+	steps := plainToolStep("plain") +
+		"    - id: shape\n" +
+		"      kind: transform\n" +
+		"      bindings: { in: steps.plain.plain_out }\n" +
+		"      outputs: [shaped]\n" +
+		sigv4Step("q1", "prod-reader", "athena.us-east-1.amazonaws.com")
+	p := decodePlan(t, "", steps)
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1 (only the contracted tool step): %+v", len(got), got)
+	}
+	if got[0].CredentialKind != "aws-sigv4" {
+		t.Errorf("binding kind = %q, want the sigv4 step's", got[0].CredentialKind)
+	}
+}
+
+// TestDerive_MixedKindsSortedDeterministically proves a plan mixing an oauth2
+// and an aws-sigv4 step yields both bindings in the documented, stable order
+// (sorted by credential_ref first).
+func TestDerive_MixedKindsSortedDeterministically(t *testing.T) {
+	steps := oauth2Step("s1", "workspace-a", "api.example.com") +
+		sigv4Step("q1", "prod-reader", "athena.us-east-1.amazonaws.com")
+	p := decodePlan(t, "", steps)
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d bindings, want 2: %+v", len(got), got)
+	}
+	// user/prod-reader < user/workspace-a lexically.
+	if got[0].CredentialRef != "user/prod-reader" || got[1].CredentialRef != "user/workspace-a" {
+		t.Errorf("order = [%q, %q], want [user/prod-reader, user/workspace-a]", got[0].CredentialRef, got[1].CredentialRef)
+	}
+}
+
+// TestDerive_UnmappedKindFailsClosed proves a tool-step contract whose
+// credential.kind is outside the closed scheme table makes Derive return an
+// error (no guessed scheme). The schema enum blocks such a kind from a decoded
+// fixture, so the plan is constructed directly over the exported runtime types.
+func TestDerive_UnmappedKindFailsClosed(t *testing.T) {
+	p := &runtime.Plan{
+		Steps: []runtime.Step{{
+			ID:      "s1",
+			Kind:    runtime.KindTool,
+			Command: []string{"tool"},
+			TrustContract: &runtime.TrustContract{
+				CredentialKind: "exotic-kind",
+				Hosts:          []string{"api.example.com"},
+				Effect:         runtime.EffectRead,
+			},
+		}},
+	}
+	_, err := Derive(p)
+	if err == nil {
+		t.Fatal("an unmapped credential kind must fail closed")
+	}
+	if !strings.Contains(err.Error(), "exotic-kind") {
+		t.Errorf("error %q should name the offending kind", err)
+	}
+}
+
+// apiKeyStep renders an api-key (host-keyed) tool step.
+func apiKeyStep(id, label, host string) string {
+	return "    - id: " + id + "\n" +
+		"      kind: tool\n" +
+		"      command: [tool]\n" +
+		"      outputs: [" + id + "_out]\n" +
+		"      trustContract:\n" +
+		"        credential: { kind: api-key, placement: header, identityLabel: " + label + " }\n" +
+		"        hosts: [\"" + host + "\"]\n" +
+		"        effect: read\n" +
+		"        idempotency: { safeToRetry: true }\n" +
+		"        audit: { fields: [result] }\n"
+}
+
+// TestDerive_ApiKeyMapsToBearerHostKeyed proves the documented api-key default:
+// it maps to the bearer scheme and a host-keyed shape (the header-bearer wire
+// form). It also pins the same-credential_ref ordering tie-break: an api-key
+// and an oauth2 step sharing one label derive the same ref (user/<label>) and
+// order by credential kind, so api-key precedes oauth2 deterministically.
+func TestDerive_ApiKeyMapsToBearerHostKeyed(t *testing.T) {
+	steps := oauth2Step("s2", "shared", "api.example.com") +
+		apiKeyStep("s1", "shared", "api.example.com")
+	p := decodePlan(t, "", steps)
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d bindings, want 2: %+v", len(got), got)
+	}
+	// Same host set + same label -> same ref, so the (kind) tie-break orders
+	// them: api-key < oauth2.
+	if got[0].CredentialRef != "user/shared" || got[1].CredentialRef != "user/shared" {
+		t.Fatalf("both refs should be user/shared, got %q and %q", got[0].CredentialRef, got[1].CredentialRef)
+	}
+	if got[0].CredentialKind != "api-key" || got[1].CredentialKind != "oauth2" {
+		t.Errorf("kind order = [%q, %q], want [api-key, oauth2]", got[0].CredentialKind, got[1].CredentialKind)
+	}
+	if got[0].Scheme != "bearer" || got[0].HostLessIdentity() {
+		t.Errorf("api-key binding = scheme %q shape %q, want bearer/host-keyed", got[0].Scheme, got[0].HostShape)
+	}
+}
+
+// TestDerive_MalformedTemplatedHostFailsClosed proves a malformed
+// `{{ inputs...` token in a mapped step's host makes Derive fail closed. The
+// decode path validates the grammar, so this defensive path is reached via a
+// directly-constructed plan; it guarantees Derive never emits a binding for a
+// host it could not scan.
+func TestDerive_MalformedTemplatedHostFailsClosed(t *testing.T) {
+	p := &runtime.Plan{
+		Steps: []runtime.Step{{
+			ID:      "s1",
+			Kind:    runtime.KindTool,
+			Command: []string{"tool"},
+			TrustContract: &runtime.TrustContract{
+				CredentialKind: "aws-sigv4",
+				IdentityLabel:  "prod-reader",
+				Hosts:          []string{"athena.{{ inputs.region"},
+				Effect:         runtime.EffectRead,
+			},
+		}},
+	}
+	if _, err := Derive(p); err == nil {
+		t.Fatal("a malformed host template must fail closed")
+	}
+}
+
+// TestDerive_DuplicateHostsInOneContractCollapse proves repeated hosts within a
+// single contract collapse to one entry in the derived binding's Hosts.
+func TestDerive_DuplicateHostsInOneContractCollapse(t *testing.T) {
+	p := &runtime.Plan{
+		Steps: []runtime.Step{{
+			ID:      "s1",
+			Kind:    runtime.KindTool,
+			Command: []string{"tool"},
+			TrustContract: &runtime.TrustContract{
+				CredentialKind: "oauth2",
+				IdentityLabel:  "workspace-a",
+				Hosts:          []string{"api.example.com", "api.example.com"},
+				Effect:         runtime.EffectRead,
+			},
+		}},
+	}
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 || strings.Join(got[0].Hosts, ",") != "api.example.com" {
+		t.Fatalf("duplicate hosts must collapse to one, got %+v", got)
+	}
+}
+
+// TestDerive_CaseVariantHostsCollapse proves two host-keyed steps whose hosts
+// differ only in case are one logical requirement: they merge to a single
+// binding whose Hosts carries one entry (a verbatim casing), never two
+// case-variant duplicates.
+func TestDerive_CaseVariantHostsCollapse(t *testing.T) {
+	p := &runtime.Plan{
+		Steps: []runtime.Step{
+			{
+				ID: "s1", Kind: runtime.KindTool, Command: []string{"tool"},
+				TrustContract: &runtime.TrustContract{
+					CredentialKind: "oauth2", IdentityLabel: "workspace-a",
+					Hosts: []string{"API.Example.com"}, Effect: runtime.EffectRead,
+				},
+			},
+			{
+				ID: "s2", Kind: runtime.KindTool, Command: []string{"tool"},
+				TrustContract: &runtime.TrustContract{
+					CredentialKind: "oauth2", IdentityLabel: "workspace-a",
+					Hosts: []string{"api.example.com"}, Effect: runtime.EffectRead,
+				},
+			},
+		},
+	}
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("case-variant hosts must collapse to one binding, got %d: %+v", len(got), got)
+	}
+	if len(got[0].Hosts) != 1 {
+		t.Errorf("Hosts = %v, want a single case-insensitively-deduplicated entry", got[0].Hosts)
+	}
+	// The retained entry is a verbatim casing (the lexicographically smallest),
+	// never a synthesized lowercase form.
+	if got[0].Hosts[0] != "API.Example.com" {
+		t.Errorf("Hosts[0] = %q, want the verbatim smallest casing API.Example.com", got[0].Hosts[0])
+	}
+}
+
+// TestDerive_NilPlan proves Derive rejects a nil plan rather than panicking.
+func TestDerive_NilPlan(t *testing.T) {
+	if _, err := Derive(nil); err == nil {
+		t.Fatal("Derive(nil) must return an error")
+	}
+}
+
+// TestDerive_EmptyPlanYieldsNoBindings proves a plan with no contracted tool
+// steps derives an empty (non-error) set.
+func TestDerive_EmptyPlanYieldsNoBindings(t *testing.T) {
+	p := decodePlan(t, "", plainToolStep("plain"))
+	got, err := Derive(p)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d bindings, want 0: %+v", len(got), got)
+	}
+}

--- a/internal/flightplan/credreq/derivefromfrozen_test.go
+++ b/internal/flightplan/credreq/derivefromfrozen_test.go
@@ -1,0 +1,126 @@
+package credreq
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// TestDeriveFromFrozen_NilStore proves the wrapper surfaces the load error
+// rather than panicking when handed a nil store (delegating to
+// runtime.LoadVerified's nil-store guard).
+func TestDeriveFromFrozen_NilStore(t *testing.T) {
+	if _, err := DeriveFromFrozen(nil, "any", "test"); err == nil {
+		t.Fatal("DeriveFromFrozen(nil, ...) must return an error")
+	}
+}
+
+// TestDeriveFromFrozen_MissingVersion proves the wrapper surfaces the store
+// read error for a version that was never frozen.
+func TestDeriveFromFrozen_MissingVersion(t *testing.T) {
+	s := store.New(t.TempDir())
+	if _, err := DeriveFromFrozen(s, "absent", "test"); err == nil {
+		t.Fatal("DeriveFromFrozen for an absent version must return an error")
+	}
+}
+
+// writeSigningKey writes a fresh ed25519 PKCS#8 signing key to a temp file and
+// returns its path, mirroring the freeze/runtime test key convention.
+func writeSigningKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "signing-key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return keyPath
+}
+
+// frozenSigv4MD is a schema-valid, environment-pinned SKILL.md with one
+// aws-sigv4 tool step, the fixture the happy-path wrapper test freezes.
+const frozenSigv4MD = `---
+name: credreq-frozen-fixture
+description: credreq frozen wrapper fixture.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  environment:
+    tools: [aws-cli@2.x]
+  inputs: []
+  outputs: []
+  steps:
+    - id: q1
+      kind: tool
+      command: [athena-query]
+      outputs: [rows]
+      trustContract:
+        credential: { kind: aws-sigv4, placement: signing, identityLabel: prod-reader }
+        hosts: ["athena.us-east-1.amazonaws.com"]
+        effect: read
+        idempotency: { safeToRetry: true }
+        audit: { fields: [result] }
+---
+# frozen fixture
+`
+
+// TestDeriveFromFrozen_HappyPath proves the wrapper freezes-then-derives end to
+// end: it reads and signature-verifies a frozen unit and returns the same set
+// the pure Derive would produce from the decoded plan. This is the one wrapper
+// integration test the plan asks for when a freeze helper is cheaply reachable.
+func TestDeriveFromFrozen_HappyPath(t *testing.T) {
+	res, err := freeze.Run(context.Background(), []byte(frozenSigv4MD), freeze.Options{
+		Version:        "1.0.0",
+		SigningKeyPath: writeSigningKey(t),
+		Resolver: freeze.DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+			return "sha256:" + strings.Repeat("b", 64), nil
+		}),
+		Composer: freeze.FeatureComposerFunc(func(_ context.Context, _ string, _ []string) (string, error) {
+			return "sha256:" + strings.Repeat("a", 64), nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run: %v", err)
+	}
+
+	s := store.New(t.TempDir())
+	const name = "credreq-frozen-fixture"
+	if err := s.WriteFrozen(name, store.FrozenVersion{
+		ID:        "test",
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+
+	got, err := DeriveFromFrozen(s, name, "test")
+	if err != nil {
+		t.Fatalf("DeriveFromFrozen: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d bindings, want 1: %+v", len(got), got)
+	}
+	rb := got[0]
+	if rb.CredentialKind != "aws-sigv4" || rb.Scheme != "sigv4-resign" || !rb.HostLessIdentity() {
+		t.Errorf("binding = %+v, want aws-sigv4/sigv4-resign/host-less-identity", rb)
+	}
+	if rb.CredentialRef != "user/prod-reader" {
+		t.Errorf("ref = %q, want user/prod-reader", rb.CredentialRef)
+	}
+}

--- a/internal/flightplan/credreq/doc.go
+++ b/internal/flightplan/credreq/doc.go
@@ -1,0 +1,68 @@
+// Package credreq derives a frozen Flight Plan's credential-binding
+// requirements from its tool-step trust contracts. It answers one question,
+// purely and deterministically: given a decoded plan, what set of credentials
+// must an operator supply before the plan can run?
+//
+// The output is a deduplicated, deterministically ordered set of
+// [RequiredBinding] values. Each names a credential kind, an injection scheme,
+// the vault path (`credential_ref`) the operator's secret must live at, the
+// declared upstream hosts, and whether the binding is selected by host or by
+// credential identity. It is the machine-readable "what the operator must
+// supply" that the `aileron skill bind` verb (#1998) consumes; nothing in this
+// package writes a descriptor, reads a vault, or prompts.
+//
+// # Purity
+//
+// [Derive] is a pure function of a *runtime.Plan: no I/O, no clock, no
+// randomness. Given the same plan it returns the same set, so it is the fully
+// tested contract surface. [DeriveFromFrozen] is the only I/O path: a thin
+// wrapper that reads and signature-verifies a frozen version through
+// runtime.LoadVerified, then delegates to Derive. It adds no derivation logic.
+//
+// # Scope: tool-step trust contracts only
+//
+// Derive iterates plan.Steps and considers a step only when it is a
+// runtime.KindTool step carrying a non-nil TrustContract. Action-level trust
+// contracts (plan.Actions) are OUT OF SCOPE for this unit: the action boundary
+// mediates credentials through the connector-spec binding layer, a different
+// mechanism from the host-side egress injection a tool step's reach describes.
+// A step whose contract declares credential kind `none` is unauthenticated and
+// produces no requirement.
+//
+// # Scheme mapping (keyed on credential.kind, fail closed)
+//
+// runtime.TrustContract carries no placement (the DTO reads it but toContract
+// drops it), so the scheme and host-shape are mapped from credential.kind
+// alone, through the single closed table in scheme.go:
+//
+//	credential.kind | scheme (inject.*) | host-shape          | note
+//	----------------+-------------------+---------------------+----------------------------------
+//	aws-sigv4       | sigv4-resign      | host-less-identity  | selected by (kind, identityLabel)
+//	oauth2          | bearer            | host-keyed          | schema pins placement=header
+//	api-key         | bearer            | host-keyed          | documented header-bearer default
+//	none            | (skip)            | (skip)              | unauthenticated, no credential
+//	anything else   | ERROR             | ERROR               | fail closed, no guessed scheme
+//
+// A kind outside this set is a hard error: the derivation never guesses a
+// scheme for an unknown kind. Placement-aware selection (a query-param api-key,
+// a header-template vendor header) is deliberately unsupported here; adding it
+// requires plumbing placement onto runtime.TrustContract first, a separate
+// future change.
+//
+// # credential_ref rule (stable, do not change without a migration)
+//
+// The derived vault path targets the user-level namespace `user/<service>`,
+// matching #1995's decision that plan-onboarded secrets live at `user/<name>`
+// and that a second operator supplies their own secret at the same ref. The
+// service segment is slug(identityLabel) when the contract declares a label,
+// else slug(credentialKind). The slug lowercases, collapses each run of
+// characters outside [a-z0-9] to a single '-', and trims leading/trailing '-',
+// so the result always satisfies the user-ref grammar
+// (`user/[a-z0-9][a-z0-9_-]*`, no dots). This is the exact, stable rule; a
+// change to it would strand every already-bound secret and must ship with a
+// migration.
+//
+// This package never reads or carries a credential value. It reads only the
+// non-secret trust-contract declaration (kind, identity label, hosts) and emits
+// non-secret binding requirements.
+package credreq

--- a/internal/flightplan/credreq/scheme.go
+++ b/internal/flightplan/credreq/scheme.go
@@ -1,0 +1,88 @@
+package credreq
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// HostShape names how the egress boundary selects a derived binding: by the
+// upstream host it reaches, or by the credential identity it carries. It is a
+// named type (not a bare bool) so tests assert on the semantic, not on which
+// side of a boolean the mapping happens to fall.
+type HostShape string
+
+const (
+	// HostShapeHostKeyed selects the binding by upstream host: the proxy
+	// matches the request's host against the binding's host pattern before
+	// injecting. This is the shape for header-carried credentials (bearer),
+	// whose scope is the set of hosts the step declares.
+	HostShapeHostKeyed HostShape = "host-keyed"
+
+	// HostShapeHostLessIdentity selects the binding by its (kind,
+	// identityLabel) pair, not by host (#1978). The AWS SigV4 re-sign scheme
+	// derives its credential scope from the resolved upstream host at egress,
+	// so the descriptor needs no host to select the binding. Hosts declared on
+	// such a contract are carried for audit context but are not the selection
+	// key.
+	HostShapeHostLessIdentity HostShape = "host-less-identity"
+)
+
+// schemeMapping is one row of the closed kind -> (scheme, host-shape) table.
+// skip marks the unauthenticated `none` kind, which yields no requirement.
+type schemeMapping struct {
+	scheme string
+	shape  HostShape
+	skip   bool
+}
+
+// kindSchemeTable is the single, closed mapping from a trust contract's
+// credential.kind to the injection scheme and host-shape a derived binding
+// carries. It fails closed: a kind absent from this table is an error, never a
+// guessed scheme.
+//
+//   - aws-sigv4 -> sigv4-resign, host-less-identity: the load-bearing case
+//     (#1978); the descriptor is selected by identity, the host is derived at
+//     egress and not needed to select the binding.
+//   - oauth2 -> bearer, host-keyed: the schema pins an oauth2 credential to
+//     placement=header, which is the bearer wire form.
+//   - api-key -> bearer, host-keyed: a DELIBERATE, documented default for the
+//     header-bearer wire form. It is a default for a MAPPED kind, not a guess
+//     on an unknown one. A query-param or header-template api-key would need
+//     placement-aware selection, which is out of scope here (see the package
+//     doc); adding it requires plumbing placement onto runtime.TrustContract.
+//   - none -> skip: an unauthenticated step declares no credential to onboard.
+var kindSchemeTable = map[string]schemeMapping{
+	"aws-sigv4": {scheme: string(inject.SchemeSigV4Resign), shape: HostShapeHostLessIdentity},
+	"oauth2":    {scheme: string(inject.SchemeBearer), shape: HostShapeHostKeyed},
+	"api-key":   {scheme: string(inject.SchemeBearer), shape: HostShapeHostKeyed},
+	"none":      {skip: true},
+}
+
+// mappedKinds returns the table's keys sorted, for a deterministic error
+// message that names the closed set.
+func mappedKinds() []string {
+	ks := make([]string, 0, len(kindSchemeTable))
+	for k := range kindSchemeTable {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// schemeFor maps a credential.kind to its injection scheme and host-shape. It
+// fails closed: a kind outside the closed table returns an error naming the
+// offending kind and the mapped set, so an unknown kind never yields a guessed
+// scheme. The `none` kind returns skip=true (an unauthenticated step onboards
+// no credential); its scheme and shape are meaningless and must not be read.
+func schemeFor(kind string) (scheme string, shape HostShape, skip bool, err error) {
+	m, ok := kindSchemeTable[kind]
+	if !ok {
+		return "", "", false, fmt.Errorf(
+			"credreq: unmapped credential kind %q (mapped kinds: %s)",
+			kind, strings.Join(mappedKinds(), ", "))
+	}
+	return m.scheme, m.shape, m.skip, nil
+}

--- a/internal/flightplan/credreq/scheme_test.go
+++ b/internal/flightplan/credreq/scheme_test.go
@@ -1,0 +1,93 @@
+package credreq
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// TestSchemeFor_MappedKinds proves every mapped credential kind returns the
+// documented scheme and host-shape from the closed table. These are the
+// load-bearing rows: aws-sigv4 is the sigv4-resign / host-less case the brief
+// names, oauth2 and api-key are the host-keyed bearer cases.
+func TestSchemeFor_MappedKinds(t *testing.T) {
+	cases := []struct {
+		kind       string
+		wantScheme string
+		wantShape  HostShape
+	}{
+		{"aws-sigv4", string(inject.SchemeSigV4Resign), HostShapeHostLessIdentity},
+		{"oauth2", string(inject.SchemeBearer), HostShapeHostKeyed},
+		{"api-key", string(inject.SchemeBearer), HostShapeHostKeyed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			scheme, shape, skip, err := schemeFor(tc.kind)
+			if err != nil {
+				t.Fatalf("schemeFor(%q) errored: %v", tc.kind, err)
+			}
+			if skip {
+				t.Fatalf("schemeFor(%q) reported skip; a mapped credential kind must not skip", tc.kind)
+			}
+			if scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", scheme, tc.wantScheme)
+			}
+			if shape != tc.wantShape {
+				t.Errorf("shape = %q, want %q", shape, tc.wantShape)
+			}
+		})
+	}
+}
+
+// TestSchemeFor_MappedSchemesAreClosedSet proves every scheme the table emits
+// is a member of the injector's closed scheme set, so the derived scheme can
+// never drift outside inject.AllSchemes().
+func TestSchemeFor_MappedSchemesAreClosedSet(t *testing.T) {
+	valid := map[string]bool{}
+	for _, s := range inject.AllSchemes() {
+		valid[string(s)] = true
+	}
+	for kind, m := range kindSchemeTable {
+		if m.skip {
+			continue
+		}
+		if !valid[m.scheme] {
+			t.Errorf("kind %q maps to scheme %q, which is not a member of inject.AllSchemes()", kind, m.scheme)
+		}
+	}
+}
+
+// TestSchemeFor_NoneSkips proves the unauthenticated `none` kind reports
+// skip=true: it onboards no credential and yields no requirement.
+func TestSchemeFor_NoneSkips(t *testing.T) {
+	_, _, skip, err := schemeFor("none")
+	if err != nil {
+		t.Fatalf("schemeFor(none) errored: %v", err)
+	}
+	if !skip {
+		t.Fatal("schemeFor(none) must report skip=true")
+	}
+}
+
+// TestSchemeFor_UnmappedErrors proves a kind outside the closed table fails
+// closed: an error naming the offending kind and the mapped set, never a
+// guessed scheme.
+func TestSchemeFor_UnmappedErrors(t *testing.T) {
+	scheme, _, skip, err := schemeFor("exotic-kind")
+	if err == nil {
+		t.Fatal("an unmapped credential kind must return an error")
+	}
+	if scheme != "" || skip {
+		t.Errorf("unmapped kind returned scheme=%q skip=%v, want empty/false", scheme, skip)
+	}
+	if !strings.Contains(err.Error(), "exotic-kind") {
+		t.Errorf("error %q should name the offending kind", err)
+	}
+	// The error names the closed mapped set so an author can correct the kind.
+	for _, k := range []string{"aws-sigv4", "oauth2", "api-key", "none"} {
+		if !strings.Contains(err.Error(), k) {
+			t.Errorf("error %q should list the mapped kind %q", err, k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Unit 2 of umbrella #1995. Adds `internal/flightplan/credreq`, a **pure derivation** that turns a frozen Flight Plan's tool-step `trustContract`s into a deduplicated, deterministically ordered set of `RequiredBinding` values — the machine-readable "what the operator must supply" that the `aileron skill bind` verb (Unit 3, #1998) will consume. The change is **additive**: one new package, no edits to any existing file, so it cannot collide with sibling units #1996 or #1998.

### What it does

- **`Derive(plan *runtime.Plan) ([]RequiredBinding, error)`** — the pure, fully-tested contract surface. No I/O; the same plan always yields the same set. Iterates `KindTool` steps with a non-nil `TrustContract`, maps each to a scheme + host-shape, derives a stable `credential_ref`, flags templated hosts, deduplicates, and stable-sorts.
- **`DeriveFromFrozen(s, name, id)`** — thin wrapper: `runtime.LoadVerified` → `Derive`. The only I/O is the store read the brief permits, and it inherits signature + content-hash verification for free.

### Key decisions (from the plan)

- **Scheme mapping keyed on `credential.kind`, fail closed** (a closed table, `scheme.go`): `aws-sigv4 → sigv4-resign` / host-less-identity (#1978); `oauth2 → bearer` / host-keyed; `api-key → bearer` / host-keyed (documented header-bearer default); `none →` skip; **anything else → error** (no guessed scheme). `TrustContract` carries no placement, so the mapping keys on kind only.
- **Stable `credential_ref` rule:** `user/<slug(identityLabel)>`, falling back to `user/<slug(kind)>` then a stable token; the slug guarantees a value valid under `internal/binding`'s `user/<service>` grammar (asserted in tests by constructing a real `binding.NewHostBinding`). Documented as exact and migration-gated.
- **Dedup + deterministic ordering:** host-less collapses on `(kind, identityLabel, scheme)` (hosts excluded, unioned on merge); host-keyed keys include the sorted-lowercased host set. Output sorted by `(credentialRef, kind, identityLabel, scheme, hosts)`. Host lists are deduplicated case-insensitively (DNS semantics) retaining a verbatim casing.
- **Scope: tool-step `trustContract`s only** — action-level contracts are out of scope (the action boundary mediates credentials differently). Templated hosts are flagged via `manifest.CommandInputRefs`, never resolved.

## Test plan

- `go test ./internal/flightplan/credreq/... -cover` → **98.1%**, all passing.
- Unit A (`scheme_test.go`): every mapped kind returns the documented scheme/shape; emitted schemes are all members of `inject.AllSchemes()`; `none` skips; an unmapped kind errors naming the closed set.
- Unit B: label present / absent / messy (spaces, dots, mixed case, unicode) all slug to a ref validated against the real `internal/binding` grammar; empty-slug fallthrough; documented collision surface pinned.
- Unit C: single sigv4 → one host-less binding; two sigv4 steps sharing an identity (incl. a templated host) dedup to one with unioned hosts; oauth2 host-keyed; distinct host sets stay distinct; api-key documented default; templated host flagged; `kind: none` yields nothing; non-tool / uncontracted steps ignored; mixed kinds sorted deterministically; unmapped kind and malformed host template both fail closed; case-variant hosts collapse; nil plan errors.
- Unit D: `DeriveFromFrozen` covered end-to-end (freeze a signed aws-sigv4 plan into a temp store → verify → derive) plus nil-store and missing-version error paths.
- `go build ./...`, `go vet`, `gofmt` clean across the module; the full `./internal/flightplan/...` tree stays green (purely additive).
- CodeRabbit review: clean (0 findings; one minor host-casing dedup nit surfaced and fixed).

**No** OpenAPI/spec change (internal function), **no** template resolution, **no** vault access / descriptor writes / prompting (Units 1 and 3), **no** action-level contracts, **no** edits to `runtime`/`dto`/`plan`.

Closes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)
