### PR TITLE
feat(cli): add aileron skill bind to onboard a plan's credential requirements

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -249,6 +249,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron skill install <source>     Install a skill (local path or git URL) into ~/.aileron/skills")
 	fmt.Fprintln(w, "  aileron skill list                 List installed skills (mounted read-only at launch)")
 	fmt.Fprintln(w, "  aileron skill freeze <name>        Seal an installed skill into a signed, pinned Flight Plan version")
+	fmt.Fprintln(w, "  aileron skill bind <name>          Onboard a frozen plan's credential requirements (vault + descriptor)")
 	fmt.Fprintln(w, "  aileron keyring trust <auth> <key> Authorize a publisher's signing key for installs")
 	fmt.Fprintln(w, "  aileron keyring list               List trusted publishers and key fingerprints")
 	fmt.Fprintln(w, "  aileron keyring revoke <auth>      Remove a publisher's keys from the trust list")

--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
@@ -16,6 +17,7 @@ const skillUsage = `usage:
   aileron skill list               List installed skills
   aileron skill freeze <name>      Seal an installed skill into a signed, digest-pinned Flight Plan version
   aileron skill launch <name>      Run a frozen Flight Plan deterministically (no-LLM step graph)
+  aileron skill bind <name>        Onboard a frozen plan's credential requirements (vault secret + binding descriptor)
   aileron skill publish <name>     Push a frozen version's image + signed artifact to an OCI registry`
 
 // skillStoreDir is a seam so tests can point the CLI at a temp store
@@ -52,6 +54,8 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 		return runSkillFreeze(args[1:], stdout, stderr)
 	case "launch":
 		return runSkillLaunch(args[1:], stdout, stderr)
+	case "bind":
+		return runSkillBind(args[1:], os.Stdin, stdout, stderr)
 	case "publish":
 		return runSkillPublish(args[1:], stdout, stderr)
 	default:

--- a/cmd/aileron/skill_bind.go
+++ b/cmd/aileron/skill_bind.go
@@ -246,6 +246,17 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 
 	statuses := diffRequirements(reqs, vaultRefs, existing)
 
+	// haveSecret tracks which credential refs already hold a vault secret,
+	// seeded from the vault snapshot and updated after each PutUser. Two
+	// host-keyed requirements can share one CredentialRef (same identity, distinct
+	// host sets), so once the first has stored the shared secret the second must
+	// not re-prompt for it; the descriptor diff is still per-host, so each host's
+	// entry is written independently.
+	haveSecret := make(map[string]bool, len(vaultRefs))
+	for ref := range vaultRefs {
+		haveSecret[ref] = true
+	}
+
 	br := bufio.NewReader(stdin)
 	var (
 		toWrite    []proxybinding.Entry
@@ -257,14 +268,26 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 			summary = append(summary, fmt.Sprintf("  satisfied: %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
 			continue
 		}
-		entries, adv, err := fillRequirement(st, client, br, stdout, stderr)
+		needSecret := !haveSecret[st.req.CredentialRef]
+		entries, adv, storedSecret, err := fillRequirement(st.req, needSecret, !st.descriptorPresent, client, br, stdout, stderr)
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %s: %v\n", st.req.CredentialRef, err)
 			return 1
 		}
+		if storedSecret {
+			haveSecret[st.req.CredentialRef] = true
+		}
 		toWrite = append(toWrite, entries...)
 		advisories = append(advisories, adv...)
-		summary = append(summary, fmt.Sprintf("  onboarded: %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
+		// "onboarded" reports a completed action (a secret stored or a descriptor
+		// entry written). A requirement that produced only an advisory (for
+		// example a host-keyed binding whose only host is a template) and stored
+		// nothing is reported as pending so the summary never overstates progress.
+		if len(entries) > 0 || storedSecret {
+			summary = append(summary, fmt.Sprintf("  onboarded: %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
+		} else {
+			summary = append(summary, fmt.Sprintf("  pending:   %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
+		}
 	}
 
 	if len(toWrite) > 0 {
@@ -289,39 +312,41 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 }
 
 // fillRequirement captures the secret and non-secret params for a requirement
-// that is not fully satisfied. It prompts for the vault secret only when the
-// vault does not already hold it, and builds descriptor entries only when the
-// descriptors do not already satisfy it, so a partially-onboarded requirement
-// fills only its missing half. It returns the descriptor entries the caller
-// batches into a single Upsert plus any advisories (for templated hosts).
-func fillRequirement(st reqStatus, client bindVaultClient, stdin *bufio.Reader, stdout, stderr io.Writer) ([]proxybinding.Entry, []string, error) {
-	req := st.req
-
-	if !st.vaultPresent {
+// that is not fully satisfied. needSecret and needDescriptor are computed by the
+// caller against a live view of the vault and descriptors, so a
+// partially-onboarded requirement fills only its missing half and a secret
+// shared by two requirements is prompted once. It returns the descriptor entries
+// the caller batches into a single Upsert, any advisories (for templated hosts),
+// and whether it stored a secret (so the caller keeps its live vault view in
+// sync and reports an accurate summary).
+func fillRequirement(req credreq.RequiredBinding, needSecret, needDescriptor bool, client bindVaultClient, stdin *bufio.Reader, stdout, stderr io.Writer) ([]proxybinding.Entry, []string, bool, error) {
+	storedSecret := false
+	if needSecret {
 		secret, err := promptPassphrase(fmt.Sprintf("Secret for %s: ", req.CredentialRef), stderr)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		if secret == "" {
-			return nil, nil, fmt.Errorf("secret cannot be empty")
+			return nil, nil, false, fmt.Errorf("secret cannot be empty")
 		}
 		service := strings.TrimPrefix(req.CredentialRef, "user/")
 		if err := client.PutUser(service, []byte(secret)); err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
+		storedSecret = true
 	}
 
-	if st.descriptorPresent {
-		return nil, nil, nil
+	if !needDescriptor {
+		return nil, nil, storedSecret, nil
 	}
 
 	if req.HostLessIdentity() {
 		if req.IdentityLabel == "" {
-			return nil, nil, fmt.Errorf("cannot write a valid %s descriptor without an identity_label; the frozen plan declares a %s credential with no identityLabel", req.Scheme, req.CredentialKind)
+			return nil, nil, storedSecret, fmt.Errorf("cannot write a valid %s descriptor without an identity_label; the frozen plan declares a %s credential with no identityLabel", req.Scheme, req.CredentialKind)
 		}
 		akid := strings.TrimSpace(promptLine(stdin, stdout, fmt.Sprintf("AWS access key ID for %s: ", req.CredentialRef)))
 		if akid == "" {
-			return nil, nil, fmt.Errorf("access key ID cannot be empty")
+			return nil, nil, storedSecret, fmt.Errorf("access key ID cannot be empty")
 		}
 		entry := proxybinding.Entry{
 			Kind:          req.CredentialKind,
@@ -333,7 +358,7 @@ func fillRequirement(st reqStatus, client bindVaultClient, stdin *bufio.Reader, 
 		for _, w := range entry.Warnings() {
 			fmt.Fprintf(stderr, "warning: %s\n", w)
 		}
-		return []proxybinding.Entry{entry}, nil, nil
+		return []proxybinding.Entry{entry}, nil, storedSecret, nil
 	}
 
 	// Host-keyed (bearer): one entry per non-templated host. A templated host
@@ -354,7 +379,7 @@ func fillRequirement(st reqStatus, client bindVaultClient, stdin *bufio.Reader, 
 			Scheme:        req.Scheme,
 		})
 	}
-	return entries, advisories, nil
+	return entries, advisories, storedSecret, nil
 }
 
 // requirementLabel is a short human description of what a requirement binds:

--- a/cmd/aileron/skill_bind.go
+++ b/cmd/aileron/skill_bind.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/credreq"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// deriveRequirements is the seam over the credential-requirement deriver
+// (#2002). DeriveFromFrozen runs runtime.LoadVerified (real signature +
+// content-hash verification) then the pure Derive; the seam lets the verb's
+// tests inject a canned []RequiredBinding and exercise the composition
+// contract (diff -> prompt -> write -> summarize) without a signed fixture.
+// End-to-end derivation is covered by credreq's own derivefromfrozen_test.go.
+var deriveRequirements = credreq.DeriveFromFrozen
+
+// skillBindDescriptorPath is a seam so tests point the verb at a temp
+// descriptor file instead of the operator's real
+// ~/.aileron/binding-descriptors.yaml. Empty means the default user path.
+var skillBindDescriptorPath = ""
+
+// descriptorPath resolves the descriptor file the verb reads and writes: the
+// test seam if set, else proxybinding.DefaultUserPath().
+func descriptorPath() string {
+	if skillBindDescriptorPath != "" {
+		return skillBindDescriptorPath
+	}
+	return proxybinding.DefaultUserPath()
+}
+
+// bindVaultClient is the seam-injected vault surface the verb needs: read the
+// set of user-level services already stored, and store one user-level secret.
+// A daemon-backed default reaches the existing GET /vault/user and
+// PUT /vault/user/<svc>/credentials endpoints; tests inject an in-memory fake.
+type bindVaultClient interface {
+	// ListUserServices returns the bare service segments under user/ that the
+	// vault already holds (for example "prod-reader" for user/prod-reader).
+	ListUserServices() ([]string, error)
+	// PutUser stores value at user/<service>, base64-encoding on the wire.
+	PutUser(service string, value []byte) error
+}
+
+// newBindVaultClient builds the daemon-backed vault client. It is a
+// package-level seam so tests inject a fake with in-memory state.
+var newBindVaultClient = func() bindVaultClient { return daemonBindVaultClient{} }
+
+// daemonBindVaultClient talks to the local daemon's vault endpoints, reusing
+// the same plumbing `vault list --user` and `vault put user/...` drive.
+type daemonBindVaultClient struct{}
+
+func (daemonBindVaultClient) ListUserServices() ([]string, error) {
+	status, body, err := vaultDoRequest(http.MethodGet, "/vault/user", nil)
+	if err != nil {
+		return nil, err
+	}
+	switch status {
+	case http.StatusOK:
+	case http.StatusServiceUnavailable:
+		return nil, fmt.Errorf("daemon is not configured with a vault")
+	default:
+		return nil, fmt.Errorf("server returned %d listing user credentials: %s", status, string(body))
+	}
+	var out struct {
+		Services []struct {
+			Service string `json:"service"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode user credential list: %w", err)
+	}
+	services := make([]string, 0, len(out.Services))
+	for _, s := range out.Services {
+		services = append(services, s.Service)
+	}
+	return services, nil
+}
+
+func (daemonBindVaultClient) PutUser(service string, value []byte) error {
+	body, err := json.Marshal(agentCredentialsBody{Value: value})
+	if err != nil {
+		return err
+	}
+	status, resp, err := vaultDoRequest(http.MethodPut, userCredentialDaemonPath(service), body)
+	if err != nil {
+		return err
+	}
+	switch status {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusLocked:
+		return fmt.Errorf("vault is locked; unlock it first")
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("daemon is not configured with a vault")
+	default:
+		return fmt.Errorf("server returned %d storing user/%s: %s", status, service, string(resp))
+	}
+}
+
+// reqStatus records, for one derived requirement, whether the vault already
+// holds its secret and whether the loaded descriptors already satisfy it. A
+// requirement is satisfied only when both are true.
+type reqStatus struct {
+	req               credreq.RequiredBinding
+	vaultPresent      bool
+	descriptorPresent bool
+}
+
+func (s reqStatus) satisfied() bool { return s.vaultPresent && s.descriptorPresent }
+
+// diffRequirements is the pure diff: for each requirement it reports whether
+// the vault set already holds the credential ref and whether the loaded
+// descriptor entries already satisfy it. It performs no I/O so it is
+// independently unit-testable. vaultRefs is the set of "user/<service>" refs
+// the vault already holds.
+func diffRequirements(reqs []credreq.RequiredBinding, vaultRefs map[string]bool, existing []proxybinding.Entry) []reqStatus {
+	out := make([]reqStatus, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, reqStatus{
+			req:               r,
+			vaultPresent:      vaultRefs[r.CredentialRef],
+			descriptorPresent: descriptorSatisfies(r, existing),
+		})
+	}
+	return out
+}
+
+// descriptorSatisfies reports whether the existing descriptor entries already
+// carry the binding a requirement names. A host-less-identity (sigv4)
+// requirement is satisfied by any entry with a matching (kind, identity_label,
+// scheme). A host-keyed (bearer) requirement is satisfied only when every
+// non-templated host it names has an entry with a matching host,
+// credential_ref, and scheme; templated hosts are skipped because they cannot
+// be onboarded automatically. A requirement whose only hosts are templated is
+// never considered satisfied (there is nothing writable to match).
+func descriptorSatisfies(req credreq.RequiredBinding, existing []proxybinding.Entry) bool {
+	if req.HostLessIdentity() {
+		for i := range existing {
+			e := existing[i]
+			if e.Kind == req.CredentialKind && e.IdentityLabel == req.IdentityLabel && e.Scheme == req.Scheme {
+				return true
+			}
+		}
+		return false
+	}
+
+	templated := templatedHostSet(req)
+	matchedAtLeastOne := false
+	for _, host := range req.Hosts {
+		if templated[host] {
+			continue
+		}
+		matchedAtLeastOne = true
+		if !descriptorHasHost(existing, host, req.CredentialRef, req.Scheme) {
+			return false
+		}
+	}
+	return matchedAtLeastOne
+}
+
+// descriptorHasHost reports whether some entry binds host to the given
+// credential ref and scheme. Host comparison is case-insensitive, matching the
+// descriptor loader's host dedup semantics.
+func descriptorHasHost(existing []proxybinding.Entry, host, credentialRef, scheme string) bool {
+	for i := range existing {
+		e := existing[i]
+		if strings.EqualFold(e.Host, host) && e.CredentialRef == credentialRef && e.Scheme == scheme {
+			return true
+		}
+	}
+	return false
+}
+
+// templatedHostSet builds a lookup of the requirement's templated hosts.
+func templatedHostSet(req credreq.RequiredBinding) map[string]bool {
+	if len(req.TemplatedHosts) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(req.TemplatedHosts))
+	for _, h := range req.TemplatedHosts {
+		set[h] = true
+	}
+	return set
+}
+
+// runSkillBind onboards a frozen plan's credential requirements: resolve the
+// installed frozen version, derive its RequiredBinding set, diff each
+// requirement against the vault and the descriptors, interactively fill only
+// the gaps, write the descriptor entries in a single atomic Upsert, print a
+// per-requirement summary, and remind the operator to restart the daemon.
+func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("skill bind", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	version := flags.String("version", "", "Frozen version id to bind (defaults to the most recently frozen version)")
+	positionals, err := parseInterspersedFlags(flags, args)
+	if err != nil {
+		return 1
+	}
+	if len(positionals) != 1 {
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+	name := positionals[0]
+
+	s := store.New(skillStoreDir)
+	id, _, err := resolveFrozenVersion(s, name, *version)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	reqs, err := deriveRequirements(s, name, id)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if len(reqs) == 0 {
+		fmt.Fprintf(stdout, "Plan %q declares no credential requirements; nothing to onboard.\n", name)
+		return 0
+	}
+
+	client := newBindVaultClient()
+	services, err := client.ListUserServices()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	vaultRefs := make(map[string]bool, len(services))
+	for _, svc := range services {
+		vaultRefs["user/"+svc] = true
+	}
+
+	existing, err := proxybinding.Load(proxybinding.LoadOptions{UserPath: descriptorPath()})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	statuses := diffRequirements(reqs, vaultRefs, existing)
+
+	br := bufio.NewReader(stdin)
+	var (
+		toWrite    []proxybinding.Entry
+		summary    []string
+		advisories []string
+	)
+	for _, st := range statuses {
+		if st.satisfied() {
+			summary = append(summary, fmt.Sprintf("  satisfied: %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
+			continue
+		}
+		entries, adv, err := fillRequirement(st, client, br, stdout, stderr)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %s: %v\n", st.req.CredentialRef, err)
+			return 1
+		}
+		toWrite = append(toWrite, entries...)
+		advisories = append(advisories, adv...)
+		summary = append(summary, fmt.Sprintf("  onboarded: %s (%s)", st.req.CredentialRef, requirementLabel(st.req)))
+	}
+
+	if len(toWrite) > 0 {
+		if err := proxybinding.Upsert(descriptorPath(), toWrite...); err != nil {
+			fmt.Fprintf(stderr, "error: write binding descriptor: %v\n", err)
+			return 1
+		}
+	}
+
+	fmt.Fprintf(stdout, "Onboarding for plan %q:\n", name)
+	for _, line := range summary {
+		fmt.Fprintln(stdout, line)
+	}
+	for _, adv := range advisories {
+		fmt.Fprintf(stdout, "  advisory: %s\n", adv)
+	}
+	if len(toWrite) > 0 {
+		fmt.Fprintf(stdout, "Wrote %d descriptor entr%s to %s\n", len(toWrite), plural(len(toWrite), "y", "ies"), descriptorPath())
+	}
+	fmt.Fprintln(stdout, "The daemon loads binding descriptors once at startup (#1887); restart it with `aileron daemon stop` then `aileron daemon start` for these bindings to take effect.")
+	return 0
+}
+
+// fillRequirement captures the secret and non-secret params for a requirement
+// that is not fully satisfied. It prompts for the vault secret only when the
+// vault does not already hold it, and builds descriptor entries only when the
+// descriptors do not already satisfy it, so a partially-onboarded requirement
+// fills only its missing half. It returns the descriptor entries the caller
+// batches into a single Upsert plus any advisories (for templated hosts).
+func fillRequirement(st reqStatus, client bindVaultClient, stdin *bufio.Reader, stdout, stderr io.Writer) ([]proxybinding.Entry, []string, error) {
+	req := st.req
+
+	if !st.vaultPresent {
+		secret, err := promptPassphrase(fmt.Sprintf("Secret for %s: ", req.CredentialRef), stderr)
+		if err != nil {
+			return nil, nil, err
+		}
+		if secret == "" {
+			return nil, nil, fmt.Errorf("secret cannot be empty")
+		}
+		service := strings.TrimPrefix(req.CredentialRef, "user/")
+		if err := client.PutUser(service, []byte(secret)); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if st.descriptorPresent {
+		return nil, nil, nil
+	}
+
+	if req.HostLessIdentity() {
+		if req.IdentityLabel == "" {
+			return nil, nil, fmt.Errorf("cannot write a valid %s descriptor without an identity_label; the frozen plan declares a %s credential with no identityLabel", req.Scheme, req.CredentialKind)
+		}
+		akid := strings.TrimSpace(promptLine(stdin, stdout, fmt.Sprintf("AWS access key ID for %s: ", req.CredentialRef)))
+		if akid == "" {
+			return nil, nil, fmt.Errorf("access key ID cannot be empty")
+		}
+		entry := proxybinding.Entry{
+			Kind:          req.CredentialKind,
+			IdentityLabel: req.IdentityLabel,
+			CredentialRef: req.CredentialRef,
+			Scheme:        req.Scheme,
+			AccessKeyID:   akid,
+		}
+		for _, w := range entry.Warnings() {
+			fmt.Fprintf(stderr, "warning: %s\n", w)
+		}
+		return []proxybinding.Entry{entry}, nil, nil
+	}
+
+	// Host-keyed (bearer): one entry per non-templated host. A templated host
+	// carries an unresolved input token and cannot be onboarded automatically.
+	templated := templatedHostSet(req)
+	var (
+		entries    []proxybinding.Entry
+		advisories []string
+	)
+	for _, host := range req.Hosts {
+		if templated[host] {
+			advisories = append(advisories, fmt.Sprintf("host %q carries an input template and cannot be onboarded automatically; add it by hand after resolving the input", host))
+			continue
+		}
+		entries = append(entries, proxybinding.Entry{
+			Host:          host,
+			CredentialRef: req.CredentialRef,
+			Scheme:        req.Scheme,
+		})
+	}
+	return entries, advisories, nil
+}
+
+// requirementLabel is a short human description of what a requirement binds:
+// its identity for a host-less-identity binding, or its host list for a
+// host-keyed one.
+func requirementLabel(req credreq.RequiredBinding) string {
+	if req.HostLessIdentity() {
+		return fmt.Sprintf("identity %s/%s", req.CredentialKind, req.IdentityLabel)
+	}
+	return "hosts " + strings.Join(req.Hosts, ", ")
+}
+
+// plural returns singular when n == 1, else plural.
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -23,9 +23,14 @@ import (
 type fakeBindVault struct {
 	services map[string][]byte
 	puts     int
+	listErr  error
+	putErr   error
 }
 
 func (f *fakeBindVault) ListUserServices() ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
 	out := make([]string, 0, len(f.services))
 	for k := range f.services {
 		out = append(out, k)
@@ -34,6 +39,9 @@ func (f *fakeBindVault) ListUserServices() ([]string, error) {
 }
 
 func (f *fakeBindVault) PutUser(service string, value []byte) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
 	if f.services == nil {
 		f.services = map[string][]byte{}
 	}
@@ -523,6 +531,105 @@ func TestDiffRequirements(t *testing.T) {
 	}
 }
 
+// TestRunSkillBindErrorPaths covers the verb's fail-closed error branches: a
+// wrong positional count, a deriver error (an unmapped credential kind), a
+// vault list failure, a malformed descriptor file, a vault write failure, and
+// the interactive-input rejections (empty secret, empty access key ID).
+func TestRunSkillBindErrorPaths(t *testing.T) {
+	t.Run("wrong positional count", func(t *testing.T) {
+		withTempStore(t)
+		var out, errb bytes.Buffer
+		if code := runSkillBind(nil, strings.NewReader(""), &out, &errb); code != 1 {
+			t.Fatalf("exit = %d, want 1", code)
+		}
+	})
+
+	t.Run("deriver error fails closed", func(t *testing.T) {
+		withTempStore(t)
+		origDesc := skillBindDescriptorPath
+		skillBindDescriptorPath = filepath.Join(t.TempDir(), "d.yaml")
+		t.Cleanup(func() { skillBindDescriptorPath = origDesc })
+		origDerive := deriveRequirements
+		deriveRequirements = func(_ *store.Store, _, _ string) ([]credreq.RequiredBinding, error) {
+			return nil, errTest("unmapped credential kind \"mystery\"")
+		}
+		t.Cleanup(func() { deriveRequirements = origDerive })
+		seedFrozen(t, "rubber-duck", "v1")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "unmapped credential kind") {
+			t.Fatalf("exit = %d stderr=%q, want 1 with the deriver error", code, errb.String())
+		}
+	})
+
+	t.Run("vault list failure", func(t *testing.T) {
+		vault := &fakeBindVault{listErr: errTest("daemon unreachable")}
+		withBindSeams(t, []credreq.RequiredBinding{bearerReq("workspace-a", "api.example.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "daemon unreachable") {
+			t.Fatalf("exit = %d stderr=%q, want 1 with the list error", code, errb.String())
+		}
+	})
+
+	t.Run("malformed descriptor file", func(t *testing.T) {
+		vault := &fakeBindVault{}
+		descPath := withBindSeams(t, []credreq.RequiredBinding{bearerReq("workspace-a", "api.example.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		if err := os.WriteFile(descPath, []byte("version: v1\nbindings: [ this is: not valid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+		if code != 1 {
+			t.Fatalf("exit = %d, want 1 on a malformed descriptor", code)
+		}
+	})
+
+	t.Run("vault write failure", func(t *testing.T) {
+		vault := &fakeBindVault{putErr: errTest("vault is locked")}
+		withBindSeams(t, []credreq.RequiredBinding{bearerReq("workspace-a", "api.example.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		withSecret(t, "tok")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "vault is locked") {
+			t.Fatalf("exit = %d stderr=%q, want 1 with the put error", code, errb.String())
+		}
+	})
+
+	t.Run("empty secret rejected", func(t *testing.T) {
+		vault := &fakeBindVault{}
+		withBindSeams(t, []credreq.RequiredBinding{bearerReq("workspace-a", "api.example.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		withSecret(t, "")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "secret cannot be empty") {
+			t.Fatalf("exit = %d stderr=%q, want 1 with the empty-secret error", code, errb.String())
+		}
+	})
+
+	t.Run("empty access key id rejected", func(t *testing.T) {
+		vault := &fakeBindVault{}
+		withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		withSecret(t, "s")
+		var out, errb bytes.Buffer
+		// Blank line for the access key ID prompt.
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader("\n"), &out, &errb)
+		if code != 1 || !strings.Contains(errb.String(), "access key ID cannot be empty") {
+			t.Fatalf("exit = %d stderr=%q, want 1 with the empty-key error", code, errb.String())
+		}
+	})
+}
+
+// errTest is a tiny error type for injecting seam failures.
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
 // TestDaemonBindVaultClientListUserServices proves the daemon-backed client
 // reads the user-service list from GET /vault/user and returns the bare service
 // segments.
@@ -544,6 +651,45 @@ func TestDaemonBindVaultClientListUserServices(t *testing.T) {
 	}
 	if strings.Join(sortedCopy(got), ",") != "prod-reader,workspace-a" {
 		t.Errorf("services = %v, want [prod-reader workspace-a]", got)
+	}
+}
+
+// TestDaemonBindVaultClientListErrors proves the client maps a 503 and an
+// unexpected status to clear errors.
+func TestDaemonBindVaultClientListErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"unavailable", http.StatusServiceUnavailable, "not configured with a vault"},
+		{"unexpected", http.StatusInternalServerError, "server returned 500"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			t.Cleanup(srv.Close)
+			setBindingBase(t, srv.URL)
+			_, err := daemonBindVaultClient{}.ListUserServices()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestDaemonBindVaultClientPutUnavailable proves a 503 on PUT maps to a clear
+// no-vault error.
+func TestDaemonBindVaultClientPutUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+	setBindingBase(t, srv.URL)
+	err := (daemonBindVaultClient{}).PutUser("prod-reader", []byte("s"))
+	if err == nil || !strings.Contains(err.Error(), "not configured with a vault") {
+		t.Errorf("err = %v, want a no-vault error", err)
 	}
 }
 

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -262,6 +262,41 @@ func TestRunSkillBindPartiallySatisfied(t *testing.T) {
 	}
 }
 
+// TestRunSkillBindSharedCredentialRefPromptsOnce proves two host-keyed
+// requirements that share one CredentialRef (same identity, distinct host sets,
+// which the deriver keeps as two bindings) prompt for the shared secret once and
+// still write both host entries.
+func TestRunSkillBindSharedCredentialRefPromptsOnce(t *testing.T) {
+	vault := &fakeBindVault{}
+	reqs := []credreq.RequiredBinding{
+		bearerReq("workspace-a", "api.one.example.com"),
+		bearerReq("workspace-a", "api.two.example.com"),
+	}
+	descPath := withBindSeams(t, reqs, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	secretCalls := withSecret(t, "shared-token")
+
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if *secretCalls != 1 {
+		t.Errorf("secret prompted %d times, want 1 for the shared ref", *secretCalls)
+	}
+	if vault.puts != 1 {
+		t.Errorf("vault puts = %d, want 1 for the shared ref", vault.puts)
+	}
+	d := parseDescriptor(t, descPath)
+	hosts := map[string]bool{}
+	for _, e := range d.Bindings {
+		hosts[e.Host] = true
+	}
+	if !hosts["api.one.example.com"] || !hosts["api.two.example.com"] {
+		t.Errorf("descriptor hosts = %v, want both api.one and api.two", hosts)
+	}
+}
+
 // TestRunSkillBindFullySatisfied proves an already-onboarded plan prompts
 // nothing and rewrites no descriptor.
 func TestRunSkillBindFullySatisfied(t *testing.T) {

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/credreq"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// fakeBindVault is an in-memory bindVaultClient: it records PutUser calls and
+// answers ListUserServices from its own state, so a bind test never touches a
+// live daemon or the operator's real vault.
+type fakeBindVault struct {
+	services map[string][]byte
+	puts     int
+}
+
+func (f *fakeBindVault) ListUserServices() ([]string, error) {
+	out := make([]string, 0, len(f.services))
+	for k := range f.services {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+func (f *fakeBindVault) PutUser(service string, value []byte) error {
+	if f.services == nil {
+		f.services = map[string][]byte{}
+	}
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	f.services[service] = cp
+	f.puts++
+	return nil
+}
+
+// withBindSeams points the verb at a temp store + temp descriptor file, injects
+// the canned requirements, and wires the fake vault. It restores every seam on
+// cleanup so a bind test leaves no global state behind.
+func withBindSeams(t *testing.T, reqs []credreq.RequiredBinding, vault *fakeBindVault) string {
+	t.Helper()
+	withTempStore(t)
+
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	origDesc := skillBindDescriptorPath
+	skillBindDescriptorPath = descPath
+	t.Cleanup(func() { skillBindDescriptorPath = origDesc })
+
+	origDerive := deriveRequirements
+	deriveRequirements = func(_ *store.Store, _, _ string) ([]credreq.RequiredBinding, error) { return reqs, nil }
+	t.Cleanup(func() { deriveRequirements = origDerive })
+
+	origClient := newBindVaultClient
+	newBindVaultClient = func() bindVaultClient { return vault }
+	t.Cleanup(func() { newBindVaultClient = origClient })
+
+	return descPath
+}
+
+// seedFrozen writes a minimal frozen version into the temp store so
+// resolveFrozenVersion resolves a real id. The deriver seam ignores it, but the
+// verb still runs the real store resolution the plan reuses.
+func seedFrozen(t *testing.T, name, id string) {
+	t.Helper()
+	s := store.New(skillStoreDir)
+	if err := s.WriteFrozen(name, installFrozen(id)); err != nil {
+		t.Fatalf("seed frozen: %v", err)
+	}
+}
+
+// withSecret makes the hidden secret prompt return the given value and returns
+// a pointer to the call count.
+func withSecret(t *testing.T, secret string) *int {
+	t.Helper()
+	calls := new(int)
+	orig := promptPassphrase
+	promptPassphrase = func(_ string, _ io.Writer) (string, error) {
+		*calls++
+		return secret, nil
+	}
+	t.Cleanup(func() { promptPassphrase = orig })
+	return calls
+}
+
+// withNoPrompt fails the test if the hidden secret prompt fires.
+func withNoPrompt(t *testing.T) {
+	t.Helper()
+	orig := promptPassphrase
+	promptPassphrase = func(_ string, _ io.Writer) (string, error) {
+		t.Fatal("promptPassphrase must not be called when every requirement is satisfied")
+		return "", nil
+	}
+	t.Cleanup(func() { promptPassphrase = orig })
+}
+
+// parseDescriptor reads and parses the descriptor file the verb wrote.
+func parseDescriptor(t *testing.T, path string) proxybinding.Descriptor {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read descriptor %q: %v", path, err)
+	}
+	d, err := proxybinding.Parse(data)
+	if err != nil {
+		t.Fatalf("parse descriptor %q: %v\n%s", path, err, data)
+	}
+	return d
+}
+
+func sigv4Req(label, host string) credreq.RequiredBinding {
+	return credreq.RequiredBinding{
+		CredentialKind: "aws-sigv4",
+		IdentityLabel:  label,
+		Scheme:         "sigv4-resign",
+		Hosts:          []string{host},
+		HostShape:      credreq.HostShapeHostLessIdentity,
+		CredentialRef:  "user/" + label,
+	}
+}
+
+func bearerReq(service string, hosts ...string) credreq.RequiredBinding {
+	return credreq.RequiredBinding{
+		CredentialKind: "oauth2",
+		IdentityLabel:  service,
+		Scheme:         "bearer",
+		Hosts:          hosts,
+		HostShape:      credreq.HostShapeHostKeyed,
+		CredentialRef:  "user/" + service,
+	}
+}
+
+// TestRunSkillBindFullyMissingSigv4 proves a fully-missing sigv4 requirement is
+// onboarded: the secret lands in the vault, the descriptor gains a valid
+// identity entry with the access key ID and no host, and the summary + restart
+// reminder are printed.
+func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
+	vault := &fakeBindVault{}
+	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	secretCalls := withSecret(t, "supersecret")
+
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader("AKIAIOSFODNN7EXAMPLE\n"), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if *secretCalls != 1 {
+		t.Errorf("secret prompted %d times, want 1", *secretCalls)
+	}
+	if vault.puts != 1 || string(vault.services["prod-reader"]) != "supersecret" {
+		t.Errorf("vault = %+v, want one put of user/prod-reader=supersecret", vault.services)
+	}
+
+	d := parseDescriptor(t, descPath)
+	if len(d.Bindings) != 1 {
+		t.Fatalf("descriptor has %d bindings, want 1: %+v", len(d.Bindings), d.Bindings)
+	}
+	e := d.Bindings[0]
+	if e.Kind != "aws-sigv4" || e.IdentityLabel != "prod-reader" || e.Scheme != "sigv4-resign" {
+		t.Errorf("entry identity = %+v, want aws-sigv4/prod-reader/sigv4-resign", e)
+	}
+	if e.AccessKeyID != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("access_key_id = %q, want the prompted key", e.AccessKeyID)
+	}
+	if e.Host != "" {
+		t.Errorf("sigv4 entry carries host %q, want none", e.Host)
+	}
+	if e.CredentialRef != "user/prod-reader" {
+		t.Errorf("credential_ref = %q, want user/prod-reader", e.CredentialRef)
+	}
+	if !strings.Contains(out.String(), "onboarded: user/prod-reader") {
+		t.Errorf("stdout = %q, want an onboarded summary line", out.String())
+	}
+	if !strings.Contains(out.String(), "#1887") || !strings.Contains(out.String(), "restart") {
+		t.Errorf("stdout = %q, want a load-once restart reminder", out.String())
+	}
+}
+
+// TestRunSkillBindPartiallySatisfied proves only the missing requirement is
+// filled: a pre-satisfied sigv4 entry is left intact while a missing bearer
+// requirement is prompted and written.
+func TestRunSkillBindPartiallySatisfied(t *testing.T) {
+	vault := &fakeBindVault{services: map[string][]byte{"prod-reader": []byte("existing")}}
+	reqs := []credreq.RequiredBinding{
+		sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com"),
+		bearerReq("workspace-a", "api.example.com"),
+	}
+	descPath := withBindSeams(t, reqs, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+
+	// Pre-seed the descriptor with the satisfied sigv4 entry.
+	if err := proxybinding.Upsert(descPath, proxybinding.Entry{
+		Kind:          "aws-sigv4",
+		IdentityLabel: "prod-reader",
+		CredentialRef: "user/prod-reader",
+		Scheme:        "sigv4-resign",
+		AccessKeyID:   "AKIAIOSFODNN7EXAMPLE",
+	}); err != nil {
+		t.Fatalf("pre-seed descriptor: %v", err)
+	}
+	before, err := os.ReadFile(descPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secretCalls := withSecret(t, "bearer-token")
+	var out, errb bytes.Buffer
+	// No stdin needed: bearer has no visible prompt.
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if *secretCalls != 1 {
+		t.Errorf("secret prompted %d times, want 1 (only the missing bearer)", *secretCalls)
+	}
+	if vault.puts != 1 || string(vault.services["workspace-a"]) != "bearer-token" {
+		t.Errorf("vault puts = %d services=%+v, want one put of workspace-a", vault.puts, vault.services)
+	}
+	// The pre-satisfied prod-reader secret is untouched (never re-prompted).
+	if string(vault.services["prod-reader"]) != "existing" {
+		t.Errorf("prod-reader secret = %q, want the untouched existing value", vault.services["prod-reader"])
+	}
+
+	d := parseDescriptor(t, descPath)
+	if len(d.Bindings) != 2 {
+		t.Fatalf("descriptor has %d bindings, want 2: %+v", len(d.Bindings), d.Bindings)
+	}
+	// The satisfied sigv4 entry's content is preserved.
+	if !strings.Contains(string(before), "AKIAIOSFODNN7EXAMPLE") {
+		t.Fatal("pre-seed sanity: expected the sigv4 key in the seeded file")
+	}
+	foundSigv4, foundBearer := false, false
+	for _, e := range d.Bindings {
+		if e.Kind == "aws-sigv4" && e.AccessKeyID == "AKIAIOSFODNN7EXAMPLE" {
+			foundSigv4 = true
+		}
+		if e.Host == "api.example.com" && e.CredentialRef == "user/workspace-a" && e.Scheme == "bearer" {
+			foundBearer = true
+		}
+	}
+	if !foundSigv4 {
+		t.Error("satisfied sigv4 entry was rewritten or lost")
+	}
+	if !foundBearer {
+		t.Error("missing bearer entry was not written")
+	}
+	if !strings.Contains(out.String(), "satisfied: user/prod-reader") {
+		t.Errorf("stdout = %q, want prod-reader marked satisfied", out.String())
+	}
+	if !strings.Contains(out.String(), "onboarded: user/workspace-a") {
+		t.Errorf("stdout = %q, want workspace-a marked onboarded", out.String())
+	}
+}
+
+// TestRunSkillBindFullySatisfied proves an already-onboarded plan prompts
+// nothing and rewrites no descriptor.
+func TestRunSkillBindFullySatisfied(t *testing.T) {
+	vault := &fakeBindVault{services: map[string][]byte{"workspace-a": []byte("tok")}}
+	descPath := withBindSeams(t, []credreq.RequiredBinding{bearerReq("workspace-a", "api.example.com")}, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+
+	if err := proxybinding.Upsert(descPath, proxybinding.Entry{
+		Host:          "api.example.com",
+		CredentialRef: "user/workspace-a",
+		Scheme:        "bearer",
+	}); err != nil {
+		t.Fatalf("pre-seed descriptor: %v", err)
+	}
+	before, err := os.ReadFile(descPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withNoPrompt(t)
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if vault.puts != 0 {
+		t.Errorf("vault puts = %d, want 0 (nothing missing)", vault.puts)
+	}
+	after, err := os.ReadFile(descPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("descriptor was rewritten:\nbefore=%s\nafter=%s", before, after)
+	}
+	if !strings.Contains(out.String(), "satisfied: user/workspace-a") {
+		t.Errorf("stdout = %q, want the satisfied summary", out.String())
+	}
+}
+
+// TestRunSkillBindSigv4ShapeWarning proves a bad-shaped access key ID is warned
+// about (warn-only) yet still written, and a well-shaped key produces no
+// warning.
+func TestRunSkillBindSigv4ShapeWarning(t *testing.T) {
+	t.Run("bad shape warns but writes", func(t *testing.T) {
+		vault := &fakeBindVault{}
+		descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		withSecret(t, "s")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader("not-a-real-key\n"), &out, &errb)
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(errb.String(), "access key ID shape") {
+			t.Errorf("stderr = %q, want a shape warning", errb.String())
+		}
+		d := parseDescriptor(t, descPath)
+		if len(d.Bindings) != 1 || d.Bindings[0].AccessKeyID != "not-a-real-key" {
+			t.Errorf("entry = %+v, want the bad key still written (warn-only)", d.Bindings)
+		}
+	})
+
+	t.Run("valid shape is clean", func(t *testing.T) {
+		vault := &fakeBindVault{}
+		withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+		seedFrozen(t, "rubber-duck", "v1")
+		withSecret(t, "s")
+		var out, errb bytes.Buffer
+		code := runSkillBind([]string{"rubber-duck"}, strings.NewReader("AKIAIOSFODNN7EXAMPLE\n"), &out, &errb)
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+		}
+		if strings.Contains(errb.String(), "access key ID shape") {
+			t.Errorf("stderr = %q, want no shape warning for a valid key", errb.String())
+		}
+	})
+}
+
+// TestRunSkillBindTemplatedHostAdvisory proves a host-keyed requirement whose
+// only host carries an input template is surfaced as an advisory and writes no
+// descriptor entry for that host.
+func TestRunSkillBindTemplatedHostAdvisory(t *testing.T) {
+	vault := &fakeBindVault{}
+	req := credreq.RequiredBinding{
+		CredentialKind: "oauth2",
+		IdentityLabel:  "workspace-a",
+		Scheme:         "bearer",
+		Hosts:          []string{"athena.{{ inputs.aws_region }}.amazonaws.com"},
+		TemplatedHosts: []string{"athena.{{ inputs.aws_region }}.amazonaws.com"},
+		HostShape:      credreq.HostShapeHostKeyed,
+		CredentialRef:  "user/workspace-a",
+	}
+	descPath := withBindSeams(t, []credreq.RequiredBinding{req}, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	withSecret(t, "tok")
+
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "advisory:") || !strings.Contains(out.String(), "input template") {
+		t.Errorf("stdout = %q, want a templated-host advisory", out.String())
+	}
+	// No descriptor entry was written for the templated host, so the file was
+	// never created (nothing to Upsert).
+	if _, err := os.Stat(descPath); !os.IsNotExist(err) {
+		d := parseDescriptor(t, descPath)
+		for _, e := range d.Bindings {
+			if strings.Contains(e.Host, "{{") {
+				t.Errorf("wrote a descriptor entry for a templated host: %+v", e)
+			}
+		}
+	}
+}
+
+// TestRunSkillBindEmptyRequirements proves a plan with no derived requirements
+// exits 0 with a "nothing to onboard" message and never prompts.
+func TestRunSkillBindEmptyRequirements(t *testing.T) {
+	vault := &fakeBindVault{}
+	withBindSeams(t, nil, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	withNoPrompt(t)
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "nothing to onboard") {
+		t.Errorf("stdout = %q, want a nothing-to-onboard message", out.String())
+	}
+	if vault.puts != 0 {
+		t.Errorf("vault puts = %d, want 0", vault.puts)
+	}
+}
+
+// TestRunSkillBindNoFrozenVersion proves the verb surfaces the shared
+// resolveFrozenVersion error when the skill has no frozen versions.
+func TestRunSkillBindNoFrozenVersion(t *testing.T) {
+	withTempStore(t)
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"never-frozen"}, strings.NewReader(""), &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "no frozen versions") {
+		t.Errorf("stderr = %q, want the no-frozen-versions error", errb.String())
+	}
+}
+
+// TestRunSkillBindSigv4MissingIdentityLabel proves a sigv4 requirement with an
+// empty identity_label is surfaced as a clear per-requirement error rather than
+// writing an invalid descriptor.
+func TestRunSkillBindSigv4MissingIdentityLabel(t *testing.T) {
+	vault := &fakeBindVault{}
+	req := credreq.RequiredBinding{
+		CredentialKind: "aws-sigv4",
+		IdentityLabel:  "",
+		Scheme:         "sigv4-resign",
+		Hosts:          []string{"athena.us-east-1.amazonaws.com"},
+		HostShape:      credreq.HostShapeHostLessIdentity,
+		CredentialRef:  "user/aws-sigv4",
+	}
+	withBindSeams(t, []credreq.RequiredBinding{req}, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	withSecret(t, "s")
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader(""), &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1, stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "identity_label") {
+		t.Errorf("stderr = %q, want an identity_label error", errb.String())
+	}
+}
+
+// TestDiffRequirements is a direct, table-driven test of the pure diff over the
+// (vault-present x descriptor-present) combinations, including host-less
+// identity match and host-keyed multi-host (all-present vs one-missing).
+func TestDiffRequirements(t *testing.T) {
+	sig := sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")
+	multi := bearerReq("workspace-a", "api.one.example.com", "api.two.example.com")
+
+	sigEntry := proxybinding.Entry{Kind: "aws-sigv4", IdentityLabel: "prod-reader", CredentialRef: "user/prod-reader", Scheme: "sigv4-resign", AccessKeyID: "AKIAIOSFODNN7EXAMPLE"}
+	hostEntry := func(h string) proxybinding.Entry {
+		return proxybinding.Entry{Host: h, CredentialRef: "user/workspace-a", Scheme: "bearer"}
+	}
+
+	cases := []struct {
+		name          string
+		req           credreq.RequiredBinding
+		vault         map[string]bool
+		existing      []proxybinding.Entry
+		wantVault     bool
+		wantDesc      bool
+		wantSatisfied bool
+	}{
+		{"sigv4 both present", sig, map[string]bool{"user/prod-reader": true}, []proxybinding.Entry{sigEntry}, true, true, true},
+		{"sigv4 vault only", sig, map[string]bool{"user/prod-reader": true}, nil, true, false, false},
+		{"sigv4 descriptor only", sig, nil, []proxybinding.Entry{sigEntry}, false, true, false},
+		{"sigv4 neither", sig, nil, nil, false, false, false},
+		{"host-keyed all hosts present", multi, map[string]bool{"user/workspace-a": true}, []proxybinding.Entry{hostEntry("api.one.example.com"), hostEntry("api.two.example.com")}, true, true, true},
+		{"host-keyed one host missing", multi, map[string]bool{"user/workspace-a": true}, []proxybinding.Entry{hostEntry("api.one.example.com")}, true, false, false},
+		{"host-keyed case-insensitive host match", multi, nil, []proxybinding.Entry{hostEntry("API.ONE.example.com"), hostEntry("api.two.example.com")}, false, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffRequirements([]credreq.RequiredBinding{tc.req}, tc.vault, tc.existing)
+			if len(got) != 1 {
+				t.Fatalf("got %d statuses, want 1", len(got))
+			}
+			st := got[0]
+			if st.vaultPresent != tc.wantVault {
+				t.Errorf("vaultPresent = %v, want %v", st.vaultPresent, tc.wantVault)
+			}
+			if st.descriptorPresent != tc.wantDesc {
+				t.Errorf("descriptorPresent = %v, want %v", st.descriptorPresent, tc.wantDesc)
+			}
+			if st.satisfied() != tc.wantSatisfied {
+				t.Errorf("satisfied = %v, want %v", st.satisfied(), tc.wantSatisfied)
+			}
+		})
+	}
+}
+
+// TestDaemonBindVaultClientListUserServices proves the daemon-backed client
+// reads the user-service list from GET /vault/user and returns the bare service
+// segments.
+func TestDaemonBindVaultClientListUserServices(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/vault/user" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"services": []map[string]string{{"service": "prod-reader"}, {"service": "workspace-a"}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	setBindingBase(t, srv.URL)
+
+	got, err := daemonBindVaultClient{}.ListUserServices()
+	if err != nil {
+		t.Fatalf("ListUserServices: %v", err)
+	}
+	if strings.Join(sortedCopy(got), ",") != "prod-reader,workspace-a" {
+		t.Errorf("services = %v, want [prod-reader workspace-a]", got)
+	}
+}
+
+// TestDaemonBindVaultClientPutUser proves the client PUTs a base64-encoded
+// value to the user credential path and maps 204 to success.
+func TestDaemonBindVaultClientPutUser(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/vault/user/prod-reader/credentials" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	setBindingBase(t, srv.URL)
+
+	if err := (daemonBindVaultClient{}).PutUser("prod-reader", []byte("supersecret")); err != nil {
+		t.Fatalf("PutUser: %v", err)
+	}
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("decode put body: %v", err)
+	}
+	dec, err := base64.StdEncoding.DecodeString(body.Value)
+	if err != nil {
+		t.Fatalf("value not base64: %v", err)
+	}
+	if string(dec) != "supersecret" {
+		t.Errorf("decoded value = %q, want supersecret", dec)
+	}
+}
+
+// TestDaemonBindVaultClientPutUserLocked proves a 423 Locked response maps to a
+// clear vault-locked error.
+func TestDaemonBindVaultClientPutUserLocked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusLocked)
+	}))
+	t.Cleanup(srv.Close)
+	setBindingBase(t, srv.URL)
+
+	err := (daemonBindVaultClient{}).PutUser("prod-reader", []byte("s"))
+	if err == nil || !strings.Contains(err.Error(), "locked") {
+		t.Errorf("err = %v, want a vault-locked error", err)
+	}
+}
+
+func sortedCopy(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	for i := range out {
+		for j := i + 1; j < len(out); j++ {
+			if out[j] < out[i] {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+// TestDescriptorSatisfiesTemplatedHostsOnly proves a host-keyed requirement
+// whose only hosts are templated is never considered descriptor-satisfied
+// (there is nothing writable to match).
+func TestDescriptorSatisfiesTemplatedHostsOnly(t *testing.T) {
+	req := credreq.RequiredBinding{
+		Scheme:         "bearer",
+		Hosts:          []string{"athena.{{ inputs.aws_region }}.amazonaws.com"},
+		TemplatedHosts: []string{"athena.{{ inputs.aws_region }}.amazonaws.com"},
+		HostShape:      credreq.HostShapeHostKeyed,
+		CredentialRef:  "user/workspace-a",
+	}
+	if descriptorSatisfies(req, nil) {
+		t.Error("a templated-only host-keyed requirement must not be satisfied")
+	}
+}

--- a/cmd/aileron/skill_install_oci.go
+++ b/cmd/aileron/skill_install_oci.go
@@ -97,5 +97,6 @@ func runSkillInstallOCI(ref string, stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "Installed frozen version %s of skill %q to %s\n",
 		res.Frozen.ID, res.Name, s.FrozenDir(res.Name, res.Frozen.ID))
+	fmt.Fprintf(stdout, "Run `aileron skill bind %q` to supply this plan's credentials\n", res.Name)
 	return 0
 }

--- a/cmd/aileron/skill_install_oci_test.go
+++ b/cmd/aileron/skill_install_oci_test.go
@@ -68,6 +68,11 @@ func TestRunSkillInstallOCIWritesFrozenAndLists(t *testing.T) {
 	if !strings.Contains(out.String(), "Installed frozen version v1abc") {
 		t.Errorf("stdout = %q, want an installed-frozen line", out.String())
 	}
+	// The install prints a one-line pointer to the onboarding verb so the
+	// operator knows how to supply the plan's credentials without hand-editing.
+	if !strings.Contains(out.String(), `aileron skill bind "rubber-duck"`) {
+		t.Errorf("stdout = %q, want a `skill bind` pointer line", out.String())
+	}
 
 	// The store now lists the skill and holds exactly the frozen version id.
 	var listOut bytes.Buffer

--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -52,7 +52,7 @@ Decoding is strict. An unknown YAML key is an error, not a silently ignored fiel
 Descriptors load from two layers, in increasing precedence.
 
 1. **Built-in defaults.** Trusted community profiles Aileron ships, embedded at build time. The Linear descriptor above is one. This is the trusted layer, distinct from the user layer below.
-2. **User layer.** `~/.aileron/binding-descriptors.yaml`.
+2. **User layer.** `~/.aileron/binding-descriptors.yaml`. `aileron skill bind <name>` writes this file programmatically when it onboards a Flight Plan's credential requirements, so hand-editing it is the fallback rather than the default. See [Onboarding credentials](/guides/installing-a-skill/#onboarding-credentials). The file format below is the reference for both the written entries and any you add by hand.
 
 A `gh` request is sealed too, but `gh`'s bindings no longer arrive as an embedded built-in default. They arrive through a third source: the sealing plane of `gh`'s CLI-capability unit, carried on its devcontainer Feature and projected into the binding table from the sandbox image's `devcontainer.metadata` label (see [the gh sealing plane](#shipped-via-the-gh-cli-capability-unit-sealing) below). Linear remains the embedded built-in worked example.
 

--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -49,11 +49,26 @@ An OCI install writes a frozen version, so it appears under `~/.aileron/skills/<
 
 ```
 Installed frozen version v1a2b3c4d5e6f of skill "weekly-metrics-digest" to /Users/you/.aileron/skills/weekly-metrics-digest/versions/v1a2b3c4d5e6f
+Run `aileron skill bind "weekly-metrics-digest"` to supply this plan's credentials
 ```
 
-The version id is the frozen content-hash slug, so a re-install of the same published plan is a no-op that reuses the same directory. Install does not pull the plan's container image. The image pin recorded in the lockfile is resolved at `aileron skill launch`, not at install.
+The version id is the frozen content-hash slug, so a re-install of the same published plan is a no-op that reuses the same directory. Install does not pull the plan's container image. The image pin recorded in the lockfile is resolved at `aileron skill launch`, not at install. The install prints a one-line pointer to `aileron skill bind` so you know how to onboard the plan's credentials next.
 
 > Installing by an [agentskills.io](https://agentskills.io) registry slug is not supported. agentskills.io is a format spec, not a registry, so a slug has no canonical location to resolve against. Install from a local path, a git URL, or an OCI reference instead.
+
+## Onboarding credentials
+
+A published Flight Plan declares the credentials it needs in its frozen trust contracts, but it never carries the secrets. After you install a frozen plan, run `aileron skill bind <name>` to supply them:
+
+```sh
+aileron skill bind weekly-metrics-digest
+```
+
+The verb derives the plan's credential requirements from its verified frozen trust contracts, then fills only the gaps. For each requirement it checks two places: your vault for the secret, and `~/.aileron/binding-descriptors.yaml` for the non-secret binding. A requirement already present in both is reported as satisfied and left untouched. A missing requirement prompts you for its secret with a hidden prompt that writes straight to the vault, prompts for any non-secret parameter such as an AWS access key ID, and writes the binding descriptor entry.
+
+The write is programmatic, so you do not hand-edit any file. A single run stores the vault secret, writes the descriptor entry, prints a per-requirement summary, and reminds you to restart the daemon. The daemon reads binding descriptors once at startup, so a new binding takes effect only after a restart.
+
+The same verb onboards a second operator on their own machine. They install the same frozen plan, run `aileron skill bind <name>`, and supply their own identity and key. The plan is shared once; each operator binds their own credentials against it. A requirement whose host carries an unresolved input template is surfaced as an advisory rather than written automatically, since the concrete host is not known until launch resolves the input.
 
 ## Action requirements and graceful degrade
 


### PR DESCRIPTION
## Summary

Adds `aileron skill bind <name>`, a no-file-editing onboarding verb that composes the two already-merged dependencies:

- the credential-requirement deriver `internal/flightplan/credreq.DeriveFromFrozen` (#2002), and
- the idempotent descriptor writer `internal/proxybinding.Upsert` (#2001).

The verb resolves the installed frozen plan, derives its `RequiredBinding` set, diffs each requirement against the vault and the current binding descriptors, interactively fills only the gaps (hidden prompt for the secret straight into the vault, visible prompt for non-secret descriptor params such as an AWS access key ID), writes the descriptor entry in a single atomic `Upsert`, prints a per-requirement summary, and reminds the operator that the daemon loads descriptors once at startup (#1887) so a restart is needed.

The OCI `skill install` path now prints a one-line pointer to the new verb.

### Design

- **cmd/aileron-only.** No `openapi.yaml` change: the verb reuses the existing `GET /vault/user` and `PUT /vault/user/<svc>/credentials` endpoints and the local descriptor file. No new `proxybinding`/`credreq` exports.
- **Seams for testability** mirror the existing cmd/aileron discipline: `deriveRequirements` (over `DeriveFromFrozen`), `newBindVaultClient` (a small `bindVaultClient` interface with a daemon-backed default), and `skillBindDescriptorPath` (temp descriptor file). The diff is a pure helper (`diffRequirements`/`descriptorSatisfies`) so it is independently unit-testable.
- **Fill only gaps.** "Satisfied" = the vault holds the `CredentialRef` and the loaded descriptors contain a matching entry. A satisfied requirement is never re-prompted and its descriptor entry is left intact.
- **sigv4 `access_key_id` shape is warn-only**, reusing `Entry.Warnings()` (keeps `AKIDEXAMPLE`/valid keys clean). `region`/`service` are never prompted (#1978). A sigv4 requirement with an empty `identity_label` is a clear per-requirement error rather than a silently invalid descriptor.
- **Templated hosts** (`{{ inputs.* }}`) are surfaced as an advisory, not written automatically.

### Scope

In: the verb, its pure diff + fill helpers, the vault/deriver/descriptor seams, the OCI-install pointer, help/usage text, tests, and guide updates. Out: no `internal/proxybinding`/`credreq` changes, no `openapi.yaml` change, no live descriptor reload (restart reminder only), no onboarding on the local/git install path.

## Test plan

- `go test ./cmd/aileron/... ./internal/proxybinding/... ./internal/flightplan/credreq/...` — green.
- New `cmd/aileron/skill_bind_test.go` covers: fully-missing sigv4 (secret stored, descriptor entry written with the access key and no host, restart reminder), partially-satisfied (only the missing req prompts/writes, satisfied entry preserved), fully-satisfied (no prompt, no descriptor rewrite), sigv4 shape warning regression (bad key warns but writes; valid key clean), templated-host advisory, empty requirements, no-frozen-version error, empty-`identity_label` error, the pure `diffRequirements`/`descriptorSatisfies` table (vault × descriptor × host-keyed multi-host, case-insensitive host match), and the daemon-backed vault client (list, put with base64 body, 423-locked mapping).
- `skill_install_oci_test.go` extended to assert the `skill bind` pointer line.
- Pure helpers `diffRequirements`/`descriptorSatisfies`/`descriptorHasHost`/`templatedHostSet` at 100% line coverage; remaining uncovered lines in `runSkillBind`/`fillRequirement`/the daemon client are defensive error branches.
- Docs: `installing-a-skill.md` gains an "Onboarding credentials" section (single-operator flow + second-operator story); `binding-descriptors.md` notes the file is now written programmatically.

Closes #1998

🤖 Generated with [Claude Code](https://claude.com/claude-code)
