### PR TITLE
fix(proxy): reload host-binding table from descriptor file without daemon restart

### DIFF
--- a/cmd/aileron/skill_bind.go
+++ b/cmd/aileron/skill_bind.go
@@ -306,8 +306,8 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	}
 	if len(toWrite) > 0 {
 		fmt.Fprintf(stdout, "Wrote %d descriptor entr%s to %s\n", len(toWrite), plural(len(toWrite), "y", "ies"), descriptorPath())
+		fmt.Fprintln(stdout, "These bindings are live: the daemon reloads binding descriptors from the file on the next request (#1887), so no restart is needed. If a request still isn't matched, `aileron daemon stop` then `aileron daemon start` reloads them as a fallback.")
 	}
-	fmt.Fprintln(stdout, "The daemon loads binding descriptors once at startup (#1887); restart it with `aileron daemon stop` then `aileron daemon start` for these bindings to take effect.")
 	return 0
 }
 

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -149,8 +149,8 @@ func bearerReq(service string, hosts ...string) credreq.RequiredBinding {
 
 // TestRunSkillBindFullyMissingSigv4 proves a fully-missing sigv4 requirement is
 // onboarded: the secret lands in the vault, the descriptor gains a valid
-// identity entry with the access key ID and no host, and the summary + restart
-// reminder are printed.
+// identity entry with the access key ID and no host, and the summary plus the
+// no-restart-needed confirmation (#1887) are printed.
 func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
 	vault := &fakeBindVault{}
 	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
@@ -189,8 +189,15 @@ func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
 	if !strings.Contains(out.String(), "onboarded: user/prod-reader") {
 		t.Errorf("stdout = %q, want an onboarded summary line", out.String())
 	}
-	if !strings.Contains(out.String(), "#1887") || !strings.Contains(out.String(), "restart") {
-		t.Errorf("stdout = %q, want a load-once restart reminder", out.String())
+	// The daemon now reloads descriptors from the file without a restart
+	// (#1887), so the closing message must confirm the bindings are live and
+	// must NOT instruct the operator to restart the daemon to apply them.
+	msg := out.String()
+	if !strings.Contains(msg, "#1887") || !strings.Contains(msg, "live") || !strings.Contains(msg, "no restart is needed") {
+		t.Errorf("stdout = %q, want a no-restart-needed confirmation citing #1887", msg)
+	}
+	if strings.Contains(msg, "restart it") || strings.Contains(msg, "for these bindings to take effect") {
+		t.Errorf("stdout = %q, must not instruct a restart to apply the bindings", msg)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -269,25 +269,17 @@ var daemonUnitLayers = func(ctx context.Context) ([]capture.CaptureDescriptor, [
 // and preserves today's defaults-only table. A present-but-malformed unit, or
 // a malformed descriptor in any layer, fails construction loudly rather than
 // silently shipping an empty (passthrough) table.
+//
+// It returns the table snapshot the reloader loads at construction. The daemon
+// boot path (NewHandlerWithConfig) instead retains the [hostBindingsReloader]
+// itself so later user-file edits are observed without a restart (#1887); this
+// helper preserves the one-shot table contract the unit-layer tests assert.
 func assembleHostBindings(ctx context.Context, log *slog.Logger) (binding.HostBindings, error) {
-	_, sealingLayer, err := daemonUnitLayers(ctx)
+	r, err := newHostBindingsReloader(ctx, log)
 	if err != nil {
-		return nil, fmt.Errorf("assemble host bindings: load image unit layer: %w", err)
+		return nil, err
 	}
-	opts := proxybinding.DefaultLoadOptions()
-	opts.ExtraEntries = sealingLayer
-	table, warnings, err := proxybinding.LoadHostBindingsWithWarnings(opts)
-	if err != nil {
-		return nil, fmt.Errorf("assemble host bindings: %w", err)
-	}
-	// Warnings are non-fatal: a well-formed-but-suspect binding (e.g. a
-	// sigv4-resign access_key_id that does not match the AWS shape) is logged
-	// at startup so an operator sees the likely mistake before it fails at
-	// launch, without blocking daemon boot.
-	for _, w := range warnings {
-		log.Warn("host binding descriptor warning", "detail", w)
-	}
-	return table, nil
+	return r.current(), nil
 }
 
 // NewHandlerWithConfig is the configurable entry point. The launcher
@@ -551,7 +543,13 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// bindings now that #1323 removed the central github.yaml; its projection
 	// is byte-identical to that former default (pinned by internal/app's
 	// TestGHUnitDriftGuard).
-	server.hostBindings, err = assembleHostBindings(ctx, log)
+	// #1887: hold the table in a re-stat reloader so out-of-band edits to
+	// ~/.aileron/binding-descriptors.yaml (including `aileron skill bind`
+	// writes) take effect at the proxy boundary without a daemon restart. The
+	// image unit layer is resolved once here and cached; a later reload
+	// re-reads only the user file. The initial load fails boot loudly on a
+	// malformed descriptor, unchanged from the previous one-shot assembly.
+	server.hostBindingsReloader, err = newHostBindingsReloader(ctx, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -94,7 +94,8 @@ type apiServer struct {
 	caveatIssuer         *auth.CaveatIssuer               // mints/validates session-scoped caveat tokens (ADR-0024, #958); nil disables caveat auth
 	actionApprovalTTL    time.Duration                    // how long RunAction holds the response open before timing out; default 5m, configurable for tests
 	bindings             binding.Store                    // capability bindings (ADR-0006); nil when no vault is wired
-	hostBindings         binding.HostBindings             // user-level host->credential bindings at the TLS forward-proxy boundary (#1193); nil/empty = today's passthrough
+	hostBindings         binding.HostBindings             // user-level host->credential bindings at the TLS forward-proxy boundary (#1193); nil/empty = today's passthrough. Used directly by tests; production reads through hostBindingsReloader.
+	hostBindingsReloader *hostBindingsReloader            // re-stat reloading holder for the host-binding table (#1887); when set, currentHostBindings() reads it so descriptor edits take effect without a daemon restart. nil in tests that set hostBindings directly.
 	specLoader           connectorSpecLoader              // installed connector operation specs for generated sandbox shims; nil loads from cstore.DefaultRoot
 	oauth2Sessions       *oauth2Sessions                  // ADR-0006 server-driven OAuth dance state; lazy-initialized on first use
 	oauth2HTTPClient     *http.Client                     // for OAuth token exchanges; nil → http.DefaultClient

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -295,7 +295,7 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 			writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy denied egress: the step's credential identity is incomplete")
 			return true
 		}
-		hb, ok = s.hostBindings.MatchIdentity(auth.StepScope.CredentialKind, auth.StepScope.IdentityLabel)
+		hb, ok = s.currentHostBindings().MatchIdentity(auth.StepScope.CredentialKind, auth.StepScope.IdentityLabel)
 		if !ok {
 			// The declared identity has no bound credential. Fail closed: no
 			// fallthrough to Match(host), no passthrough.
@@ -306,7 +306,7 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 	} else {
 		// Host path: today's behavior. On a miss, return false so the caller
 		// falls through to passthrough (unchanged).
-		hb, ok = s.hostBindings.Match(hostForMatch)
+		hb, ok = s.currentHostBindings().Match(hostForMatch)
 		if !ok {
 			return false
 		}

--- a/internal/app/host_bindings_reloader.go
+++ b/internal/app/host_bindings_reloader.go
@@ -1,0 +1,181 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// currentHostBindings returns the host-binding table the forward proxy should
+// match against. When a reloader is wired (production boot), it returns the
+// reloader's live table, re-reading the user descriptor file first if it
+// changed on disk (#1887). When no reloader is set (tests that populate
+// hostBindings directly, and any pre-reloader construction path), it returns
+// the static table, preserving today's behavior.
+func (s *apiServer) currentHostBindings() binding.HostBindings {
+	if s.hostBindingsReloader != nil {
+		return s.hostBindingsReloader.current()
+	}
+	return s.hostBindings
+}
+
+// hostBindingsReloader holds the daemon's host->credential binding table and
+// re-reads the user descriptor file (~/.aileron/binding-descriptors.yaml) when
+// it changes on disk, so out-of-band edits — including `aileron skill bind`
+// writes — take effect at the forward-proxy boundary without a daemon restart
+// (#1887). Before this, the table was assembled once at boot and never
+// reassigned, so a `skill bind` write and the running daemon silently diverged
+// until a restart.
+//
+// Reload strategy is re-stat, not fsnotify: the proxy access path os.Stats the
+// user file (mtime+size) and only re-parses when the signature changes. A
+// steady-state CONNECT costs one stat syscall and no parse; a parse happens
+// only after an actual edit. This is the simpler path the issue endorses over a
+// filesystem watcher.
+//
+// The image-derived unit layer (#1322) is resolved once at boot and cached in
+// extraEntries: a reload re-reads only the user file and never re-resolves the
+// image via daemonUnitLayers, so a reload can never block on a container
+// runtime and the sealing layer stays stable for the daemon's lifetime.
+//
+// A reload that fails (malformed/placeholder descriptor — the same load-time
+// validation as #1873) keeps the previously-loaded table and surfaces the error
+// via the log rather than half-applying or degrading to an empty (passthrough)
+// table. The stat signature is NOT advanced on failure, so the next access
+// retries; once the operator fixes the file the reload succeeds.
+//
+// This mirrors the reload precedent already in the daemon: ReloadingKeyring
+// (verify.go) re-reads the keyring so `keyring trust` writes take effect, and
+// the action store reloads after an install (handlers_install_actions.go).
+type hostBindingsReloader struct {
+	userPath     string
+	extraEntries []proxybinding.Entry
+	log          *slog.Logger
+
+	mu    sync.Mutex
+	table binding.HostBindings
+	// sig is the stat signature of the user file as of the last successful
+	// (or initial) load. A zero-value sig means the file was absent then.
+	sig hostBindingsStatSig
+}
+
+// hostBindingsStatSig is the change-detection signature for the user descriptor
+// file: presence plus mtime and size. An edit that changes content changes at
+// least one of mtime or size, so this distinguishes an unchanged file (skip the
+// re-parse) from an edited one (reload). Absence is a first-class state so
+// creating or deleting the file is detected too.
+type hostBindingsStatSig struct {
+	exists  bool
+	modTime time.Time
+	size    int64
+}
+
+func (a hostBindingsStatSig) equal(b hostBindingsStatSig) bool {
+	return a.exists == b.exists && a.size == b.size && a.modTime.Equal(b.modTime)
+}
+
+// newHostBindingsReloader resolves the image-derived unit layer once, performs
+// the initial load, and returns a reloader primed to observe later edits to the
+// user descriptor file. An initial load error (malformed image unit or a
+// malformed descriptor in any layer) is surfaced so the daemon fails boot
+// loudly, exactly as the previous one-shot assembly did — a broken descriptor
+// must never silently ship an empty (passthrough) table.
+func newHostBindingsReloader(ctx context.Context, log *slog.Logger) (*hostBindingsReloader, error) {
+	_, sealingLayer, err := daemonUnitLayers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("assemble host bindings: load image unit layer: %w", err)
+	}
+	r := &hostBindingsReloader{
+		userPath:     proxybinding.DefaultUserPath(),
+		extraEntries: sealingLayer,
+		log:          log,
+	}
+	// Record the stat before the initial load so an edit that races the load is
+	// not silently missed: if the file changes after this stat but before or
+	// during the load, the recorded (older) signature differs from the next
+	// access's stat and triggers a redundant-but-correct reload.
+	sig := r.statUserFile()
+	table, err := r.loadTable()
+	if err != nil {
+		return nil, fmt.Errorf("assemble host bindings: %w", err)
+	}
+	r.table = table
+	r.sig = sig
+	return r, nil
+}
+
+// statUserFile returns the current change-detection signature for the user
+// descriptor file. An absent or unstattable file yields the zero signature: an
+// absent user layer is valid (built-in defaults only), matching the loader's
+// missing-file semantics, so absence is not an error here.
+func (r *hostBindingsReloader) statUserFile() hostBindingsStatSig {
+	if r.userPath == "" {
+		return hostBindingsStatSig{}
+	}
+	fi, err := os.Stat(r.userPath)
+	if err != nil {
+		return hostBindingsStatSig{}
+	}
+	return hostBindingsStatSig{exists: true, modTime: fi.ModTime(), size: fi.Size()}
+}
+
+// loadTable re-reads the user descriptor layer, merges it with the cached image
+// unit layer and the embedded built-in defaults, and adapts the result to the
+// canonical binding table. Non-fatal warnings (a well-formed-but-suspect
+// binding) are logged, matching the boot-time warn-only contract; a malformed
+// layer returns an error and no table.
+func (r *hostBindingsReloader) loadTable() (binding.HostBindings, error) {
+	opts := proxybinding.LoadOptions{
+		UserPath:     r.userPath,
+		ExtraEntries: r.extraEntries,
+	}
+	table, warnings, err := proxybinding.LoadHostBindingsWithWarnings(opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, w := range warnings {
+		if r.log != nil {
+			r.log.Warn("host binding descriptor warning", "detail", w)
+		}
+	}
+	return table, nil
+}
+
+// current returns the live host-binding table, reloading it first if the user
+// descriptor file changed since the last load. It is called on the concurrent
+// proxy access path, so it serializes stat+reload+swap under a mutex; the stat
+// itself is done before the lock to keep the common (unchanged) case cheap.
+//
+// On a reload failure the previous table is returned unchanged and the error is
+// logged: a bad edit degrades to "stale but serving", never to an empty table,
+// and never half-applies a partially-valid document.
+func (r *hostBindingsReloader) current() binding.HostBindings {
+	sig := r.statUserFile()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if sig.equal(r.sig) {
+		return r.table
+	}
+
+	table, err := r.loadTable()
+	if err != nil {
+		if r.log != nil {
+			r.log.Error("host binding descriptor reload failed; keeping previous table",
+				"path", r.userPath, "error", err)
+		}
+		// Do not advance r.sig: the next access retries the reload, so a fixed
+		// file is picked up without waiting for a further edit.
+		return r.table
+	}
+	r.table = table
+	r.sig = sig
+	return table
+}

--- a/internal/app/host_bindings_reloader_test.go
+++ b/internal/app/host_bindings_reloader_test.go
@@ -1,0 +1,169 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/auth/capture"
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// primeHostBindingsReloader builds a reloader over a specific user-descriptor
+// path and cached unit layer, performing the initial load exactly as the
+// production constructor does (minus the image resolution the tests control
+// separately). It is the seam that lets a test drive the user-file edit path
+// deterministically without a real home directory.
+func primeHostBindingsReloader(t *testing.T, userPath string, extra []proxybinding.Entry) *hostBindingsReloader {
+	t.Helper()
+	r := &hostBindingsReloader{
+		userPath:     userPath,
+		extraEntries: extra,
+		log:          discardLogger(),
+	}
+	sig := r.statUserFile()
+	table, err := r.loadTable()
+	if err != nil {
+		t.Fatalf("initial loadTable: %v", err)
+	}
+	r.table = table
+	r.sig = sig
+	return r
+}
+
+// writeUserDescriptor writes a single bearer host binding into a fresh
+// descriptor at path via the same Upsert the CLI uses, so the file is a
+// realistic, load-valid document rather than hand-rolled YAML.
+func writeUserDescriptor(t *testing.T, path, host, ref string) {
+	t.Helper()
+	if err := proxybinding.Upsert(path, proxybinding.Entry{
+		Host:          host,
+		CredentialRef: ref,
+		Scheme:        binding.SchemeBearer,
+	}); err != nil {
+		t.Fatalf("Upsert descriptor: %v", err)
+	}
+}
+
+// TestHostBindingsReloader_PicksUpUserFileEdit is the core #1887 regression: a
+// binding written to the descriptor file AFTER the reloader was constructed is
+// matched on the next access, with no reconstruction ("restart"). Before the
+// reload holder existed, the table was assembled once and this edit was invisible
+// until a daemon restart.
+func TestHostBindingsReloader_PicksUpUserFileEdit(t *testing.T) {
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+
+	// Constructed against an absent user file: built-in defaults only.
+	r := primeHostBindingsReloader(t, descPath, nil)
+	if _, ok := r.current().Match("api.linear.app"); !ok {
+		t.Fatal("defaults-only table must still carry the built-in api.linear.app")
+	}
+	if _, ok := r.current().Match("edited.example.test"); ok {
+		t.Fatal("host must be unbound before the descriptor is written")
+	}
+
+	// Operator (or `skill bind`) writes a new binding out of band.
+	writeUserDescriptor(t, descPath, "edited.example.test", "user/edited")
+
+	hb, ok := r.current().Match("edited.example.test")
+	if !ok {
+		t.Fatal("edited binding must be live on the next access without a restart")
+	}
+	if hb.CredentialRef != "user/edited" {
+		t.Errorf("credential_ref = %q, want user/edited", hb.CredentialRef)
+	}
+	// The additive edit must not drop the built-in defaults.
+	if _, ok := r.current().Match("api.linear.app"); !ok {
+		t.Error("built-in api.linear.app must survive the reload")
+	}
+}
+
+// TestHostBindingsReloader_MalformedReloadKeepsPreviousTable proves a broken edit
+// (the same load-time validation as #1873) does NOT half-apply or degrade to an
+// empty passthrough table: the previously-loaded bindings keep serving, and once
+// the file is corrected the reload succeeds on a later access.
+func TestHostBindingsReloader_MalformedReloadKeepsPreviousTable(t *testing.T) {
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	writeUserDescriptor(t, descPath, "kept.example.test", "user/kept")
+
+	r := primeHostBindingsReloader(t, descPath, nil)
+	if _, ok := r.current().Match("kept.example.test"); !ok {
+		t.Fatal("initial valid binding must be present")
+	}
+
+	// Corrupt the file with content of a clearly different length so the size
+	// component of the stat signature changes even on coarse-mtime filesystems.
+	if err := os.WriteFile(descPath, []byte("::: this is not valid descriptor yaml :::\n"), 0o600); err != nil {
+		t.Fatalf("write malformed descriptor: %v", err)
+	}
+
+	// The malformed reload is rejected; the previous table keeps serving.
+	if _, ok := r.current().Match("kept.example.test"); !ok {
+		t.Fatal("previous binding must survive a malformed reload (no half-apply, no empty table)")
+	}
+	if _, ok := r.current().Match("api.linear.app"); !ok {
+		t.Error("built-in defaults must survive a malformed reload")
+	}
+
+	// Correcting the file lets a later access reload cleanly (the failed reload
+	// did not advance the stat signature, so the retry is not blocked). Replace
+	// the malformed file outright rather than Upsert-merging onto it.
+	if err := os.Remove(descPath); err != nil {
+		t.Fatalf("remove malformed descriptor: %v", err)
+	}
+	writeUserDescriptor(t, descPath, "fixed.example.test", "user/fixed")
+	if _, ok := r.current().Match("fixed.example.test"); !ok {
+		t.Fatal("a corrected descriptor must reload on the next access")
+	}
+}
+
+// TestHostBindingsReloader_ReloadReusesCachedUnitLayer proves a reload re-reads
+// only the user file and never re-resolves the image unit layer: daemonUnitLayers
+// is called exactly once (at construction), and the cached sealing entry remains
+// resolvable across reloads driven by user-file edits.
+func TestHostBindingsReloader_ReloadReusesCachedUnitLayer(t *testing.T) {
+	calls := 0
+	sealing := []proxybinding.Entry{{
+		Host:          "sealed.example.test",
+		CredentialRef: "user/sealed",
+		Scheme:        binding.SchemeBearer,
+	}}
+	swapDaemonUnitLayers(t, func(context.Context) ([]capture.CaptureDescriptor, []proxybinding.Entry, error) {
+		calls++
+		return nil, sealing, nil
+	})
+
+	r, err := newHostBindingsReloader(context.Background(), discardLogger())
+	if err != nil {
+		t.Fatalf("newHostBindingsReloader: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("daemonUnitLayers called %d times at construction, want 1", calls)
+	}
+
+	// Repoint at a controllable user file and reset the stat signature so the
+	// next access observes the new file and reloads.
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+	r.userPath = descPath
+	r.sig = hostBindingsStatSig{}
+
+	writeUserDescriptor(t, descPath, "userland.example.test", "user/userland")
+	if _, ok := r.current().Match("userland.example.test"); !ok {
+		t.Fatal("user-file binding must reload")
+	}
+	// A second edit forces another reload.
+	writeUserDescriptor(t, descPath, "userland2.example.test", "user/userland2")
+	if _, ok := r.current().Match("userland2.example.test"); !ok {
+		t.Fatal("second user-file edit must reload")
+	}
+
+	if calls != 1 {
+		t.Errorf("daemonUnitLayers called %d times total, want 1 (reload must not re-resolve the image)", calls)
+	}
+	// The cached image unit layer is still applied after the user-file reloads.
+	if _, ok := r.current().Match("sealed.example.test"); !ok {
+		t.Error("cached unit-layer binding must remain resolvable across reloads")
+	}
+}

--- a/internal/app/sandbox_forward_proxy_binding_reload_test.go
+++ b/internal/app/sandbox_forward_proxy_binding_reload_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+)
+
+// TestSandboxForwardProxy_HostBindingReloadsOnFileEdit is the end-to-end #1887
+// regression at the actual proxy boundary: a host that is unbound when the
+// daemon's proxy first sees it (passthrough, no injection) becomes bound and
+// injected on a later request once its descriptor is written to the user file —
+// with no reconstruction of the server or the binding table ("restart"). Before
+// the reload holder, the proxy read a table assembled once at boot and the
+// second request would still pass through un-injected.
+func TestSandboxForwardProxy_HostBindingReloadsOnFileEdit(t *testing.T) {
+	descPath := filepath.Join(t.TempDir(), "binding-descriptors.yaml")
+
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-reload" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/reloaded/octocat", "api_key", []byte("reloaded_secret")),
+		// The proxy reads through the reloader (production wiring), not the
+		// static hostBindings field, so a descriptor edit is observed live.
+		hostBindingsReloader: primeHostBindingsReloader(t, descPath, nil),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	// First request: reload.example.test is unbound, so it passes through with
+	// no credential injected.
+	resp1, err := setup.client.Get("https://reload.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("first GET: %v", err)
+	}
+	io.Copy(io.Discard, resp1.Body)
+	resp1.Body.Close()
+	if upstreamAuth != "" {
+		t.Fatalf("first request must pass through un-injected; upstream Authorization = %q", upstreamAuth)
+	}
+
+	// Operator (or `aileron skill bind`) writes the binding out of band.
+	writeUserDescriptor(t, descPath, "reload.example.test", "api_key/reloaded/octocat")
+
+	// Sanity: the daemon's live table observes the edit (proves the reload
+	// itself, independent of proxy connection pooling).
+	if _, ok := srv.currentHostBindings().Match("reload.example.test"); !ok {
+		t.Fatal("live host-binding table must observe the descriptor edit")
+	}
+
+	// Force a fresh CONNECT tunnel: each intercepted tunnel serves a single
+	// request, but the client may pool the tunnel, which would skip re-matching.
+	setup.client.CloseIdleConnections()
+
+	// Second request: the daemon reloads the descriptor from the file and now
+	// injects the bound credential — no restart.
+	resp2, err := setup.client.Get("https://reload.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("second GET: %v", err)
+	}
+	io.Copy(io.Discard, resp2.Body)
+	resp2.Body.Close()
+	if upstreamAuth != "Bearer reloaded_secret" {
+		t.Fatalf("second request must inject the newly-bound credential; upstream Authorization = %q, want Bearer reloaded_secret", upstreamAuth)
+	}
+}


### PR DESCRIPTION
## Summary

The daemon assembled its host->credential binding table once at boot (`assembleHostBindings`, `internal/app/app.go`) and never reassigned it, so an out-of-band edit to `~/.aileron/binding-descriptors.yaml` — including every `aileron skill bind` write — was invisible to the running forward proxy until a daemon restart. Worse, `status host-bindings` and the launch preflight read the file fresh CLI-side, so they falsely reported healthy exactly when the daemon had silently diverged. `skill bind` then told the operator to restart the daemon.

This implements the issue's preferred "Best" option (option 1): make the daemon's table reload from the user descriptor file so file edits take effect without a restart, closing the silent file/daemon divergence.

### What changed

- **`hostBindingsReloader`** (`internal/app/host_bindings_reloader.go`): a re-stat reloading holder for the table. The proxy now reads through a new `currentHostBindings()` accessor (replacing the two direct `s.hostBindings` reads in `handlers_sandbox_forward_proxy.go`). On access it `os.Stat`s the user file and re-parses only when mtime/size changes, swapping the table atomically under a mutex (the proxy path is concurrent).
- **Image unit layer cached once**: the image-derived sealing layer (#1322) is resolved at boot and cached in the reloader, so a reload re-reads only the user file and never re-resolves the image via a container runtime.
- **Fail-safe reload**: a malformed/placeholder descriptor (the same load-time validation as #1873) keeps the previous table and logs the error rather than half-applying or degrading to an empty passthrough table. The stat signature is not advanced on failure, so a corrected file is picked up on the next access.
- **`aileron skill bind`** (`cmd/aileron/skill_bind.go`) no longer instructs a restart: it confirms the bindings are live and keeps restart only as a fallback hint. Consolidates #2016.
- Boot wiring retains the reloader; `assembleHostBindings` now delegates to it, preserving the one-shot table contract the unit-layer tests assert.

Mirrors the reload precedent already in the daemon: `ReloadingKeyring` and the post-install action-store reload.

Since the daemon now tracks the file, `status host-bindings` / preflight (which read the file) stay consistent with the running daemon, satisfying the acceptance "floor" without separate staleness plumbing. Re-stat over fsnotify is the simpler path the issue endorses.

## Test plan

- `internal/app/host_bindings_reloader_test.go`:
  - proxy table picks up a descriptor edit without restart (the core regression);
  - a malformed reload keeps the previous table and does not apply, then a corrected file reloads on the next access;
  - a reload reuses the cached image unit layer and never re-resolves the image (`daemonUnitLayers` called exactly once).
- `internal/app/sandbox_forward_proxy_binding_reload_test.go`: end-to-end at the real proxy boundary — an unbound host passes through un-injected, then after the descriptor is written the next request injects the newly-bound credential, with no server/table reconstruction.
- `cmd/aileron/skill_bind_test.go`: closing message confirms bindings are live and no longer instructs a restart to apply them.
- `go test ./app/ ./proxybinding/ ./launch/` and the `cmd/aileron` suite pass; `go vet` clean.

Closes #1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
