### PR TITLE
fix(keyring): trust private-repo publishers via authenticated API and --key-file

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -77,23 +78,43 @@ func runKeyring(args []string, stdout, stderr io.Writer) int {
 //     guidance to trust via a specific connector instead of guessing a
 //     profile-repo path.
 //
+// The `--key-file <path>` flag bypasses every network fetch: it reads the
+// publisher key from a local file and grants owner-level trust for the
+// named authority. This unblocks air-gapped hosts and private-repo
+// operators who already hold `publisher.pub` locally. The authority arg
+// is still required because it names the owner the grant covers.
+//
 // Writing an owner-level key the keyring already trusts is a no-op, so
 // re-running is safe.
 func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
-	if len(args) != 1 {
-		fmt.Fprintln(stderr, "usage: aileron keyring trust <authority>")
-		fmt.Fprintln(stderr, "  authority: github://owner            (trust the whole publisher, key resolved via the Hub)")
-		fmt.Fprintln(stderr, "             github://owner/connector  (trust the whole publisher, key from the connector repo)")
-		fmt.Fprintln(stderr, "  Trusting an owner covers every connector that publisher ships.")
+	flags := flag.NewFlagSet("keyring trust", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.Usage = func() { printTrustUsage(stderr) }
+	keyFile := flags.String("key-file", "", "Read the publisher key from a local file (no network fetch)")
+	if err := flags.Parse(args); err != nil {
 		return 1
 	}
-	authority := args[0]
+	rest := flags.Args()
+	if len(rest) != 1 {
+		printTrustUsage(stderr)
+		return 1
+	}
+	authority := rest[0]
 	if authority == "" {
 		fmt.Fprintln(stderr, "error: authority cannot be empty")
 		return 1
 	}
 
-	ownerAuthority, pub, err := resolveTrustKey(authority, stderr)
+	var (
+		ownerAuthority string
+		pub            ed25519.PublicKey
+		err            error
+	)
+	if *keyFile != "" {
+		ownerAuthority, pub, err = resolveTrustKeyFromFile(authority, *keyFile)
+	} else {
+		ownerAuthority, pub, err = resolveTrustKey(authority, stderr)
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -156,6 +177,58 @@ func resolveTrustKey(authority string, stderr io.Writer) (string, ed25519.Public
 		return "", nil, fmt.Errorf("fetch publisher key for %s: %w", fqn.Authority(), err)
 	}
 	return fqn.OwnerAuthority(), pub, nil
+}
+
+// printTrustUsage writes the `keyring trust` usage block. Shared by the
+// flag parser's error path and the arg-count guard so the two stay in
+// sync.
+func printTrustUsage(stderr io.Writer) {
+	fmt.Fprintln(stderr, "usage: aileron keyring trust [--key-file <path>] <authority>")
+	fmt.Fprintln(stderr, "  authority: github://owner            (trust the whole publisher, key resolved via the Hub)")
+	fmt.Fprintln(stderr, "             github://owner/connector  (trust the whole publisher, key from the connector repo)")
+	fmt.Fprintln(stderr, "  --key-file <path>  read the publisher key from a local file with no network fetch")
+	fmt.Fprintln(stderr, "                     (for private repos or air-gapped hosts); the authority is still required.")
+	fmt.Fprintln(stderr, "  Trusting an owner covers every connector that publisher ships.")
+	fmt.Fprintln(stderr, "  Set GH_TOKEN or GITHUB_TOKEN to fetch the key from a private repo over the GitHub API.")
+}
+
+// resolveTrustKeyFromFile grants trust from a local key file with no
+// network fetch. The authority still names the owner the grant covers:
+// a bare owner (`github://owner`) or a full per-repo FQN both collapse to
+// the owner-level authority so the single grant covers every connector
+// the publisher ships (ADR-0013). The file may be PEM or base64 raw, the
+// same shapes decodePublicKey accepts on the convention path.
+func resolveTrustKeyFromFile(authority, keyFile string) (string, ed25519.PublicKey, error) {
+	ownerAuthority, err := ownerAuthorityForGrant(authority)
+	if err != nil {
+		return "", nil, err
+	}
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("read key file %s: %w", keyFile, err)
+	}
+	pub, err := decodePublicKey(data)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse key file %s: %w", keyFile, err)
+	}
+	return ownerAuthority, pub, nil
+}
+
+// ownerAuthorityForGrant maps a `keyring trust` authority argument to the
+// owner-level authority the grant lands under, accepting both a bare
+// owner (`github://owner`, which ParseFQN rejects for want of a repo
+// segment) and a full per-repo FQN (`github://owner/repo`). Used by the
+// `--key-file` path, which never fetches and so cannot lean on
+// resolveTrustKey's Hub / per-repo network branches.
+func ownerAuthorityForGrant(authority string) (string, error) {
+	if isBareOwnerAuthority(authority) {
+		return strings.TrimRight(authority, "/"), nil
+	}
+	fqn, err := cstore.ParseFQN(authority)
+	if err != nil {
+		return "", fmt.Errorf("parse authority %s: %w", authority, err)
+	}
+	return fqn.OwnerAuthority(), nil
 }
 
 // isBareOwnerAuthority reports whether s is a `<scheme>://<owner>` with
@@ -237,8 +310,12 @@ func ownerMatchesEntry(owner string, e hubConnectorEntry) bool {
 // publisher commits at `keys/publisher.pub` on the default branch
 // (per ADR-0002). v1 supports `github://` authorities only.
 //
-// The HTTP call is anonymous — the convention path is on the public
-// internet by definition, so no token plumbing is needed here.
+// When a GitHub token is present (GH_TOKEN then GITHUB_TOKEN, matching
+// resolveLatestRef), the key is resolved through the GitHub Contents API,
+// which serves private-repo content that raw.githubusercontent.com hides
+// behind a 404 (raw does not accept bearer tokens). Without a token the
+// fetch stays anonymous against raw, so public-repo trust still works
+// unauthenticated.
 func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 	fqn, err := cstore.ParseFQN(authority)
 	if err != nil {
@@ -246,6 +323,10 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 	}
 	if fqn.Scheme != "github" {
 		return nil, fmt.Errorf("auto-fetch supports github:// authorities only (got %s://)", fqn.Scheme)
+	}
+
+	if tok := githubToken(); tok != "" {
+		return fetchPublisherKeyViaAPI(fqn, tok)
 	}
 
 	// `HEAD` resolves to the repo's default branch on raw.githubusercontent.com,
@@ -257,6 +338,61 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 		publisherKeyPath,
 	)
 	return fetchKeyFromURL(keyURL)
+}
+
+// githubToken returns the GitHub token from the environment, preferring
+// GH_TOKEN over GITHUB_TOKEN (the gh CLI's precedence). Empty string
+// means no token is set, in which case the fetch stays anonymous.
+func githubToken() string {
+	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+		return tok
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}
+
+// fetchPublisherKeyViaAPI resolves the publisher key through the GitHub
+// Contents API with a bearer token, so a private repo's
+// `keys/publisher.pub` is reachable. `Accept: application/vnd.github.raw`
+// makes the endpoint return the file's raw bytes (PEM or base64), which
+// decodePublicKey handles the same as the anonymous raw path. HEAD /
+// default-branch resolution is implicit (no `?ref=`), matching the raw
+// path's `HEAD`.
+func fetchPublisherKeyViaAPI(fqn cstore.FQN, token string) (ed25519.PublicKey, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/contents/%s",
+		strings.TrimRight(githubAPIBase, "/"),
+		url.PathEscape(fqn.Owner),
+		url.PathEscape(fqn.Repo),
+		publisherKeyPath,
+	)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.raw")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: publisherKeyFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch; check the token has read access to this repo)",
+			endpoint, resp.StatusCode, publisherKeyPath)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	pub, err := decodePublicKey(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", endpoint, err)
+	}
+	return pub, nil
 }
 
 // fetchKeyFromURL GETs an ed25519 public key from an absolute URL and
@@ -275,7 +411,7 @@ func fetchKeyFromURL(keyURL string) (ed25519.PublicKey, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch)",
+		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch; a private repo 404s here — set GH_TOKEN or GITHUB_TOKEN to fetch it over the GitHub API)",
 			keyURL, resp.StatusCode, publisherKeyPath)
 	}
 

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -73,6 +74,12 @@ func genTestKey(t *testing.T) (ed25519.PublicKey, []byte) {
 // filesystem and the test does not pollute the user's real ~/.aileron.
 func withTempHome(t *testing.T) string {
 	t.Helper()
+	// Neutralize any ambient GitHub token so the default (token-absent)
+	// keyring test path is the anonymous raw fetch. Tests that exercise the
+	// authenticated Contents API set GH_TOKEN/GITHUB_TOKEN explicitly after
+	// this, overriding the cleared value.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	return setTestHome(t)
 }
 
@@ -84,6 +91,13 @@ func withTempHome(t *testing.T) string {
 // rotation between two `keyring trust` calls).
 func withMockGitHubRaw(t *testing.T, paths map[string][]byte) func(path string, body []byte) {
 	t.Helper()
+
+	// The convention path is anonymous only when no token is set; clear
+	// any ambient token so a developer/CI environment with GH_TOKEN or
+	// GITHUB_TOKEN exported does not silently reroute the fetch to the
+	// (unmocked) Contents API base.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 
 	bodies := make(map[string][]byte, len(paths))
 	for k, v := range paths {
@@ -108,6 +122,36 @@ func withMockGitHubRaw(t *testing.T, paths map[string][]byte) func(path string, 
 	return func(path string, body []byte) {
 		bodies[path] = body
 	}
+}
+
+// withMockGitHubAPI stands up an httptest server that mimics the GitHub
+// Contents API (`/repos/{owner}/{repo}/contents/{path}`) and points the
+// CLI's githubAPIBase at it. The server serves body only when the request
+// carries an `Authorization: Bearer <token>` header (private content), and
+// 404s otherwise, so a test can prove the authenticated path is exercised.
+// It records whether it was ever hit for tests that assert no network call.
+func withMockGitHubAPI(t *testing.T, contentsPath string, body []byte) *bool {
+	t.Helper()
+	hit := new(bool)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*hit = true
+		if r.URL.Path != contentsPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "requires authentication", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = prev })
+	return hit
 }
 
 // --- decodePublicKey ---
@@ -313,6 +357,198 @@ func TestKeyringTrust_GarbageBody(t *testing.T) {
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	if rc := runKeyring([]string{"trust", "github://owner/repo"}, stdout, stderr); rc == 0 {
 		t.Fatal("expected non-zero exit for garbage body")
+	}
+}
+
+// TestKeyringTrust_PrivateRepoResolvesViaAuthenticatedAPI is the #2009
+// regression: raw.githubusercontent.com 404s on private content, but with
+// a token present the key resolves through the authenticated Contents API
+// and trust succeeds. Fails before the fix (anonymous raw only) because
+// raw returns 404.
+func TestKeyringTrust_PrivateRepoResolvesViaAuthenticatedAPI(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	// raw returns 404 for every path (mirrors a private repo hidden from
+	// anonymous raw).
+	withMockGitHubRaw(t, map[string][]byte{})
+	// The token flips the fetch onto the Contents API, which serves the key.
+	t.Setenv("GH_TOKEN", "gh-secret")
+	apiHit := withMockGitHubAPI(t, "/repos/acme/private-connector/contents/keys/publisher.pub", pemBytes)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "github://acme/private-connector"}, stdout, stderr)
+	if rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !*apiHit {
+		t.Error("authenticated Contents API was not called")
+	}
+	if !strings.Contains(stdout.String(), "Trusted publisher github://acme\n") {
+		t.Errorf("expected owner-level success message; got: %s", stdout.String())
+	}
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("owner-level key not pinned after authenticated fetch")
+	}
+}
+
+// TestKeyringTrust_GHTokenPreferredOverGitHubToken verifies GH_TOKEN wins
+// when both are set (gh CLI precedence), matching resolveLatestRef.
+func TestKeyringTrust_GHTokenPreferredOverGitHubToken(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{})
+	t.Setenv("GH_TOKEN", "gh-wins")
+	t.Setenv("GITHUB_TOKEN", "github-loses")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write(pemBytes)
+	}))
+	t.Cleanup(srv.Close)
+	prev := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = prev })
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://acme/repo"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if gotAuth != "Bearer gh-wins" {
+		t.Errorf("Authorization = %q, want Bearer gh-wins", gotAuth)
+	}
+}
+
+// TestKeyringTrust_PrivateRepoAPI404GivesGuidance verifies the
+// authenticated-path 404 (e.g. token lacks repo access) names the
+// convention path and hints at token access.
+func TestKeyringTrust_PrivateRepoAPI404GivesGuidance(t *testing.T) {
+	withTempHome(t)
+	withMockGitHubRaw(t, map[string][]byte{})
+	t.Setenv("GITHUB_TOKEN", "no-access")
+	withMockGitHubAPI(t, "/repos/acme/nope/contents/keys/publisher.pub", nil) // 404s: path mismatch below
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "github://acme/other"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit when the API path is absent")
+	}
+	if !strings.Contains(stderr.String(), "keys/publisher.pub") {
+		t.Errorf("expected error to name the convention path; got: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "read access") {
+		t.Errorf("expected token-access hint; got: %s", stderr.String())
+	}
+}
+
+// TestKeyringTrust_Anonymous404MentionsToken verifies the anonymous-path
+// 404 now points the operator at GH_TOKEN/GITHUB_TOKEN for private repos.
+func TestKeyringTrust_Anonymous404MentionsToken(t *testing.T) {
+	withTempHome(t)
+	withMockGitHubRaw(t, map[string][]byte{}) // 404 for every path, no token
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://acme/private"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit on 404")
+	}
+	if !strings.Contains(stderr.String(), "GH_TOKEN") || !strings.Contains(stderr.String(), "GITHUB_TOKEN") {
+		t.Errorf("expected 404 to mention GH_TOKEN/GITHUB_TOKEN; got: %s", stderr.String())
+	}
+}
+
+// TestKeyringTrust_KeyFileGrantsOwnerTrustNoNetwork covers acceptance item
+// 2: --key-file reads a local key and grants owner trust with no HTTP call.
+func TestKeyringTrust_KeyFileGrantsOwnerTrustNoNetwork(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	keyPath := filepath.Join(t.TempDir(), "publisher.pub")
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	// Point both bases at a server that fails the test if it is ever hit.
+	fail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected network call to %s", r.URL.Path)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(fail.Close)
+	prevRaw, prevAPI := rawGitHubBase, githubAPIBase
+	rawGitHubBase, githubAPIBase = fail.URL, fail.URL
+	t.Cleanup(func() { rawGitHubBase, githubAPIBase = prevRaw, prevAPI })
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "--key-file", keyPath, "github://acme/connector"}, stdout, stderr)
+	if rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Trusted publisher github://acme\n") {
+		t.Errorf("expected owner-level success message; got: %s", stdout.String())
+	}
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("owner-level key not pinned from --key-file")
+	}
+}
+
+// TestKeyringTrust_KeyFileBareOwner verifies --key-file also accepts a
+// bare owner authority (which ParseFQN rejects), granting owner trust.
+func TestKeyringTrust_KeyFileBareOwner(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	keyPath := filepath.Join(t.TempDir(), "publisher.pub")
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "--key-file", keyPath, "github://acme"}, stdout, stderr)
+	if rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("owner-level key not pinned from --key-file for bare owner")
+	}
+}
+
+// TestKeyringTrust_KeyFileMissingFileErrors verifies a bad --key-file path
+// fails cleanly with context.
+func TestKeyringTrust_KeyFileMissingFileErrors(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "--key-file", filepath.Join(t.TempDir(), "absent.pub"), "github://acme/repo"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit for missing key file")
+	}
+	if !strings.Contains(stderr.String(), "read key file") {
+		t.Errorf("expected read-file error context; got: %s", stderr.String())
+	}
+}
+
+// TestKeyringTrust_KeyFileGarbageErrors verifies a --key-file that is not a
+// valid key fails with decode context.
+func TestKeyringTrust_KeyFileGarbageErrors(t *testing.T) {
+	withTempHome(t)
+	keyPath := filepath.Join(t.TempDir(), "publisher.pub")
+	if err := os.WriteFile(keyPath, []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "--key-file", keyPath, "github://acme/repo"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit for garbage key file")
+	}
+	if !strings.Contains(stderr.String(), "parse key file") {
+		t.Errorf("expected parse-file error context; got: %s", stderr.String())
 	}
 }
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -95,7 +95,7 @@ The keyring is the v1 source of trust for connector signature verification. Ever
 
 | Command | Purpose |
 |---|---|
-| `aileron keyring trust <authority>` | Authorize a publisher's signing key at owner granularity, so the single grant covers every connector that publisher ships. The key is resolved automatically: `github://owner/connector` reads that repo's `keys/publisher.pub` on its default branch, and a bare `github://owner` resolves the key from the Hub catalog entry's `key_url`. Re-running is a safe no-op. |
+| `aileron keyring trust [--key-file <path>] <authority>` | Authorize a publisher's signing key at owner granularity, so the single grant covers every connector that publisher ships. The key is resolved automatically: `github://owner/connector` reads that repo's `keys/publisher.pub` on its default branch, and a bare `github://owner` resolves the key from the Hub catalog entry's `key_url`. Set `GH_TOKEN` or `GITHUB_TOKEN` to trust a publisher whose repo is private (the key is then fetched over the authenticated GitHub API rather than anonymous raw). Pass `--key-file <path>` to trust a locally-held `publisher.pub` with no network fetch, for air-gapped or private-repo operators. Re-running is a safe no-op. |
 | `aileron keyring list` | List trusted publishers and their key fingerprints. |
 | `aileron keyring revoke <authority>` | Remove a publisher's keys from the trust list. Pass `--key <fingerprint>` instead of an authority to revoke a single key by fingerprint. |
 


### PR DESCRIPTION
## Summary

`aileron keyring trust github://<owner>/<private-repo>` returned a 404 even with `GH_TOKEN`/`GITHUB_TOKEN` exported, because publisher-key resolution always fetched `keys/publisher.pub` via an **anonymous** GET to `raw.githubusercontent.com`, which hides private-repo content (raw does not accept bearer tokens).

Two fixes, matching the acceptance items on #2009:

1. **Authenticated fetch.** When a token is present (`GH_TOKEN` then `GITHUB_TOKEN`, mirroring `resolveLatestRef`), the key resolves through the GitHub Contents API: `GET <githubAPIBase>/repos/{owner}/{repo}/contents/keys/publisher.pub` with `Accept: application/vnd.github.raw`, `X-GitHub-Api-Version: 2022-11-28`, and `Authorization: Bearer <token>`. This serves private content. With **no** token, the anonymous `raw.githubusercontent.com` fetch is unchanged, so public-repo trust still works unauthenticated. The anonymous 404 message now points the operator at `GH_TOKEN`/`GITHUB_TOKEN`.

2. **Local-file fallback.** New `--key-file <path>` flag on `aileron keyring trust <authority>` reads the file, decodes it (PEM or base64 via the existing `decodePublicKey`), and grants owner-level trust with **no** network fetch, unblocking air-gapped and private-repo operators who hold `publisher.pub` locally. The authority arg is still required (it names the owner the grant covers).

CLI-only surface, no OpenAPI/spec change. Docs table in `docs/src/content/docs/cli/index.md` updated.

## Test plan

New regression tests in `cmd/aileron/keyring_test.go` (all fail before the fix, pass after):

- **Private repo:** raw returns 404 but the authenticated Contents API returns the key when `Authorization` is set → trust succeeds and pins the owner key. Also asserts the API is actually hit and honors `GH_TOKEN` over `GITHUB_TOKEN`.
- **`--key-file`:** grants owner trust with **no** HTTP call (a fail-if-hit server is wired to both bases); also covers bare-owner authority, a missing file, and a garbage file.
- **Public/no-token path unchanged:** existing anonymous raw tests still pass; the shared helper now neutralizes any ambient token so the token-absent path is exercised deterministically.
- Anonymous 404 message asserts it names `GH_TOKEN`/`GITHUB_TOKEN`; API 404 asserts it names the convention path + token access.

`go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and `go test ./cmd/aileron/` all green.

Closes #2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `keyring trust --key-file <path>` to trust a publisher using a local key file, avoiding network access.
  * Improved key resolution for GitHub-hosted publishers, including support for private repositories when a token is available.

* **Bug Fixes**
  * Added clearer error messages when publisher keys can’t be fetched, including guidance for private-repo access and token setup.

* **Documentation**
  * Updated CLI help docs to include the new `--key-file` option and GitHub token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->