### PR TITLE
fix(proxy): attribute identity-selected injections in audit; pin mixed-reach forfeiture

### DIFF
--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -685,10 +685,11 @@ func isSafeHTTPMethod(method string) bool {
 }
 
 // addHostBindingTrustIdentity stamps the optional, non-secret trust-contract
-// effect and audit-addressing identity triple onto a proxy audit payload
-// when the matched binding declares them. Empty fields are omitted. It
-// carries the declared effect and the plan/step/tool addressing only, never
-// a credential byte, the credential-ref, or an AllowedHosts value.
+// effect, audit-addressing identity triple, and manifest credential-identity
+// pair onto a proxy audit payload when the matched binding declares them.
+// Empty fields are omitted. It carries the declared effect, the plan/step/tool
+// addressing, and the (kind, label) credential identity only, never a
+// credential byte, the credential-ref, or an AllowedHosts value.
 func addHostBindingTrustIdentity(payload map[string]any, hb binding.HostBinding) {
 	if hb.Effect != "" {
 		payload["aileron.trust.effect"] = hb.Effect
@@ -701,6 +702,16 @@ func addHostBindingTrustIdentity(payload map[string]any, hb binding.HostBinding)
 	}
 	if hb.ToolName != "" {
 		payload["aileron.tool.name"] = hb.ToolName
+	}
+	// The manifest credential-identity pair (kind, label) is the selection
+	// key for an identity binding (#1978), which may declare an empty
+	// HostPattern. Without this field an identity-selected injection would
+	// audit with a blank binding.host and no operator-credential attribution.
+	// It is the non-secret (kind, label) pair only, never the credential
+	// bytes, the credential-ref, or an AllowedHosts value. Both fields are
+	// canonical: emitted only when both are set (see HostBinding.IdentityKind).
+	if hb.IdentityKind != "" && hb.IdentityLabel != "" {
+		payload["aileron.proxy.binding.identity"] = hb.IdentityKind + "/" + hb.IdentityLabel
 	}
 }
 

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -276,6 +276,16 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 	// match, never a passthrough of a bound-but-unavailable credential — so a
 	// scoped request can only ever egress with the exact credential its
 	// manifest identity names.
+	//
+	// Mixed-reach forfeiture: an identity-declaring step scope enters this
+	// path for EVERY in-reach host it targets and forfeits passthrough for its
+	// non-credential hosts. Once MatchIdentity succeeds the selected scheme is
+	// injected on whatever host the request targets; a host the scheme cannot
+	// serve (e.g. a non-AWS host under a sigv4-resign identity, whose SigV4
+	// scope is non-derivable) makes injectSandboxProxyHostBindingCredential
+	// return injected=false and fails closed at the injection point below. It
+	// is never passed through un-injected. A step that needs plain passthrough
+	// to some other in-reach host must not declare a credential identity.
 	if auth.StepScope != nil && auth.StepScope.CredentialKind != "" {
 		if auth.StepScope.IdentityLabel == "" {
 			// A present kind with an empty label is a malformed half-identity.

--- a/internal/app/sandbox_forward_proxy_identity_selection_test.go
+++ b/internal/app/sandbox_forward_proxy_identity_selection_test.go
@@ -332,6 +332,101 @@ func TestSandboxForwardProxy_TwoIdentitiesDisambiguate(t *testing.T) {
 	}
 }
 
+// TestSandboxForwardProxy_IdentityInjectedAuditCarriesIdentity pins the
+// success-path attribution fix: a host-less identity binding leaves
+// aileron.proxy.binding.host blank, so the binding_injected audit event must
+// carry aileron.proxy.binding.identity = "<kind>/<label>" for the injection to
+// be attributable to an operator credential. The field is the non-secret
+// (kind, label) pair, never the credential bytes or the credential-ref.
+func TestSandboxForwardProxy_IdentityInjectedAuditCarriesIdentity(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-attr" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		hostBindings:  binding.HostBindings{mustSigV4IdentityBinding(t, "user/aws", "metrics-reader", "AKIDEXAMPLE")},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	token := registerStepScope(srv, "session-123", "extract", []string{identityTargetHost}, "aws-sigv4", "metrics-reader")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + identityTargetHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q, want binding_injected", evt.EventType)
+	}
+	// The host-less identity binding leaves binding.host blank; the identity
+	// field is what makes the injection attributable.
+	if got := evt.Payload["aileron.proxy.binding.host"]; got != "" {
+		t.Errorf("binding.host = %v, want empty for a host-less identity binding", got)
+	}
+	if got := evt.Payload["aileron.proxy.binding.identity"]; got != "aws-sigv4/metrics-reader" {
+		t.Errorf("binding.identity = %v, want %q", got, "aws-sigv4/metrics-reader")
+	}
+}
+
+// TestSandboxForwardProxy_IdentityNonDerivableHostFailsClosed pins the
+// mixed-reach forfeiture: a step scope that declares a sigv4-resign identity
+// enters the identity path for EVERY in-reach host, so a request to a
+// non-derivable (non-AWS) host — whose SigV4 scope cannot be derived and whose
+// binding carries no Region/Service fallback — fails closed at injection
+// rather than passing through un-injected. injected=false, a protocol_rejected
+// audit event is emitted, and no upstream dial occurs.
+func TestSandboxForwardProxy_IdentityNonDerivableHostFailsClosed(t *testing.T) {
+	const nonDerivableHost = "metrics.example.com"
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-nonderivable" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte("wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")),
+		// A host-less sigv4 identity binding with no Region/Service fallback:
+		// its scope is derivable only from an AWS host.
+		hostBindings: binding.HostBindings{mustSigV4IdentityBinding(t, "user/aws", "metrics-reader", "AKIDEXAMPLE")},
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed when sigv4 injection fails closed; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	// The scope's reach includes the non-derivable host; the identity is
+	// matched by (kind, label), not by host, so selection succeeds and the
+	// request is driven to injection on a host the scheme cannot serve.
+	token := registerStepScope(srv, "session-123", "extract", []string{nonDerivableHost}, "aws-sigv4", "metrics-reader")
+	client := setupIdentityProxyServer(t, srv, "session-123", token)
+
+	resp, err := client.Get("https://" + nonDerivableHost + "/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Fatalf("status = %d, want a 4xx/5xx fail-closed", resp.StatusCode)
+	}
+	assertProxyReason(t, auditStore, model.EventTypeSandboxProxyRejected, hostBindingRejectUnsupportedScheme)
+}
+
 // TestSandboxForwardProxy_IdentityBindingTrustGateUnchanged proves the
 // per-step trust-contract gate runs identically on an identity-selected
 // binding: a `read`-effect binding still denies a mutating method at


### PR DESCRIPTION
## Summary

Resolves the two remaining actionable findings from cw-review-residual #1990 (sub-issue #1981), both scoped to the sandbox forward-proxy identity path (#1978).

**P1 — Success-path audit loses identity attribution.** `addHostBindingTrustIdentity` (`internal/app/handlers_connector_operations.go`) stamped the trust effect and the plan/step/tool triple but not the credential identity. A host-less identity binding leaves `aileron.proxy.binding.host` blank, so an identity-selected injection was audited with no operator-credential attribution. It now stamps a non-secret `aileron.proxy.binding.identity = "<kind>/<label>"` field when both `IdentityKind` and `IdentityLabel` are set. Because `binding_injected`, `trust_denied`, and `foreign_token_not_swapped` payloads all call this helper, the field lands on all three. The field carries the (kind, label) pair only, never the credential bytes, the credential-ref, or an AllowedHosts value.

**P2 — Mixed-reach step semantics were implied but never stated.** Added a comment in `routeSandboxForwardProxyHostBinding` (`internal/app/handlers_sandbox_forward_proxy.go`) stating that an identity-declaring step scope enters the identity path for EVERY in-reach host and forfeits passthrough for its non-credential hosts: once `MatchIdentity` succeeds, the selected scheme is injected on whatever host is targeted, and a host the scheme cannot serve (e.g. a non-AWS host under a `sigv4-resign` identity, whose SigV4 scope is non-derivable) fails closed at injection rather than passing through un-injected.

No change to host-field semantics or to the host path.

## Test plan

- `TestSandboxForwardProxy_IdentityInjectedAuditCarriesIdentity` (new): a host-less identity binding injects on the happy path; asserts the emitted `binding_injected` event has an empty `binding.host` and `binding.identity == "aws-sigv4/metrics-reader"`.
- `TestSandboxForwardProxy_IdentityNonDerivableHostFailsClosed` (new): a matched `sigv4-resign` identity binding whose request targets a non-derivable (non-AWS) host returns a 4xx fail-closed with a `protocol_rejected` audit event (`binding_unsupported_scheme`) and no upstream dial.
- `go test ./internal/app/` — full package green (existing identity, sentinel-swap, and trust-gate tests unchanged).
- `go build` + `go vet ./internal/app/` clean.

Closes #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
