### PR TITLE
fix(skill): hint freeze-then-bind on local install; cover real derive wiring

### DIFF
--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -111,6 +111,11 @@ func runSkillInstall(args []string, stdout, stderr io.Writer) int {
 	}
 
 	fmt.Fprintf(stdout, "Installed skill %q to %s\n", res.Name, res.Dir)
+	// A local/git install writes the pre-freeze SKILL.md, not a frozen version,
+	// so it carries no signed trust contract to derive credentials from and
+	// cannot be bound yet. Point the operator at freeze-then-bind, mirroring the
+	// bind pointer the OCI path prints for an already-frozen version.
+	fmt.Fprintf(stdout, "Run `aileron skill freeze %q` then `aileron skill bind %q` to onboard its credentials\n", res.Name, res.Name)
 	return 0
 }
 

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -768,3 +768,117 @@ func TestDescriptorSatisfiesTemplatedHostsOnly(t *testing.T) {
 		t.Error("a templated-only host-keyed requirement must not be satisfied")
 	}
 }
+
+// bindIntegrationFixtureMD is a schema-valid, environment-pinned SKILL.md with
+// two credential-bearing tool steps: one aws-sigv4 (host-less identity) and one
+// oauth2 (host-keyed). The real credreq deriver yields one RequiredBinding per
+// step, so the verb-level integration test can prove the declared identities
+// thread through resolveFrozenVersion -> DeriveFromFrozen to the onboarding
+// summary. A `kind: action-call` step (as the worked example uses) would carry
+// its trust contract on the action, not the step, and never reach the deriver.
+const bindIntegrationFixtureMD = `---
+name: bind-integration-fixture
+description: bind verb integration fixture.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  environment:
+    tools: [aws-cli@2.x]
+  inputs: []
+  outputs: []
+  steps:
+    - id: q1
+      kind: tool
+      command: [athena-query]
+      outputs: [rows]
+      trustContract:
+        credential: { kind: aws-sigv4, placement: signing, identityLabel: prod-reader }
+        hosts: ["athena.us-east-1.amazonaws.com"]
+        effect: read
+        idempotency: { safeToRetry: true }
+        audit: { fields: [result] }
+    - id: q2
+      kind: tool
+      command: [file-issue]
+      outputs: [issue]
+      trustContract:
+        credential: { kind: oauth2, placement: header, identityLabel: digest-bot }
+        oauth:
+          scopes: [issues:write]
+          endpoints:
+            authorization: https://auth.example.com/oauth/authorize
+            token: https://auth.example.com/oauth/token
+          refresh: refresh-token
+        hosts: ["tracker.example.com"]
+        effect: write
+        idempotency: { safeToRetry: false, idempotencyKey: true }
+        audit: { fields: [result] }
+---
+# bind integration fixture
+`
+
+// TestRunSkillBind_RealDeriveFromFrozen is the thin verb-level integration test
+// that exercises the genuine resolveFrozenVersion -> DeriveFromFrozen wiring on a
+// signed frozen fixture. Unlike every other bind test in this file, it does NOT
+// stub deriveRequirements: it freezes a two-credential fixture with a real
+// ed25519 signing key, then runs bind with the real deriver live and asserts the
+// declared identities thread through resolveFrozenVersion ->
+// credreq.DeriveFromFrozen -> deriveCredentialRef to their derived vault refs in
+// the onboarding summary.
+func TestRunSkillBind_RealDeriveFromFrozen(t *testing.T) {
+	storeDir := withTempStore(t)
+	dir := filepath.Join(storeDir, "bind-integration-fixture")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(bindIntegrationFixtureMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	var fout, ferr bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "bind-integration-fixture"}, &fout, &ferr); code != 0 {
+		t.Fatalf("freeze exit = %d, stderr=%s", code, ferr.String())
+	}
+
+	// Point the descriptor + vault seams at test doubles, but leave
+	// deriveRequirements (credreq.DeriveFromFrozen) live so the real deriver runs
+	// against the just-frozen, signature-verified plan.
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	origDesc := skillBindDescriptorPath
+	skillBindDescriptorPath = descPath
+	t.Cleanup(func() { skillBindDescriptorPath = origDesc })
+
+	vault := &fakeBindVault{}
+	origClient := newBindVaultClient
+	newBindVaultClient = func() bindVaultClient { return vault }
+	t.Cleanup(func() { newBindVaultClient = origClient })
+
+	secretCalls := withSecret(t, "supersecret")
+
+	// The only stdin consumer is the aws-sigv4 (host-less identity) requirement's
+	// AWS access key ID prompt; the oauth2 (host-keyed) requirement reads none.
+	var out, errb bytes.Buffer
+	code := runSkillBind([]string{"bind-integration-fixture"}, strings.NewReader("AKIAIOSFODNN7EXAMPLE\n"), &out, &errb)
+	if code != 0 {
+		t.Fatalf("bind exit = %d, stderr=%s", code, errb.String())
+	}
+
+	// Both declared identities collapse to their deterministic vault refs and are
+	// reported onboarded, proving the id flowed through the real frozen plan.
+	got := out.String()
+	for _, ref := range []string{
+		"onboarded: user/prod-reader",
+		"onboarded: user/digest-bot",
+	} {
+		if !strings.Contains(got, ref) {
+			t.Errorf("stdout missing %q; got:\n%s", ref, got)
+		}
+	}
+	if *secretCalls != 2 {
+		t.Errorf("secret prompted %d times, want 2 (one per distinct credential ref)", *secretCalls)
+	}
+	if vault.puts != 2 {
+		t.Errorf("vault puts = %d, want 2 (one per distinct credential ref)", vault.puts)
+	}
+}

--- a/cmd/aileron/skill_test.go
+++ b/cmd/aileron/skill_test.go
@@ -112,6 +112,13 @@ func TestRunSkillInstall_InstructionOnly_Clean(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Installed skill \"rubber-duck\"") {
 		t.Errorf("stdout = %q", stdout.String())
 	}
+	// A local install lands a pre-freeze SKILL.md that cannot be bound until it
+	// is frozen, so the operator must be pointed at freeze-then-bind rather than
+	// bind directly (the OCI path's pointer).
+	if !strings.Contains(stdout.String(), "aileron skill freeze \"rubber-duck\"") ||
+		!strings.Contains(stdout.String(), "aileron skill bind \"rubber-duck\"") {
+		t.Errorf("local install must print a freeze-then-bind hint, stdout = %q", stdout.String())
+	}
 	if _, err := os.Stat(filepath.Join(store, "rubber-duck", "SKILL.md")); err != nil {
 		t.Errorf("skill not written: %v", err)
 	}


### PR DESCRIPTION
## Summary

Resolves the two remaining actionable findings from cw-review-residual #2003 (sub-issue #1998).

1. **Local/git install now points at freeze-then-bind.** `runSkillInstall` (`cmd/aileron/skill.go`) previously printed only `Installed skill %q to %s` on the local/git path, while the OCI path prints a bind pointer. A local install lands a pre-freeze `SKILL.md` that carries no signed trust contract and cannot be bound until frozen, so it now prints ``Run `aileron skill freeze %q` then `aileron skill bind %q` to onboard its credentials``, mirroring the OCI pointer.

2. **Real derive wiring is now covered at the verb level.** Every existing bind test stubs `deriveRequirements`; none flowed a genuinely frozen plan through `credreq.DeriveFromFrozen`. Added `TestRunSkillBind_RealDeriveFromFrozen`, which freezes a two-credential (aws-sigv4 + oauth2) fixture with a real ed25519 signing key via `runSkillFreeze`, leaves `deriveRequirements` live, and asserts the declared identities thread through `resolveFrozenVersion -> DeriveFromFrozen -> deriveCredentialRef` to the onboarding summary.

## Test plan

- `go test ./cmd/aileron/` — green (includes the new integration test and the extended local-install assertion).
- `go vet ./cmd/aileron/` — clean.
- `gofmt -l` on changed files — clean.

The fixture uses `kind: tool` steps (not `action-call`) because only tool steps carry the trust contract the deriver reads; an `action-call` step attaches its contract to the action and never reaches `Derive`.

Both listed findings are implemented; no fixes skipped.

Closes #2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
