### PR TITLE
fix(skill): warn on sigv4 secret reuse to catch access-key rotation mismatch (#2017)

### DIFF
--- a/cmd/aileron/skill_bind.go
+++ b/cmd/aileron/skill_bind.go
@@ -316,9 +316,11 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 // caller against a live view of the vault and descriptors, so a
 // partially-onboarded requirement fills only its missing half and a secret
 // shared by two requirements is prompted once. It returns the descriptor entries
-// the caller batches into a single Upsert, any advisories (for templated hosts),
-// and whether it stored a secret (so the caller keeps its live vault view in
-// sync and reports an accurate summary).
+// the caller batches into a single Upsert, any advisories (a templated host that
+// cannot be onboarded automatically, or a sigv4 access key ID written while an
+// existing secret is reused so a rotation mismatch is caught at bind time), and
+// whether it stored a secret (so the caller keeps its live vault view in sync and
+// reports an accurate summary).
 func fillRequirement(req credreq.RequiredBinding, needSecret, needDescriptor bool, client bindVaultClient, stdin *bufio.Reader, stdout, stderr io.Writer) ([]proxybinding.Entry, []string, bool, error) {
 	storedSecret := false
 	if needSecret {
@@ -358,7 +360,21 @@ func fillRequirement(req credreq.RequiredBinding, needSecret, needDescriptor boo
 		for _, w := range entry.Warnings() {
 			fmt.Fprintf(stderr, "warning: %s\n", w)
 		}
-		return []proxybinding.Entry{entry}, nil, storedSecret, nil
+		// For an aws-sigv4 credential the access key ID and the secret are a
+		// matched pair. When bind writes an access key ID while reusing a secret
+		// it did not just capture (!needSecret), the operator may have rotated
+		// the key (new ID + new secret) but only re-entered the new ID, leaving
+		// the stale old secret in the vault. That mismatch surfaces far away as an
+		// opaque SignatureDoesNotMatch at launch, so warn at bind time to update
+		// the secret if this key was rotated. The access key ID is the non-secret
+		// half and is safe to echo.
+		var advisories []string
+		if !needSecret {
+			advisories = append(advisories, fmt.Sprintf(
+				"reusing the secret already stored at %s with access key ID %s; if you rotated this key, run `aileron vault put %s` with the new secret access key so the stored secret matches the new access key ID (they must belong to the same key)",
+				req.CredentialRef, akid, req.CredentialRef))
+		}
+		return []proxybinding.Entry{entry}, advisories, storedSecret, nil
 	}
 
 	// Host-keyed (bearer): one entry per non-templated host. A templated host

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -194,6 +194,64 @@ func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
 	}
 }
 
+// TestRunSkillBindSigv4ReusesSecretWarnsRotation proves the rotation-mismatch
+// guard (#2017): when the vault already holds a secret for a sigv4 identity but
+// the descriptor is missing, bind fills only the missing access key ID without an
+// unnecessary secret prompt, and warns that the reused secret must match the
+// entered key. This is the exact rotation footgun — entering a rotated key's new
+// ID while the vault keeps the deleted key's secret would otherwise fail far away
+// at launch with an opaque SignatureDoesNotMatch, with no hint the secret is
+// stale. The advisory names `vault put` so the operator can reconcile at bind
+// time.
+func TestRunSkillBindSigv4ReusesSecretWarnsRotation(t *testing.T) {
+	// Vault already holds the (old key's) secret; descriptor is missing.
+	vault := &fakeBindVault{services: map[string][]byte{"prod-reader": []byte("old-key-secret")}}
+	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+	seedFrozen(t, "rubber-duck", "v1")
+	secretCalls := withSecret(t, "unused")
+
+	var out, errb bytes.Buffer
+	// Operator enters the rotated key's new access key ID at the prompt.
+	code := runSkillBind([]string{"rubber-duck"}, strings.NewReader("AKIANEWROTATEDKEY99\n"), &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	// Acceptance: the no-secret-prompt half is preserved — bind must not
+	// re-prompt for or overwrite the existing secret just to fill the descriptor.
+	if *secretCalls != 0 {
+		t.Errorf("secret prompted %d times, want 0 (secret already present)", *secretCalls)
+	}
+	if vault.puts != 0 {
+		t.Errorf("vault puts = %d, want 0 (existing secret untouched)", vault.puts)
+	}
+	if string(vault.services["prod-reader"]) != "old-key-secret" {
+		t.Errorf("secret = %q, want the untouched existing value", vault.services["prod-reader"])
+	}
+
+	// The descriptor gains the entered (rotated) access key ID.
+	d := parseDescriptor(t, descPath)
+	if len(d.Bindings) != 1 || d.Bindings[0].AccessKeyID != "AKIANEWROTATEDKEY99" {
+		t.Fatalf("descriptor = %+v, want one entry with the entered key", d.Bindings)
+	}
+
+	// Acceptance: a clear advisory to update the secret on rotation, naming the
+	// vault put command so the operator can reconcile before launch.
+	got := out.String()
+	if !strings.Contains(got, "advisory:") {
+		t.Errorf("stdout = %q, want a rotation advisory", got)
+	}
+	if !strings.Contains(got, "aileron vault put user/prod-reader") {
+		t.Errorf("stdout = %q, want the advisory to name `vault put`", got)
+	}
+	if !strings.Contains(got, "rotated") {
+		t.Errorf("stdout = %q, want the advisory to mention rotation", got)
+	}
+	// No secret material is ever echoed.
+	if strings.Contains(got, "old-key-secret") || strings.Contains(errb.String(), "old-key-secret") {
+		t.Errorf("secret material leaked into output: stdout=%q stderr=%q", got, errb.String())
+	}
+}
+
 // TestRunSkillBindPartiallySatisfied proves only the missing requirement is
 // filled: a pre-satisfied sigv4 entry is left intact while a missing bearer
 // requirement is prompted and written.

--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -70,6 +70,8 @@ The write is programmatic, so you do not hand-edit any file. A single run stores
 
 The same verb onboards a second operator on their own machine. They install the same frozen plan, run `aileron skill bind <name>`, and supply their own identity and key. The plan is shared once; each operator binds their own credentials against it. A requirement whose host carries an unresolved input template is surfaced as an advisory rather than written automatically, since the concrete host is not known until launch resolves the input.
 
+For an `aws-sigv4` credential the access key ID and the secret are a matched pair. When you re-run bind and the vault already holds the secret, bind fills only the missing access key ID and does not re-prompt for the secret. If you rotated the key (minted a new access key ID and secret, then deleted the old one) and entered the new ID, the vault still holds the old secret, which fails at launch with an opaque `SignatureDoesNotMatch`. To catch this before launch, bind prints an advisory whenever it writes an access key ID while reusing an existing secret, telling you to run `aileron vault put user/<service>` with the new secret if you rotated the key so the stored secret matches the entered access key ID.
+
 ## Action requirements and graceful degrade
 
 When a skill declares `requires:` action references (for example `aileron:metrics.query_series`), the installer asks your running daemon which actions are installed and checks each reference. A reference is satisfied when an installed action matches both the connector and the action name.


### PR DESCRIPTION
## Summary

Closes #2017.

`aileron skill bind` fills a credential requirement's two halves independently: the secret (in the vault) and the access key ID (in the descriptor). When the vault already holds a secret at the credential ref, bind skips the secret prompt and asks only for the access key ID.

For an `aws-sigv4` credential the access key ID and secret are a **matched pair**. The most common credential operation, rotation (mint a new access key with a new ID **and** secret, delete the old one), then breaks silently: the operator re-runs bind and enters the **new** ID, but bind keeps the **old** secret in the vault because *a* secret already exists at that ref. The result is `descriptor.access_key_id = <new>` paired with the vault secret of the old, now-deleted key. Launch fails far away at the proxy with an opaque `SignatureDoesNotMatch`, giving no hint the stored secret is stale.

This adds a bind-time advisory: whenever bind writes a sigv4 access key ID while **reusing** an existing vault secret (it did not just capture one), it prints

> reusing the secret already stored at `user/<svc>` with access key ID `AKIA…`; if you rotated this key, run `aileron vault put user/<svc>` with the new secret access key so the stored secret matches the new access key ID (they must belong to the same key)

so the operator can reconcile at bind time instead of debugging a cryptic AWS signature error at launch.

### Scope / design notes

Per the issue's acceptance criteria ("either bind re-prompts for the secret, **or** it clearly warns to update the secret"), this ships the advisory (the issue's option 3). The more robust option 1 (record the access key ID in the vault secret's metadata and compare on re-bind) is deliberately out of scope: the bind path's wire body (`agentCredentialsBody`) carries only the secret value with no metadata, and `bindVaultClient` cannot read metadata back, so option 1 would need wire + daemon-endpoint + vault read-back plumbing across several surfaces. Option 2 (compare against an existing descriptor's access key ID) can never fire, because a present descriptor makes the requirement `satisfied()` and bind skips it entirely. The advisory lives entirely in `cmd/aileron/skill_bind.go` and fully satisfies the stated acceptance.

The no-rotation case is unchanged: bind still fills only the missing descriptor half without an unnecessary secret prompt. No secret material is echoed (the access key ID is the non-secret half).

## Test plan

- New regression test `TestRunSkillBindSigv4ReusesSecretWarnsRotation` reproduces the exact footgun: vault already holds the (old key's) secret, descriptor missing, operator enters a rotated key's new ID. Asserts the secret is **not** re-prompted or overwritten, the descriptor gains the entered key, a clear `advisory:` line names `aileron vault put user/prod-reader` and mentions rotation, and no secret material leaks into stdout/stderr. Verified it **fails before** the fix (no advisory) and **passes after**.
- `fillRequirement` coverage 94.1%; the new advisory branch is covered.
- `go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and the full `SkillBind`/`Bind` test set pass.
- Docs updated: `docs/src/content/docs/guides/installing-a-skill.md` documents the matched-pair advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
