### PR TITLE
feat(skill): offer to auto-bind declared credentials on frozen/OCI install

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -193,7 +193,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 	case "action":
 		return runAction(args[1:], os.Stdin, stdout, stderr)
 	case "skill":
-		return runSkill(args[1:], stdout, stderr)
+		return runSkill(args[1:], os.Stdin, stdout, stderr)
 	case "keyring":
 		return runKeyring(args[1:], stdout, stderr)
 	case "hub":

--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
@@ -40,14 +39,14 @@ var newSkillFetcher = func() (resolver.Fetcher, error) {
 	}, nil
 }
 
-func runSkill(args []string, stdout, stderr io.Writer) int {
+func runSkill(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, skillUsage)
 		return 1
 	}
 	switch args[0] {
 	case "install":
-		return runSkillInstall(args[1:], stdout, stderr)
+		return runSkillInstall(args[1:], stdin, stdout, stderr)
 	case "list":
 		return runSkillList(args[1:], stdout, stderr)
 	case "freeze":
@@ -55,7 +54,7 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 	case "launch":
 		return runSkillLaunch(args[1:], stdout, stderr)
 	case "bind":
-		return runSkillBind(args[1:], os.Stdin, stdout, stderr)
+		return runSkillBind(args[1:], stdin, stdout, stderr)
 	case "publish":
 		return runSkillPublish(args[1:], stdout, stderr)
 	default:
@@ -65,7 +64,7 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-func runSkillInstall(args []string, stdout, stderr io.Writer) int {
+func runSkillInstall(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("skill install", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	positionals, err := parseInterspersedFlags(flags, args)
@@ -83,7 +82,7 @@ func runSkillInstall(args []string, stdout, stderr io.Writer) int {
 	// FROZEN version, not the pre-freeze installed SKILL.md the local/git path
 	// copies. Local paths and git URLs fall through to the unchanged install.
 	if store.IsOCIReference(src) {
-		return runSkillInstallOCI(src, stdout, stderr)
+		return runSkillInstallOCI(src, stdin, stdout, stderr)
 	}
 
 	s := store.New(skillStoreDir)

--- a/cmd/aileron/skill_install_oci.go
+++ b/cmd/aileron/skill_install_oci.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -41,7 +43,7 @@ var newInstallPublisherVerifier = func(diag io.Writer) pull.PublisherVerifier {
 // indistinguishable from a local freeze (umbrella #1898, the read half). It
 // never pulls the image subject; the pin in the lock is carried into the store
 // untouched and resolved lazily at launch (#1903).
-func runSkillInstallOCI(ref string, stdout, stderr io.Writer) int {
+func runSkillInstallOCI(ref string, stdin io.Reader, stdout, stderr io.Writer) int {
 	s := store.New(skillStoreDir)
 
 	// Bound the network pull and honor Ctrl-C so a hung or unreachable registry
@@ -97,6 +99,28 @@ func runSkillInstallOCI(ref string, stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "Installed frozen version %s of skill %q to %s\n",
 		res.Frozen.ID, res.Name, s.FrozenDir(res.Name, res.Frozen.ID))
+
+	// A frozen/OCI install carries a signed trust contract, so bind can derive
+	// this plan's credential requirements right now. When attached to a terminal,
+	// offer to chain straight into bind so the operator onboards credentials in
+	// one step instead of remembering a second command. Non-interactive installs
+	// (CI, piped stdin) fall through to the pointer and never block on input.
+	if isTTYFn() {
+		// Wrap stdin once and hand the same *bufio.Reader to both the offer
+		// prompt and bind: promptLine reuses an existing *bufio.Reader instead of
+		// buffering ahead into a throwaway, so the bytes bind reads next (access
+		// key ids, etc.) survive the first ReadString rather than being consumed.
+		br := bufio.NewReader(stdin)
+		answer := promptLine(br, stdout,
+			fmt.Sprintf("Bind %q's declared credentials now? [Y/n]: ", res.Name))
+		if !strings.EqualFold(answer, "n") && !strings.EqualFold(answer, "no") {
+			// Bind exactly the version just written, not merely the most recent,
+			// so a concurrent freeze cannot redirect the onboarding. Bind reuses
+			// the same stdin so its own prompts read from the operator's terminal.
+			return runSkillBind([]string{res.Name, "--version", res.Frozen.ID}, br, stdout, stderr)
+		}
+	}
+
 	fmt.Fprintf(stdout, "Run `aileron skill bind %q` to supply this plan's credentials\n", res.Name)
 	return 0
 }

--- a/cmd/aileron/skill_install_oci_test.go
+++ b/cmd/aileron/skill_install_oci_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/flightplan/credreq"
 	"github.com/ALRubinger/aileron/internal/flightplan/pull"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 )
@@ -62,7 +64,7 @@ func TestRunSkillInstallOCIWritesFrozenAndLists(t *testing.T) {
 	})
 
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, &out, &errb); code != 0 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, strings.NewReader(""), &out, &errb); code != 0 {
 		t.Fatalf("install exit = %d, stderr=%s", code, errb.String())
 	}
 	if !strings.Contains(out.String(), "Installed frozen version v1abc") {
@@ -115,7 +117,7 @@ func TestRunSkillInstallOCISecondInstallIsNoOp(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		out.Reset()
 		errb.Reset()
-		if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, &out, &errb); code != 0 {
+		if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, strings.NewReader(""), &out, &errb); code != 0 {
 			t.Fatalf("install %d exit = %d, stderr=%s", i, code, errb.String())
 		}
 	}
@@ -136,7 +138,7 @@ func TestRunSkillInstallOCIPullErrorExits1(t *testing.T) {
 		return pull.Result{}, pull.ErrMissingArtifact
 	})
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "no published Flight Plan") {
@@ -152,7 +154,7 @@ func TestRunSkillInstallOCIMissingTagExits1(t *testing.T) {
 	})
 	var out, errb bytes.Buffer
 	// Force the OCI branch with a host-shaped ref; the fake returns the tag error.
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:x"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:x"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "tagged reference") {
@@ -168,7 +170,7 @@ func TestRunSkillInstallOCIUntrustedPublisherExits1(t *testing.T) {
 		return pull.Result{}, refusal
 	})
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "not trusted") {
@@ -191,7 +193,7 @@ func TestRunSkillInstallOCINotAnArtifactExits1(t *testing.T) {
 		return pull.Result{}, pull.ErrNotAnArtifact
 	})
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "does not resolve to a Flight Plan signed artifact") {
@@ -206,7 +208,7 @@ func TestRunSkillInstallOCINoNameExits1(t *testing.T) {
 		return pull.Result{}, pull.ErrNoName
 	})
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "declares no skill name") {
@@ -223,11 +225,102 @@ func TestRunSkillInstallOCIWriteErrorExits1(t *testing.T) {
 		return pull.Result{Frozen: installFrozen(""), Name: "rubber-duck"}, nil
 	})
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, &out, &errb); code != 1 {
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1"}, strings.NewReader(""), &out, &errb); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	if !strings.Contains(errb.String(), "write frozen version") {
 		t.Errorf("stderr = %q, want the write-frozen error", errb.String())
+	}
+}
+
+// withForcedTTY forces the interactive-terminal seam on so a test exercises the
+// auto-bind offer without a real TTY, restoring the package default (false, set
+// in main_test.go's init) afterwards.
+func withForcedTTY(t *testing.T) {
+	t.Helper()
+	orig := isTTYFn
+	isTTYFn = func() bool { return true }
+	t.Cleanup(func() { isTTYFn = orig })
+}
+
+// TestRunSkillInstallOCITTYDeclineKeepsPointer is the regression for the
+// interactive auto-bind offer (#2026): when a terminal is attached but the
+// operator declines with "n", the frozen/OCI install falls back to the same
+// `skill bind` pointer the non-interactive path prints and writes no binding
+// descriptor. Before the offer existed the install printed only the pointer; the
+// decline path must preserve exactly that behavior.
+func TestRunSkillInstallOCITTYDeclineKeepsPointer(t *testing.T) {
+	vault := &fakeBindVault{}
+	// withBindSeams sets up the temp store + descriptor path and canned reqs; the
+	// deriver would yield a real requirement if bind were reached, so a descriptor
+	// appearing proves the offer chained into bind.
+	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+	withSilentInstallVerifier(t)
+	withForcedTTY(t)
+	withFakePull(t, func(_ context.Context, _ pull.Options) (pull.Result, error) {
+		return pull.Result{Frozen: installFrozen("v1abc"), Name: "rubber-duck"}, nil
+	})
+
+	var out, errb bytes.Buffer
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, strings.NewReader("n\n"), &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	// The offer was made...
+	if !strings.Contains(out.String(), "Bind \"rubber-duck\"") {
+		t.Errorf("stdout = %q, want the interactive bind offer", out.String())
+	}
+	// ...declined, so the fallback pointer prints and nothing is bound.
+	if !strings.Contains(out.String(), `aileron skill bind "rubber-duck"`) {
+		t.Errorf("stdout = %q, want the bind pointer after declining", out.String())
+	}
+	if _, err := os.Stat(descPath); !os.IsNotExist(err) {
+		t.Errorf("descriptor %q exists (stat err=%v), want none written on decline", descPath, err)
+	}
+	if vault.puts != 0 {
+		t.Errorf("vault puts = %d, want 0 when the offer is declined", vault.puts)
+	}
+}
+
+// TestRunSkillInstallOCITTYAcceptChainsToBind proves the accept path (#2026):
+// with a terminal attached and the operator accepting (empty line = default
+// yes), the install chains straight into bind, which onboards the plan's declared
+// credentials and writes the binding descriptor. The fallback pointer must not
+// print once the operator accepted.
+func TestRunSkillInstallOCITTYAcceptChainsToBind(t *testing.T) {
+	vault := &fakeBindVault{}
+	descPath := withBindSeams(t, []credreq.RequiredBinding{sigv4Req("prod-reader", "athena.us-east-1.amazonaws.com")}, vault)
+	withSilentInstallVerifier(t)
+	withForcedTTY(t)
+	secretCalls := withSecret(t, "supersecret")
+	withFakePull(t, func(_ context.Context, _ pull.Options) (pull.Result, error) {
+		return pull.Result{Frozen: installFrozen("v1abc"), Name: "rubber-duck"}, nil
+	})
+
+	// Empty line accepts the [Y/n] default; the next line feeds bind's own
+	// access-key-id prompt, proving stdin bytes survive the offer's ReadString.
+	stdin := strings.NewReader("\nAKIAIOSFODNN7EXAMPLE\n")
+	var out, errb bytes.Buffer
+	if code := runSkillInstall([]string{"ghcr.io/acme/plan:v1abc"}, stdin, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, errb.String())
+	}
+	if *secretCalls != 1 {
+		t.Errorf("secret prompted %d times, want 1", *secretCalls)
+	}
+	if vault.puts != 1 || string(vault.services["prod-reader"]) != "supersecret" {
+		t.Errorf("vault = %+v, want one put of user/prod-reader=supersecret", vault.services)
+	}
+	// Bind wrote the descriptor for the plan's declared identity, using the key
+	// read from the shared stdin.
+	d := parseDescriptor(t, descPath)
+	if len(d.Bindings) != 1 || d.Bindings[0].IdentityLabel != "prod-reader" {
+		t.Fatalf("descriptor bindings = %+v, want one prod-reader entry", d.Bindings)
+	}
+	if d.Bindings[0].AccessKeyID != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("access_key_id = %q, want the key read from the shared stdin", d.Bindings[0].AccessKeyID)
+	}
+	// The fallback pointer must not print once the operator accepted.
+	if strings.Contains(out.String(), "to supply this plan's credentials") {
+		t.Errorf("stdout = %q, must not print the fallback pointer after accepting", out.String())
 	}
 }
 
@@ -241,7 +334,7 @@ func TestRunSkillInstallLocalPathStillWorks(t *testing.T) {
 	})
 	dir := writeSkillFile(t, instructionOnlySkillMd)
 	var out, errb bytes.Buffer
-	if code := runSkillInstall([]string{dir}, &out, &errb); code != 0 {
+	if code := runSkillInstall([]string{dir}, strings.NewReader(""), &out, &errb); code != 0 {
 		t.Fatalf("local install exit = %d, stderr=%s", code, errb.String())
 	}
 }

--- a/cmd/aileron/skill_test.go
+++ b/cmd/aileron/skill_test.go
@@ -100,7 +100,7 @@ func TestRunSkillInstall_InstructionOnly_Clean(t *testing.T) {
 	constructed := stubFetcher(t, nil, nil, errors.New("must not be reached"))
 
 	var stdout, stderr bytes.Buffer
-	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+	if code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
 	}
 	if *constructed {
@@ -133,7 +133,7 @@ func TestRunSkillInstall_CredentialedSatisfiable_NoWarning(t *testing.T) {
 	}, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+	if code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
 	}
 	if strings.Contains(stderr.String(), "warning") {
@@ -148,7 +148,7 @@ func TestRunSkillInstall_Unsatisfiable_WarnsButExits0(t *testing.T) {
 	stubFetcher(t, nil, nil, nil)
 
 	var stdout, stderr bytes.Buffer
-	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("unsatisfiable install must still exit 0, got %d", code)
 	}
@@ -167,7 +167,7 @@ func TestRunSkillInstall_DaemonDownInstructionOnly_Clean(t *testing.T) {
 	stubFetcher(t, nil, nil, errors.New("daemon down"))
 
 	var stdout, stderr bytes.Buffer
-	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+	if code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if strings.Contains(stderr.String(), "daemon") {
@@ -182,7 +182,7 @@ func TestRunSkillInstall_DaemonDownCredentialed_DegradesNotFails(t *testing.T) {
 	stubFetcher(t, nil, nil, errors.New("connection refused"))
 
 	var stdout, stderr bytes.Buffer
-	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("daemon-down credentialed install must degrade not fail, got %d", code)
 	}
@@ -226,7 +226,7 @@ func TestRunSkillList_Empty(t *testing.T) {
 
 func TestRunSkill_UnknownSubcommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := runSkill([]string{"frobnicate"}, &stdout, &stderr); code != 1 {
+	if code := runSkill([]string{"frobnicate"}, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("unknown subcommand exit = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "unknown skill command") {
@@ -238,11 +238,11 @@ func TestRunSkillInstall_RequiresExactlyOneSource(t *testing.T) {
 	withTempStore(t)
 	var stdout, stderr bytes.Buffer
 	// No source argument.
-	if code := runSkillInstall(nil, &stdout, &stderr); code != 1 {
+	if code := runSkillInstall(nil, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("no source exit = %d, want 1", code)
 	}
 	// Two sources.
-	if code := runSkillInstall([]string{"a", "b"}, &stdout, &stderr); code != 1 {
+	if code := runSkillInstall([]string{"a", "b"}, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("two sources exit = %d, want 1", code)
 	}
 }
@@ -250,7 +250,7 @@ func TestRunSkillInstall_RequiresExactlyOneSource(t *testing.T) {
 func TestRunSkillInstall_BadFlag(t *testing.T) {
 	withTempStore(t)
 	var stdout, stderr bytes.Buffer
-	if code := runSkillInstall([]string{"--nope"}, &stdout, &stderr); code != 1 {
+	if code := runSkillInstall([]string{"--nope"}, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("bad flag exit = %d, want 1", code)
 	}
 }
@@ -261,7 +261,7 @@ func TestRunSkillInstall_BadSourceError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	// A nonexistent local path that is not a git URL classifies as a slug,
 	// which is not wired, so install surfaces an error and exits 1.
-	if code := runSkillInstall([]string{"definitely/not/installed"}, &stdout, &stderr); code != 1 {
+	if code := runSkillInstall([]string{"definitely/not/installed"}, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("unresolvable source exit = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "error:") {
@@ -278,7 +278,7 @@ func TestNewSkillFetcher_DaemonUnreachableDegrades(t *testing.T) {
 	src := exampleSource(t)
 
 	var stdout, stderr bytes.Buffer
-	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	code := runSkillInstall([]string{src}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("daemon-unreachable credentialed install must degrade not fail, got %d, stderr=%s", code, stderr.String())
 	}
@@ -289,7 +289,7 @@ func TestNewSkillFetcher_DaemonUnreachableDegrades(t *testing.T) {
 
 func TestRunSkill_NoArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := runSkill(nil, &stdout, &stderr); code != 1 {
+	if code := runSkill(nil, strings.NewReader(""), &stdout, &stderr); code != 1 {
 		t.Errorf("no-args exit = %d, want 1", code)
 	}
 }

--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -49,10 +49,18 @@ An OCI install writes a frozen version, so it appears under `~/.aileron/skills/<
 
 ```
 Installed frozen version v1a2b3c4d5e6f of skill "weekly-metrics-digest" to /Users/you/.aileron/skills/weekly-metrics-digest/versions/v1a2b3c4d5e6f
+Bind "weekly-metrics-digest"'s declared credentials now? [Y/n]:
+```
+
+A frozen plan carries a signed trust contract, so the install can derive its credential requirements right away. When you run the install at a terminal, it offers to bind those credentials on the spot. Answering yes (the default) chains straight into `aileron skill bind` for the version it just wrote, so you onboard the plan's credentials in one step. Answering no prints the pointer instead:
+
+```
 Run `aileron skill bind "weekly-metrics-digest"` to supply this plan's credentials
 ```
 
-The version id is the frozen content-hash slug, so a re-install of the same published plan is a no-op that reuses the same directory. Install does not pull the plan's container image. The image pin recorded in the lockfile is resolved at `aileron skill launch`, not at install. The install prints a one-line pointer to `aileron skill bind` so you know how to onboard the plan's credentials next.
+The offer only appears at an interactive terminal. A non-interactive install (in CI, or with piped stdin) never blocks on the prompt and always prints the pointer, so a scripted install behaves exactly as before.
+
+The version id is the frozen content-hash slug, so a re-install of the same published plan is a no-op that reuses the same directory. Install does not pull the plan's container image. The image pin recorded in the lockfile is resolved at `aileron skill launch`, not at install.
 
 > Installing by an [agentskills.io](https://agentskills.io) registry slug is not supported. agentskills.io is a format spec, not a registry, so a slug has no canonical location to resolve against. Install from a local path, a git URL, or an OCI reference instead.
 


### PR DESCRIPTION
## Summary

On the OCI/frozen `aileron skill install` path, the install used to print a bare `Run aileron skill bind ...` pointer and stop, leaving credential onboarding as a second command the operator had to remember. This replaces that pointer with an interactive **"Bind this plan's credentials now? [Y/n]"** offer that chains straight into `runSkillBind`.

- `stdin` is threaded through `runSkill -> runSkillInstall -> runSkillInstallOCI`, mirroring `connector`/`action`/`binding` which already take `os.Stdin` (`main.go`).
- The prompt is gated on the existing `isTTYFn` seam, so non-interactive installs (CI, piped stdin) fall back to the pointer and never block.
- On yes/enter (default yes), bind runs for **exactly the just-written frozen id** via `--version res.Frozen.ID`, so a concurrent freeze cannot redirect the onboarding. On no/skip, the existing pointer prints and the install returns 0.
- The offer prompt and bind share one `*bufio.Reader`, so the bytes bind reads next (access key ids, etc.) survive the offer's `ReadString` rather than being buffered ahead into a throwaway reader and lost.
- Bind reuses the derive machinery (`credreq.DeriveFromFrozen`), whose existing zero-requirement and locked-vault handling cover the edge cases, so no new failure modes in install.

The **local/git install path is out of scope** (no signed trust contract pre-freeze) and keeps its freeze-then-bind pointer unchanged.

Docs: `docs/src/content/docs/guides/installing-a-skill.md` updated to describe the interactive auto-bind offer and the non-interactive fallback.

## Test plan

- `go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, `gofmt -l` clean.
- Full `go test ./cmd/aileron/` green.
- Existing OCI install tests keep the pointer behavior: the package `init()` in `main_test.go` forces `isTTYFn=false`, so they exercise the non-interactive fallback unchanged. ~20 mechanical `stdin` args added to `runSkillInstall`/`runSkill` call sites.
- New regression tests (verified fail-before / pass-after by stubbing the TTY branch off):
  - `TestRunSkillInstallOCITTYDeclineKeepsPointer` — `isTTYFn=true` + stdin `n\n`: asserts the offer is made, the pointer prints on decline, and no descriptor is written and no vault put happens.
  - `TestRunSkillInstallOCITTYAcceptChainsToBind` — `isTTYFn=true` + stdin `\nAKIA...\n`: asserts the empty line accepts the default, bind runs via the fake seams, the vault secret is stored, and the descriptor is written with the access key id read from the shared stdin (proving the buffer survives the offer prompt).

Closes #2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
