### PR TITLE
fix(skill): trim skill bind success output to a one-line liveness note

### DIFF
--- a/cmd/aileron/skill_bind.go
+++ b/cmd/aileron/skill_bind.go
@@ -306,7 +306,7 @@ func runSkillBind(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	}
 	if len(toWrite) > 0 {
 		fmt.Fprintf(stdout, "Wrote %d descriptor entr%s to %s\n", len(toWrite), plural(len(toWrite), "y", "ies"), descriptorPath())
-		fmt.Fprintln(stdout, "These bindings are live: the daemon reloads binding descriptors from the file on the next request (#1887), so no restart is needed. If a request still isn't matched, `aileron daemon stop` then `aileron daemon start` reloads them as a fallback.")
+		fmt.Fprintln(stdout, "These bindings are live.")
 	}
 	return 0
 }

--- a/cmd/aileron/skill_bind_test.go
+++ b/cmd/aileron/skill_bind_test.go
@@ -150,7 +150,7 @@ func bearerReq(service string, hosts ...string) credreq.RequiredBinding {
 // TestRunSkillBindFullyMissingSigv4 proves a fully-missing sigv4 requirement is
 // onboarded: the secret lands in the vault, the descriptor gains a valid
 // identity entry with the access key ID and no host, and the summary plus the
-// no-restart-needed confirmation (#1887) are printed.
+// trimmed liveness confirmation are printed.
 func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
 	vault := &fakeBindVault{}
 	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
@@ -189,15 +189,15 @@ func TestRunSkillBindFullyMissingSigv4(t *testing.T) {
 	if !strings.Contains(out.String(), "onboarded: user/prod-reader") {
 		t.Errorf("stdout = %q, want an onboarded summary line", out.String())
 	}
-	// The daemon now reloads descriptors from the file without a restart
-	// (#1887), so the closing message must confirm the bindings are live and
-	// must NOT instruct the operator to restart the daemon to apply them.
+	// The closing message must confirm the bindings are live, and must stay
+	// trimmed: no reload internals, no fallback disclaimer, and no issue
+	// reference (#1887) leaking into user-facing CLI output.
 	msg := out.String()
-	if !strings.Contains(msg, "#1887") || !strings.Contains(msg, "live") || !strings.Contains(msg, "no restart is needed") {
-		t.Errorf("stdout = %q, want a no-restart-needed confirmation citing #1887", msg)
+	if !strings.Contains(msg, "These bindings are live.") {
+		t.Errorf("stdout = %q, want a trimmed liveness confirmation", msg)
 	}
-	if strings.Contains(msg, "restart it") || strings.Contains(msg, "for these bindings to take effect") {
-		t.Errorf("stdout = %q, must not instruct a restart to apply the bindings", msg)
+	if strings.Contains(msg, "#1887") || strings.Contains(msg, "reloads") || strings.Contains(msg, "fallback") || strings.Contains(msg, "restart") {
+		t.Errorf("stdout = %q, must not carry reload internals, a fallback disclaimer, or an issue reference", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `aileron skill bind` success output over-explained the daemon reload mechanics and leaked a GitHub issue reference (`#1887`) into user-facing CLI text. This trims the closing line to a single liveness statement.

Before:
```
Wrote 1 descriptor entry to ...\binding-descriptors.yaml
These bindings are live: the daemon reloads binding descriptors from the file on the next request (#1887), so no restart is needed. If a request still isn't matched, `aileron daemon stop` then `aileron daemon start` reloads them as a fallback.
```

After:
```
Wrote 1 descriptor entry to ...\binding-descriptors.yaml
These bindings are live.
```

Dropped the reload internals, the `#1887` reference, and the fallback disclaimer from the happy-path output. The behavior itself is unchanged; only the message is trimmed.

## Test plan

- Updated `TestRunSkillBindFullyMissingSigv4` to assert the trimmed `These bindings are live.` line and to fail if reload internals, a fallback disclaimer, or an issue reference (`#1887`) reappear in CLI output.
- `go test ./cmd/aileron/ -run TestRunSkillBind` passes.

Closes #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the success message shown after updating skill bindings.
  * The confirmation now clearly states that the bindings are live, without extra technical guidance or restart-related wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->