### PR TITLE
fix(publish): resolve config digest from OCI image index (containerd store)

### DIFF
--- a/internal/flightplan/ociremote/configdigest.go
+++ b/internal/flightplan/ociremote/configdigest.go
@@ -1,0 +1,135 @@
+package ociremote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+)
+
+// Docker media type / annotation constants not exported by image-spec. A
+// containerd-backed `docker push` (Docker Desktop's default image store) emits
+// an OCI image index wrapping the single-platform image manifest plus a
+// buildkit attestation manifest; the attestation carries an
+// unknown/unknown platform and the docker reference-type annotation below.
+const (
+	// dockerManifestListMediaType is the schema2 manifest-list media type, the
+	// Docker equivalent of ocispec.MediaTypeImageIndex. Both wrap child manifests.
+	dockerManifestListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
+	// dockerReferenceTypeAnnotation marks the role of a child manifest inside a
+	// buildkit-produced index; attestation manifests carry the value below.
+	dockerReferenceTypeAnnotation = "vnd.docker.reference.type"
+	// dockerAttestationRefType is the dockerReferenceTypeAnnotation value that
+	// flags a buildkit attestation (SBOM/provenance) manifest, not a runnable image.
+	dockerAttestationRefType = "attestation-manifest"
+	// unknownPlatform is the placeholder os/arch buildkit stamps on an attestation
+	// manifest's platform so it is never selected for execution.
+	unknownPlatform = "unknown"
+)
+
+// ConfigDigest resolves the config-blob digest of the image at desc, the value a
+// composed-tools pin is bound to. It is store-agnostic: when desc is a classic
+// image manifest it reads config.digest directly; when desc is an OCI image
+// index (or a Docker manifest list), it unwraps the index to the single
+// platform image manifest and reads THAT manifest's config.digest.
+//
+// The containerd image store behind Docker Desktop makes `docker push` emit an
+// index wrapping the real single-platform image manifest plus a buildkit
+// attestation manifest, so both publish's post-push read-back and pull's
+// install/launch read-back must tolerate an index at the composed tag. The read
+// is store-agnostic (it covers the classic single-manifest store and the
+// containerd index store) rather than relying on push-side provenance flags.
+//
+// Selection inside an index skips attestation entries (platform os == "unknown"
+// or the docker attestation reference-type annotation). For the single-platform
+// composed image exactly one real manifest remains and is used; when several
+// real manifests exist the host runtime.GOOS/GOARCH match is chosen; when none
+// is usable an actionable error is returned rather than a silently-wrong digest.
+func ConfigDigest(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) (string, error) {
+	raw, err := content.FetchAll(ctx, fetcher, desc)
+	if err != nil {
+		return "", err
+	}
+	if isImageIndex(desc.MediaType) {
+		child, err := selectPlatformManifest(raw)
+		if err != nil {
+			return "", err
+		}
+		raw, err = content.FetchAll(ctx, fetcher, child)
+		if err != nil {
+			return "", fmt.Errorf("fetch platform image manifest %s: %w", child.Digest, err)
+		}
+	}
+	return configDigestFromManifest(raw)
+}
+
+// isImageIndex reports whether mediaType names a multi-manifest wrapper (an OCI
+// image index or a Docker manifest list) rather than a single image manifest.
+func isImageIndex(mediaType string) bool {
+	return mediaType == ocispec.MediaTypeImageIndex || mediaType == dockerManifestListMediaType
+}
+
+// configDigestFromManifest decodes raw as a single image manifest (OCI or the
+// wire-compatible docker schema2 manifest) and returns its config blob digest.
+func configDigestFromManifest(raw []byte) (string, error) {
+	var m ocispec.Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", fmt.Errorf("decode image manifest: %w", err)
+	}
+	if m.Config.Digest == "" {
+		return "", fmt.Errorf("image manifest has no config digest")
+	}
+	return m.Config.Digest.String(), nil
+}
+
+// selectPlatformManifest picks the runnable image manifest from an index's raw
+// bytes: it drops attestation/unknown-platform entries, then returns the sole
+// remaining manifest, or the host-platform match when several remain. It returns
+// an actionable error when no runnable manifest is present.
+func selectPlatformManifest(raw []byte) (ocispec.Descriptor, error) {
+	var idx ocispec.Index
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("decode image index: %w", err)
+	}
+	candidates := make([]ocispec.Descriptor, 0, len(idx.Manifests))
+	for _, m := range idx.Manifests {
+		if isAttestationManifest(m) {
+			continue
+		}
+		candidates = append(candidates, m)
+	}
+	switch len(candidates) {
+	case 0:
+		return ocispec.Descriptor{}, fmt.Errorf("image index has no runnable image manifest (found %d entr%s, all attestation or unknown-platform)", len(idx.Manifests), plural(len(idx.Manifests)))
+	case 1:
+		return candidates[0], nil
+	}
+	for _, m := range candidates {
+		if m.Platform != nil && m.Platform.OS == runtime.GOOS && m.Platform.Architecture == runtime.GOARCH {
+			return m, nil
+		}
+	}
+	return ocispec.Descriptor{}, fmt.Errorf("image index has %d image manifests but none match host platform %s/%s", len(candidates), runtime.GOOS, runtime.GOARCH)
+}
+
+// isAttestationManifest reports whether a child descriptor is a buildkit
+// attestation manifest rather than a runnable image: buildkit stamps it with an
+// unknown/unknown platform and the docker attestation reference-type annotation.
+func isAttestationManifest(m ocispec.Descriptor) bool {
+	if m.Platform != nil && m.Platform.OS == unknownPlatform {
+		return true
+	}
+	return m.Annotations[dockerReferenceTypeAnnotation] == dockerAttestationRefType
+}
+
+// plural returns "ies" for n != 1 and "y" for n == 1 so the count message reads
+// naturally ("1 entry" / "2 entries").
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/internal/flightplan/ociremote/configdigest_test.go
+++ b/internal/flightplan/ociremote/configdigest_test.go
@@ -1,0 +1,261 @@
+package ociremote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// pushBytes pushes data under mediaType and returns its descriptor.
+func pushBytes(t *testing.T, st content.Storage, mediaType string, data []byte) ocispec.Descriptor {
+	t.Helper()
+	desc := content.NewDescriptorFromBytes(mediaType, data)
+	if err := st.Push(context.Background(), desc, bytes.NewReader(data)); err != nil {
+		t.Fatalf("push %s: %v", mediaType, err)
+	}
+	return desc
+}
+
+// seedManifest pushes a minimal single-config image manifest and returns its
+// descriptor plus its config descriptor.
+func seedManifest(t *testing.T, st content.Storage, configBody string) (manifest, config ocispec.Descriptor) {
+	t.Helper()
+	cfg := pushBytes(t, st, ocispec.MediaTypeImageConfig, []byte(configBody))
+	layer := pushBytes(t, st, ocispec.MediaTypeImageLayerGzip, []byte("layer-"+configBody))
+	m := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    cfg,
+		Layers:    []ocispec.Descriptor{layer},
+	}
+	mb, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	md := pushBytes(t, st, ocispec.MediaTypeImageManifest, mb)
+	return md, cfg
+}
+
+// pushIndex pushes an OCI image index (mediaType selectable) wrapping the given
+// child descriptors and returns the index descriptor.
+func pushIndex(t *testing.T, st content.Storage, mediaType string, children ...ocispec.Descriptor) ocispec.Descriptor {
+	t.Helper()
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: mediaType,
+		Manifests: children,
+	}
+	ib, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	return pushBytes(t, st, mediaType, ib)
+}
+
+// attestationManifest builds a child descriptor that mimics a buildkit
+// attestation entry: unknown/unknown platform + docker attestation annotation.
+func attestationManifest(t *testing.T, st content.Storage) ocispec.Descriptor {
+	t.Helper()
+	// The attestation manifest content is irrelevant to selection; seed a body so
+	// a store fetch would succeed if (incorrectly) selected.
+	md, _ := seedManifest(t, st, "attestation-body")
+	md.Platform = &ocispec.Platform{OS: "unknown", Architecture: "unknown"}
+	md.Annotations = map[string]string{dockerReferenceTypeAnnotation: dockerAttestationRefType}
+	return md
+}
+
+func TestConfigDigest_ClassicSingleManifest(t *testing.T) {
+	st := memory.New()
+	manifest, cfg := seedManifest(t, st, "classic-config")
+	got, err := ConfigDigest(context.Background(), st, manifest)
+	if err != nil {
+		t.Fatalf("ConfigDigest: %v", err)
+	}
+	if got != cfg.Digest.String() {
+		t.Errorf("config digest = %q, want %q", got, cfg.Digest)
+	}
+}
+
+func TestConfigDigest_OCIIndexUnwrapsToImageManifest(t *testing.T) {
+	// The containerd store behind Docker Desktop emits an OCI index wrapping the
+	// single-platform image manifest plus a buildkit attestation. The config
+	// digest must resolve to the image manifest's config, not error out.
+	st := memory.New()
+	image, cfg := seedManifest(t, st, "composed-config")
+	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	att := attestationManifest(t, st)
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, image, att)
+
+	got, err := ConfigDigest(context.Background(), st, idx)
+	if err != nil {
+		t.Fatalf("ConfigDigest over index: %v", err)
+	}
+	if got != cfg.Digest.String() {
+		t.Errorf("config digest = %q, want the wrapped image manifest's config %q", got, cfg.Digest)
+	}
+}
+
+func TestConfigDigest_DockerManifestListUnwraps(t *testing.T) {
+	// The Docker schema2 manifest-list media type must be treated as an index too.
+	st := memory.New()
+	image, cfg := seedManifest(t, st, "docker-list-config")
+	att := attestationManifest(t, st)
+	idx := pushIndex(t, st, dockerManifestListMediaType, image, att)
+
+	got, err := ConfigDigest(context.Background(), st, idx)
+	if err != nil {
+		t.Fatalf("ConfigDigest over docker manifest list: %v", err)
+	}
+	if got != cfg.Digest.String() {
+		t.Errorf("config digest = %q, want %q", got, cfg.Digest)
+	}
+}
+
+func TestConfigDigest_IndexWithOnlyAttestationErrors(t *testing.T) {
+	// An index carrying no runnable image manifest cannot yield a config digest;
+	// the helper must fail closed with an actionable message.
+	st := memory.New()
+	att := attestationManifest(t, st)
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, att)
+
+	_, err := ConfigDigest(context.Background(), st, idx)
+	if err == nil {
+		t.Fatal("want an error for an index with no runnable image manifest")
+	}
+	if !strings.Contains(err.Error(), "runnable image manifest") {
+		t.Errorf("err = %v, want an actionable no-runnable-manifest message", err)
+	}
+}
+
+func TestConfigDigest_MultiPlatformMatchesHost(t *testing.T) {
+	st := memory.New()
+	// A foreign-platform manifest plus the host-platform manifest; the host one wins.
+	foreign, _ := seedManifest(t, st, "foreign-arch-config")
+	foreign.Platform = &ocispec.Platform{OS: "plan9", Architecture: "mips"}
+	host, hostCfg := seedManifest(t, st, "host-arch-config")
+	host.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, foreign, host)
+
+	got, err := ConfigDigest(context.Background(), st, idx)
+	if err != nil {
+		t.Fatalf("ConfigDigest: %v", err)
+	}
+	if got != hostCfg.Digest.String() {
+		t.Errorf("config digest = %q, want the host-platform config %q", got, hostCfg.Digest)
+	}
+}
+
+func TestConfigDigest_MultiPlatformNoHostMatchErrors(t *testing.T) {
+	st := memory.New()
+	a, _ := seedManifest(t, st, "arch-a")
+	a.Platform = &ocispec.Platform{OS: "plan9", Architecture: "mips"}
+	b, _ := seedManifest(t, st, "arch-b")
+	b.Platform = &ocispec.Platform{OS: "solaris", Architecture: "sparc64"}
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, a, b)
+
+	_, err := ConfigDigest(context.Background(), st, idx)
+	if err == nil {
+		t.Fatal("want an error when no manifest matches the host platform")
+	}
+	if !strings.Contains(err.Error(), "host platform") {
+		t.Errorf("err = %v, want a host-platform mismatch message", err)
+	}
+}
+
+func TestConfigDigest_ManifestWithoutConfigErrors(t *testing.T) {
+	st := memory.New()
+	m := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		// Config left zero.
+	}
+	mb, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	md := pushBytes(t, st, ocispec.MediaTypeImageManifest, mb)
+	if _, err := ConfigDigest(context.Background(), st, md); err == nil || !strings.Contains(err.Error(), "no config digest") {
+		t.Fatalf("err = %v, want a no-config-digest error", err)
+	}
+}
+
+// fetchFailStore fails every Fetch, standing in for a store that serves a
+// descriptor it cannot back with content.
+type fetchFailStore struct {
+	*memory.Store
+	err error
+}
+
+func (f fetchFailStore) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
+	return nil, f.err
+}
+
+func TestConfigDigest_FetchErrorPropagates(t *testing.T) {
+	boom := errors.New("connection reset")
+	st := fetchFailStore{Store: memory.New(), err: boom}
+	desc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, []byte("{}"))
+	if _, err := ConfigDigest(context.Background(), st, desc); !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the underlying fetch error", err)
+	}
+}
+
+// indexFetchFailStore serves the index bytes but fails to fetch the wrapped
+// child manifest, standing in for a partial/corrupt index push.
+type indexFetchFailStore struct {
+	*memory.Store
+	failDigest string
+	err        error
+}
+
+func (s indexFetchFailStore) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	if desc.Digest.String() == s.failDigest {
+		return nil, s.err
+	}
+	return s.Store.Fetch(ctx, desc)
+}
+
+func TestConfigDigest_IndexChildFetchErrorPropagates(t *testing.T) {
+	inner := memory.New()
+	image, _ := seedManifest(t, inner, "child-config")
+	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	idx := pushIndex(t, inner, ocispec.MediaTypeImageIndex, image)
+	boom := errors.New("child manifest read reset")
+	st := indexFetchFailStore{Store: inner, failDigest: image.Digest.String(), err: boom}
+
+	_, err := ConfigDigest(context.Background(), st, idx)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the child fetch error", err)
+	}
+	if !strings.Contains(err.Error(), "platform image manifest") {
+		t.Errorf("err = %v, want a platform-image-manifest fetch message", err)
+	}
+}
+
+// rawFetcher returns fixed bytes for any descriptor, letting a test drive
+// ConfigDigest with content a validating store (memory.Store parses index JSON
+// on Push) would reject.
+type rawFetcher struct{ data []byte }
+
+func (r rawFetcher) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(r.data)), nil
+}
+
+func TestConfigDigest_CorruptIndexErrors(t *testing.T) {
+	bad := []byte("not json")
+	// Describe the bytes as an index so ConfigDigest takes the unwrap path, then
+	// serve them raw; content.FetchAll verifies the digest, and the decode fails.
+	desc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageIndex, bad)
+	if _, err := ConfigDigest(context.Background(), rawFetcher{bad}, desc); err == nil || !strings.Contains(err.Error(), "decode image index") {
+		t.Fatalf("err = %v, want a decode-image-index error", err)
+	}
+}

--- a/internal/flightplan/publish/publish.go
+++ b/internal/flightplan/publish/publish.go
@@ -30,12 +30,12 @@ package publish
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -241,7 +241,11 @@ func publishComposed(ctx context.Context, opts Options, pin freeze.ImagePin, tar
 	}
 	// Defense in depth: the pushed manifest's config digest must still equal
 	// the signed lock (a registry must not have altered the config on push).
-	pushedConfig, err := imageConfigDigest(ctx, target, desc)
+	// ociremote.ConfigDigest unwraps an OCI image index (the containerd image
+	// store behind Docker Desktop makes `docker push` emit one wrapping the
+	// single-platform image manifest plus a buildkit attestation) so the read
+	// back succeeds on both the classic and containerd stores.
+	pushedConfig, err := ociremote.ConfigDigest(ctx, target, desc)
 	if err != nil {
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: read pushed image config: %w", err)
 	}
@@ -282,23 +286,6 @@ func publishForeignBase(ctx context.Context, opts Options, pin freeze.ImagePin, 
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: copied manifest digest %s != lock attested %s", root.Digest, pin.Digest)
 	}
 	return root, freeze.BindingManifestDigest, nil
-}
-
-// imageConfigDigest fetches an image manifest and returns its config blob
-// digest (the composed pin's attested identity).
-func imageConfigDigest(ctx context.Context, fetcher content.Fetcher, manifest ocispec.Descriptor) (string, error) {
-	raw, err := content.FetchAll(ctx, fetcher, manifest)
-	if err != nil {
-		return "", err
-	}
-	var m ocispec.Manifest
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return "", fmt.Errorf("decode image manifest: %w", err)
-	}
-	if m.Config.Digest == "" {
-		return "", fmt.Errorf("image manifest has no config digest")
-	}
-	return m.Config.Digest.String(), nil
 }
 
 // pushBlob pushes data under mediaType, treating an already-present blob as

--- a/internal/flightplan/publish/publish_test.go
+++ b/internal/flightplan/publish/publish_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -118,6 +119,66 @@ func TestRunComposedConfigDigestBinding(t *testing.T) {
 		t.Errorf("image digest = %q, want %q", res.ImageDigest, manifest.Digest)
 	}
 	assertReferrerAttached(t, target, res, manifest.Digest.String(), freeze.BindingConfigDigest)
+}
+
+// seedComposedIndexTarget seeds target with the composed image published as an
+// OCI image index (the shape `docker push` emits on Docker Desktop's containerd
+// image store): the single-platform image manifest plus a buildkit attestation
+// manifest, tagged where publishComposed resolves it. It returns the index and
+// config descriptors. The config-digest read-back must unwrap the index.
+func seedComposedIndexTarget(t *testing.T, target *memory.Store, versionID, configBody string) (index, config ocispec.Descriptor) {
+	t.Helper()
+	ctx := context.Background()
+	image, cfg := seedImage(t, target, configBody)
+	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+
+	// A buildkit attestation entry: unknown/unknown platform + attestation type.
+	// Selection skips it, so its blobs are never fetched and need not be pushed.
+	attManifest := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, []byte("attestation-"+configBody))
+	attManifest.Platform = &ocispec.Platform{OS: "unknown", Architecture: "unknown"}
+	attManifest.Annotations = map[string]string{"vnd.docker.reference.type": "attestation-manifest"}
+
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{image, attManifest},
+	}
+	ib, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	id := content.NewDescriptorFromBytes(ocispec.MediaTypeImageIndex, ib)
+	mustPush(t, target, id, ib)
+	if err := target.Tag(ctx, id, freeze.ComposedImageTag(versionID)); err != nil {
+		t.Fatalf("tag composed index: %v", err)
+	}
+	return id, cfg
+}
+
+// TestRunComposedConfigDigestBindingOverOCIIndex is the #2012 regression: the
+// containerd image store makes the pushed composed ref an OCI index wrapping the
+// image manifest plus a buildkit attestation. Publish's post-push config-digest
+// read-back must unwrap the index and verify against the signed lock rather than
+// hard-erroring "image manifest has no config digest".
+func TestRunComposedConfigDigestBindingOverOCIIndex(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	index, cfg := seedComposedIndexTarget(t, target, "v1", "composed-config")
+
+	res, err := Run(ctx, composedOptions(target, cfg))
+	if err != nil {
+		t.Fatalf("Run over an OCI-index composed image: %v", err)
+	}
+	if res.BindingKind != freeze.BindingConfigDigest {
+		t.Errorf("binding = %q, want %q", res.BindingKind, freeze.BindingConfigDigest)
+	}
+	// The subject/image digest is the resolved INDEX digest (what Docker/containerd
+	// boot correctly); the config-digest binding was verified from the unwrapped
+	// image manifest.
+	if res.ImageDigest != index.Digest.String() {
+		t.Errorf("image digest = %q, want the resolved index digest %q", res.ImageDigest, index.Digest)
+	}
+	assertReferrerAttached(t, target, res, index.Digest.String(), freeze.BindingConfigDigest)
 }
 
 func TestRunComposedConfigDigestMismatchFailsClosed(t *testing.T) {

--- a/internal/flightplan/pull/image.go
+++ b/internal/flightplan/pull/image.go
@@ -2,16 +2,13 @@ package pull
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
 	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
 
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	oras "oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 )
 
@@ -113,8 +110,13 @@ func PullImage(ctx context.Context, opts ImagePullOptions) (ImagePullResult, err
 }
 
 // pullComposedImage resolves the composed image by its published tag, reads its
-// manifest's config digest (mirroring publish's imageConfigDigest read
-// semantics), and requires it to equal the signed lock pin. The bootable
+// config digest through the shared ociremote.ConfigDigest helper (the same
+// index-aware read publish uses post-push, so the read and write halves compute
+// the same value), and requires it to equal the signed lock pin. When the
+// published ref is an OCI image index (the containerd store behind Docker
+// Desktop), the helper unwraps it to the platform image manifest before reading
+// config; BootRef stays anchored to the resolved (index) manifest digest, which
+// the runner/daemon boot correctly. The bootable
 // reference is content-addressed to the resolved MANIFEST digest
 // ("<registry>@<manifest-digest>"), not the mutable tag: the config-digest check
 // proved this exact manifest carries the attested config, so anchoring the boot
@@ -135,7 +137,7 @@ func pullComposedImage(ctx context.Context, src oras.ReadOnlyTarget, opts ImageP
 		return ImagePullResult{}, fmt.Errorf("%w: composed image %q resolved to an empty manifest digest", ErrImagePullFailed, imageTag)
 	}
 
-	config, err := imageConfigDigest(ctx, src, desc)
+	config, err := ociremote.ConfigDigest(ctx, src, desc)
 	if err != nil {
 		return ImagePullResult{}, fmt.Errorf("%w: read composed image config: %w", ErrImagePullFailed, err)
 	}
@@ -177,22 +179,4 @@ func pullManifestDigestImage(ctx context.Context, src oras.ReadOnlyTarget, opts 
 		BindingKind: freeze.BindingManifestDigest,
 		ImageDigest: opts.Pin.Digest,
 	}, nil
-}
-
-// imageConfigDigest fetches an image manifest and returns its config blob digest
-// (a composed pin's attested identity). It mirrors publish's imageConfigDigest so
-// the read and write halves compute the same value.
-func imageConfigDigest(ctx context.Context, fetcher content.Fetcher, manifest ocispec.Descriptor) (string, error) {
-	raw, err := content.FetchAll(ctx, fetcher, manifest)
-	if err != nil {
-		return "", err
-	}
-	var m ocispec.Manifest
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return "", fmt.Errorf("decode image manifest: %w", err)
-	}
-	if m.Config.Digest == "" {
-		return "", fmt.Errorf("image manifest has no config digest")
-	}
-	return m.Config.Digest.String(), nil
 }

--- a/internal/flightplan/pull/image_test.go
+++ b/internal/flightplan/pull/image_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -77,6 +78,114 @@ func seedComposed(t *testing.T, st *memory.Store, versionTag, configBody string)
 		LocalTag: "aileron/sandbox-tools:abc123",
 	}
 	return pin, manifest
+}
+
+// seedComposedIndex publishes the composed image as an OCI image index (the
+// shape Docker Desktop's containerd store emits): the single-platform image
+// manifest plus a buildkit attestation manifest, tagged where PullImage's
+// composed branch resolves it. It returns the composed pin and the index
+// descriptor (the value BootRef must anchor to).
+func seedComposedIndex(t *testing.T, st *memory.Store, versionTag, configBody string) (freeze.ImagePin, ocispec.Descriptor) {
+	t.Helper()
+	ctx := context.Background()
+	image, cfg := seedImage(t, st, configBody)
+	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+
+	// Selection skips the attestation, so its blobs are never fetched; craft the
+	// descriptor without pushing (the shared layer would collide on a second push).
+	att := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, []byte("attestation-"+configBody))
+	att.Platform = &ocispec.Platform{OS: "unknown", Architecture: "unknown"}
+	att.Annotations = map[string]string{"vnd.docker.reference.type": "attestation-manifest"}
+
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{image, att},
+	}
+	ib, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	id := content.NewDescriptorFromBytes(ocispec.MediaTypeImageIndex, ib)
+	if err := st.Push(ctx, id, bytes.NewReader(ib)); err != nil {
+		t.Fatalf("push index: %v", err)
+	}
+	if err := st.Tag(ctx, id, freeze.ComposedImageTag(versionTag)); err != nil {
+		t.Fatalf("tag composed index: %v", err)
+	}
+	pin := freeze.ImagePin{
+		Ref:      "aileron/sandbox-tools+tools(gh)",
+		Digest:   cfg.Digest.String(),
+		LocalTag: "aileron/sandbox-tools:abc123",
+	}
+	return pin, id
+}
+
+// TestPullImage_ComposedOverOCIIndex is the consumer half of the #2012
+// regression: `skill install`+launch resolves the same published composed tag,
+// which is an OCI index on a containerd store. The config-digest read-back must
+// unwrap the index and verify, and BootRef must anchor to the resolved index
+// digest (what Docker/containerd boot correctly).
+func TestPullImage_ComposedOverOCIIndex(t *testing.T) {
+	st := memory.New()
+	pin, index := seedComposedIndex(t, st, "v1abc", "composed-config-bytes")
+
+	got, err := PullImage(context.Background(), ImagePullOptions{
+		Source:     st,
+		Registry:   testRegistry,
+		VersionTag: "v1abc",
+		Pin:        pin,
+	})
+	if err != nil {
+		t.Fatalf("PullImage over an OCI-index composed image: %v", err)
+	}
+	if got.BindingKind != freeze.BindingConfigDigest {
+		t.Errorf("binding = %q, want %q", got.BindingKind, freeze.BindingConfigDigest)
+	}
+	wantRef := testRegistry + "@" + index.Digest.String()
+	if got.BootRef != wantRef {
+		t.Errorf("boot ref = %q, want the content-addressed index ref %q", got.BootRef, wantRef)
+	}
+	if got.ImageDigest != pin.Digest {
+		t.Errorf("image digest = %q, want the config digest %q", got.ImageDigest, pin.Digest)
+	}
+}
+
+// TestPullImage_ComposedIndexNoRunnableManifestFailsClosed proves an index with
+// no runnable image manifest (only an attestation) fails closed with an
+// actionable message rather than booting an unverifiable image.
+func TestPullImage_ComposedIndexNoRunnableManifestFailsClosed(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	att := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, []byte("attestation-only"))
+	att.Platform = &ocispec.Platform{OS: "unknown", Architecture: "unknown"}
+	att.Annotations = map[string]string{"vnd.docker.reference.type": "attestation-manifest"}
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{att},
+	}
+	ib, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	id := content.NewDescriptorFromBytes(ocispec.MediaTypeImageIndex, ib)
+	if err := st.Push(ctx, id, bytes.NewReader(ib)); err != nil {
+		t.Fatalf("push index: %v", err)
+	}
+	if err := st.Tag(ctx, id, freeze.ComposedImageTag("v1abc")); err != nil {
+		t.Fatalf("tag: %v", err)
+	}
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:" + strings.Repeat("a", 64), LocalTag: "t"}
+	_, err = PullImage(ctx, ImagePullOptions{
+		Source: st, Registry: testRegistry, VersionTag: "v1abc", Pin: pin,
+	})
+	if !errors.Is(err, ErrImagePullFailed) {
+		t.Fatalf("err = %v, want ErrImagePullFailed", err)
+	}
+	if !strings.Contains(err.Error(), "runnable image manifest") {
+		t.Errorf("err = %v, want an actionable no-runnable-manifest message", err)
+	}
 }
 
 func TestPullImage_ComposedMatchReturnsBootableRef(t *testing.T) {


### PR DESCRIPTION
## Summary

`skill publish`'s "read pushed image config" step and `skill install`+launch's read-back both `json.Unmarshal`ed the resolved descriptor as an `ocispec.Manifest` and hard-errored **"image manifest has no config digest"** whenever the pushed manifest is an OCI **index**.

On Docker Desktop's containerd image store, `docker push` emits `application/vnd.oci.image.index.v1+json` wrapping the single-platform image manifest **plus** a buildkit attestation manifest. So the config-digest read-back failed *after* the slow push already succeeded, and because the published ref in the registry is an index, `aileron skill install`+launch was broken on the consumer machine too. Both halves had to change together.

### Fix

- New shared **`ociremote.ConfigDigest`** helper (index-aware) replaces the duplicated `imageConfigDigest` in both `publish` and `pull`, honoring the existing "read and write halves compute the same value" intent and the prefer-shared-abstractions convention.
- When the resolved descriptor is an OCI image index (or a Docker manifest list `application/vnd.docker.distribution.manifest.list.v2+json`), it fetches the index, selects the platform-matching **non-attestation** image manifest — skipping entries with `platform.os == "unknown"` or the `vnd.docker.reference.type == attestation-manifest` annotation — and reads THAT manifest's `config.digest`.
- Single composed image → exactly one runnable manifest. Several real manifests → match host `runtime.GOOS/GOARCH`. None usable → actionable error.
- The classic single-schema2 path (descriptor already an image manifest) is unchanged, so both the classic and containerd stores work.
- `BootRef` keeps using the resolved (index) digest, which Docker/containerd boot correctly.

The read-back approach is store-agnostic and covers both classic and containerd stores, preferred over push-side `--provenance=false` pinning. Internal package only — no spec/OpenAPI change.

## Test plan

- `internal/flightplan/ociremote/configdigest_test.go` (new): classic single manifest resolves; OCI index and Docker manifest list unwrap to the image manifest's config; attestation-only index errors actionably; multi-platform matches host / errors when no host match; config-less manifest errors; fetch-error and corrupt-index propagation. 92.9% package coverage.
- `publish_test.go`: `TestRunComposedConfigDigestBindingOverOCIIndex` — the composed image published as an OCI index (image + attestation) now verifies and attaches the referrer; would fail before the fix ("no config digest").
- `pull/image_test.go`: `TestPullImage_ComposedOverOCIIndex` — install/launch read-back over the same index verifies and boots by the resolved index digest; `TestPullImage_ComposedIndexNoRunnableManifestFailsClosed` — attestation-only index fails closed.
- `go test ./internal/flightplan/...` all green; `go vet` clean; `gofmt` clean.

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of composed image references that resolve to OCI image indexes or Docker manifest lists.
  * Added support for selecting the correct runnable image when multiple platform entries are present.

* **Bug Fixes**
  * Config digest resolution now works with images that include attestation-only entries.
  * Pulling and publishing composed images now fail clearly when no runnable image manifest is available.
  * Added broader error handling for missing config data, corrupt indexes, and fetch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->