### PR TITLE
fix(proxybinding): atomic descriptor write and zero-entry no-op

### DIFF
--- a/internal/proxybinding/writer.go
+++ b/internal/proxybinding/writer.go
@@ -36,10 +36,26 @@ import (
 // first Upsert into a fresh path creates a valid descriptor. The parent
 // directory is created 0700 if absent.
 //
+// A zero-entry Upsert is a no-op: it returns nil without reading, creating, or
+// rewriting the file, so an absent path stays absent and an existing file is
+// left byte-identical.
+//
+// The write itself is atomic: the merged document is written to a temp file in
+// the same directory and renamed over path, so a crash or concurrent writer
+// never leaves a truncated or partially-written descriptor.
+//
 // Upsert handles only [Entry] values, which carry a credential *reference*
 // (a vault path) and never credential bytes. It never resolves or logs secret
 // material, inheriting this package's secret-hygiene invariant.
 func Upsert(path string, entries ...Entry) error {
+	// A zero-entry Upsert is a no-op: with nothing to merge in, the only
+	// possible effect would be to create or rewrite the file for no reason,
+	// so return before touching the filesystem. This keeps an absent path
+	// absent and an existing file byte-identical.
+	if len(entries) == 0 {
+		return nil
+	}
+
 	existing, err := readExisting(path)
 	if err != nil {
 		return fmt.Errorf("proxybinding: read existing descriptor %q: %w", path, err)
@@ -60,12 +76,57 @@ func Upsert(path string, entries ...Entry) error {
 		return fmt.Errorf("proxybinding: merged descriptor is invalid: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("proxybinding: create descriptor dir: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := atomicWrite(path, data); err != nil {
 		return fmt.Errorf("proxybinding: write descriptor %q: %w", path, err)
 	}
+	return nil
+}
+
+// atomicWrite replaces path with data via a temp-file-plus-rename so a crash or
+// concurrent writer can never observe a truncated or partially-written
+// descriptor: readers see either the old file or the fully-written new one. The
+// temp file is created in the same directory as path (so the final rename is a
+// same-filesystem operation, which is atomic on POSIX) with 0600 permissions,
+// matching the descriptor's secret-adjacent sensitivity. On any error before
+// the rename the temp file is removed so a failed write leaves no litter.
+func atomicWrite(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".binding-descriptors-*.yaml.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	// From here on, ensure the temp file is cleaned up on any failure path.
+	// After a successful rename tmpName no longer exists, so the deferred
+	// Remove is a harmless no-op.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
 	return nil
 }
 

--- a/internal/proxybinding/writer_test.go
+++ b/internal/proxybinding/writer_test.go
@@ -323,3 +323,131 @@ func TestMergeEntries(t *testing.T) {
 		}
 	})
 }
+
+// Atomic write: a successful Upsert leaves the final descriptor content and
+// 0600 perms with no leftover temp files in the directory (the temp-file +
+// rename must land the exact bytes and clean up after itself).
+func TestUpsert_AtomicWriteContentAndPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binding-descriptors.yaml")
+	e := bearerEntry("api.example.com", "user/example")
+
+	if err := Upsert(path, e); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Final content re-parses to exactly the upserted entry.
+	d := parseFile(t, path)
+	if len(d.Bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1", len(d.Bindings))
+	}
+	if !reflect.DeepEqual(d.Bindings[0], e) {
+		t.Errorf("entry = %+v, want %+v", d.Bindings[0], e)
+	}
+
+	// Perms are 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %o, want 600", perm)
+	}
+
+	// No temp litter left behind: the descriptor is the only entry in the dir.
+	names, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(names) != 1 || names[0].Name() != "binding-descriptors.yaml" {
+		var got []string
+		for _, n := range names {
+			got = append(got, n.Name())
+		}
+		t.Errorf("directory contents = %v, want [binding-descriptors.yaml] (temp file not cleaned up)", got)
+	}
+}
+
+// Overwriting an existing descriptor atomically leaves the fully-written new
+// content and no temp litter (a rename over an existing file, not just a fresh
+// create).
+func TestUpsert_AtomicOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binding-descriptors.yaml")
+	if err := Upsert(path, bearerEntry("a.example.com", "user/a")); err != nil {
+		t.Fatalf("seed Upsert: %v", err)
+	}
+
+	if err := Upsert(path, bearerEntry("b.example.com", "user/b")); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	d := parseFile(t, path)
+	if len(d.Bindings) != 2 {
+		t.Fatalf("bindings = %d, want 2", len(d.Bindings))
+	}
+
+	names, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(names) != 1 || names[0].Name() != "binding-descriptors.yaml" {
+		var got []string
+		for _, n := range names {
+			got = append(got, n.Name())
+		}
+		t.Errorf("directory contents = %v, want [binding-descriptors.yaml]", got)
+	}
+}
+
+// Zero-entry Upsert is a no-op: it neither creates an absent file nor rewrites
+// an existing one.
+func TestUpsert_ZeroEntriesIsNoOp(t *testing.T) {
+	t.Run("absent file not created", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "binding-descriptors.yaml")
+
+		if err := Upsert(path); err != nil {
+			t.Fatalf("Upsert with zero entries: %v", err)
+		}
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file exists after zero-entry Upsert; want absent (stat err = %v)", err)
+		}
+		// The parent dir must also be untouched (no MkdirAll, no temp litter).
+		names, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("readdir: %v", err)
+		}
+		if len(names) != 0 {
+			var got []string
+			for _, n := range names {
+				got = append(got, n.Name())
+			}
+			t.Errorf("directory contents = %v, want empty", got)
+		}
+	})
+
+	t.Run("existing file byte-identical", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+		if err := Upsert(path, bearerEntry("api.example.com", "user/example")); err != nil {
+			t.Fatalf("seed Upsert: %v", err)
+		}
+		before, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+
+		if err := Upsert(path); err != nil {
+			t.Fatalf("Upsert with zero entries: %v", err)
+		}
+
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Errorf("file mutated on zero-entry Upsert:\nbefore=%q\nafter=%q", before, after)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two bounded fixes to `internal/proxybinding/writer.go` `Upsert`, both authorized verbatim by the cw-review-residual triage for #1999 (sub-issue #1996):

- **Non-atomic write could corrupt a valid user file on crash or concurrent writer.** `Upsert` wrote the merged descriptor in place with `os.WriteFile(path, data, 0o600)`, so a crash or a concurrent writer could observe a truncated or partially-written file. The write now goes through a new `atomicWrite` helper: create a temp file in the *same directory* (0600 perms), write, `fsync`, `Close`, then `os.Rename` over the target. Readers only ever see the old file or the fully-written new one. The temp file is removed on any pre-rename error, so a failed write leaves no litter.
- **Zero-entry `Upsert` behavior was unspecified.** A call with no entries now returns `nil` before touching the filesystem, so an absent path stays absent and an existing file is left byte-identical instead of being needlessly created or rewritten. The doc comment now states this contract.

The doc comment also documents the atomic-write guarantee.

## Test plan

- `go test ./internal/proxybinding/... -cover` — passes, coverage 91.7%.
- `go vet` and `gofmt -l` clean.
- New regression tests in `writer_test.go`:
  - `TestUpsert_AtomicWriteContentAndPerms` — final content re-parses to the upserted entry, perms are 0600, and no temp file is left behind.
  - `TestUpsert_AtomicOverwriteExisting` — rename-over-existing lands the new content with no temp litter.
  - `TestUpsert_ZeroEntriesIsNoOp` — (a) zero-entry Upsert against an absent path does not create the file (and leaves the dir empty), (b) against an existing valid file leaves it byte-identical.

Both listed findings are applied; no fixes skipped.

Closes #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
