### PR TITLE
docs(inject): pin host-label==service assumption, name deferred SES/SimpleDB cliff

### DIFF
--- a/internal/credential/inject/awshost.go
+++ b/internal/credential/inject/awshost.go
@@ -50,6 +50,28 @@ var endpointInfixModifiers = map[string]bool{
 // This is the single host->scope parser shared by the SigV4 injector
 // (host-authoritative signing scope) and the WASM host's region-scoped
 // binding selection, so the two cannot drift.
+//
+// Assumption (host-label == signing service): the derived service is the
+// endpoint host label itself. This holds for every service Aileron signs
+// today (Athena: "athena.<region>.amazonaws.com" -> service "athena"), so
+// the parser returns the host label verbatim as the SigV4 signing service.
+// A handful of AWS services break this assumption because their endpoint
+// host label differs from the SigV4 service name they must be signed as:
+//   - Amazon SES: "email.<region>.amazonaws.com" is signed as service "ses"
+//     (the host label is "email", not "ses").
+//   - Amazon SimpleDB: "sdb.<region>.amazonaws.com" is signed as service
+//     "sdb", and other historical endpoints carry similar host/service skew.
+//
+// For those divergent-service endpoints the host-authoritative service this
+// function returns (the raw host label, e.g. "email") is not the correct
+// SigV4 signing service (e.g. "ses"). Divergent-service handling is
+// deliberately deferred: none of these services are on Aileron's signing
+// path yet, and the operator decision (consistent with the no-back-compat
+// stance) is to keep the signing service host-authoritative rather than
+// carry a host-label->service lookup table before a concrete need. Adding a
+// divergent-service mapping here is the named follow-up if such a service is
+// ever put on the SigV4 path. Do not change signing behavior for these
+// hosts without that mapping; today they simply parse to their host label.
 func ParseAWSEndpointHost(host string) (service, region string, err error) {
 	h := strings.TrimSpace(strings.ToLower(host))
 	// Strip a trailing :port if present. A hostname never contains a colon,

--- a/internal/credential/inject/awshost_test.go
+++ b/internal/credential/inject/awshost_test.go
@@ -69,6 +69,80 @@ func TestParseAWSEndpointHostErrors(t *testing.T) {
 	}
 }
 
+// TestParseAWSEndpointHostServiceIsHostLabel pins the host-label == signing
+// service assumption that ParseAWSEndpointHost relies on. For every service
+// Aileron signs today the SigV4 service name equals the endpoint host label,
+// so the parser returns that label verbatim as the service. Athena is the
+// live example (athena.<region> -> service "athena"); this test fails loudly
+// if the derived service ever stops matching the host label for it.
+func TestParseAWSEndpointHostServiceIsHostLabel(t *testing.T) {
+	const region = "us-east-1"
+	cases := []struct {
+		hostLabel string // the leading (service-shaped) label of the endpoint host
+	}{
+		{"athena"},
+		{"s3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.hostLabel, func(t *testing.T) {
+			host := tc.hostLabel + "." + region + ".amazonaws.com"
+			service, gotRegion, err := ParseAWSEndpointHost(host)
+			if err != nil {
+				t.Fatalf("ParseAWSEndpointHost(%q) unexpected error: %v", host, err)
+			}
+			if service != tc.hostLabel {
+				t.Errorf("service = %q, want host label %q (host-label==service assumption)", service, tc.hostLabel)
+			}
+			if gotRegion != region {
+				t.Errorf("region = %q, want %q", gotRegion, region)
+			}
+		})
+	}
+}
+
+// TestParseAWSEndpointHostDivergentServiceDeferred documents the known cliff
+// in the host-label == signing service assumption: a few AWS services must be
+// signed under a SigV4 service name that differs from their endpoint host
+// label. These are NOT on Aileron's signing path today, and divergent-service
+// handling is deferred (see ParseAWSEndpointHost's doc comment). This test
+// pins the CURRENT behavior — the parser returns the raw host label, not the
+// real signing service — so that if a mapping is ever added, the follow-up is
+// forced to update this test deliberately. The wantSigningService field
+// records the service these hosts would actually need to sign as; it is the
+// deferred cliff, intentionally NOT what the parser returns today.
+func TestParseAWSEndpointHostDivergentServiceDeferred(t *testing.T) {
+	const region = "us-east-1"
+	cases := []struct {
+		name string
+		host string
+		// wantLabel is what ParseAWSEndpointHost returns today (the host
+		// label), which is what we assert on.
+		wantLabel string
+		// wantSigningService is the correct SigV4 service for this endpoint.
+		// It differs from wantLabel; handling this divergence is DEFERRED, so
+		// it is documented here but deliberately not asserted as the result.
+		wantSigningService string
+	}{
+		{"ses-email", "email." + region + ".amazonaws.com", "email", "ses"},
+		{"simpledb-sdb", "sdb." + region + ".amazonaws.com", "sdb", "sdb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, gotRegion, err := ParseAWSEndpointHost(tc.host)
+			if err != nil {
+				t.Fatalf("ParseAWSEndpointHost(%q) unexpected error: %v", tc.host, err)
+			}
+			if service != tc.wantLabel {
+				t.Errorf("service = %q, want host label %q (divergent-service handling is deferred; real signing service would be %q)",
+					service, tc.wantLabel, tc.wantSigningService)
+			}
+			if gotRegion != region {
+				t.Errorf("region = %q, want %q", gotRegion, region)
+			}
+		})
+	}
+}
+
 // TestParseAWSEndpointHostErrorNamesHost asserts the error clearly names the
 // offending host so an operator can diagnose it. The host is non-secret;
 // there is no credential material in this function at all.


### PR DESCRIPTION
## Summary

`ParseAWSEndpointHost` in `internal/credential/inject/awshost.go` derives the SigV4 signing scope host-authoritatively: it returns the endpoint host label verbatim as the signing service. That assumption (host label == signing service) holds for every service Aileron signs today (Athena: `athena.<region>` -> service `athena`), but a handful of AWS endpoints break it because the endpoint host label differs from the SigV4 service they must be signed as:

- Amazon SES: `email.<region>.amazonaws.com` is signed as service `ses` (host label is `email`).
- Amazon SimpleDB / other historical endpoints: host/service skew.

Per the operator decision on residual #1984 (keep the SigV4 service host-authoritative, consistent with the no-back-compat stance), this PR does **not** change signing behavior. It adds documentation and regression coverage only:

- Extends the `ParseAWSEndpointHost` doc comment to state the host-label==service assumption and name the deferred divergent-service work (SES `email`->`ses`, SimpleDB) as an explicit follow-up cliff.
- `TestParseAWSEndpointHostServiceIsHostLabel` pins the assumption for the live cases (Athena, s3).
- `TestParseAWSEndpointHostDivergentServiceDeferred` pins the *current* parse for the divergent-service hosts and records, via a `wantSigningService` field, that `email`->`ses` is the deferred cliff — so any future mapping change is forced to update the test deliberately.

## Test plan

- `go build ./internal/credential/inject/`
- `go vet ./internal/credential/inject/`
- `go test ./internal/credential/inject/` — all pass, including the two new tests.
- No production logic changed; signing behavior is unchanged.

Closes #1984

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for AWS endpoint host parsing to confirm region detection and host-label handling.
  * Added regression checks for known service/host mismatches to preserve current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->