### PR TITLE
feat(flightplan): ergonomic install tags — default latest, key id off annotation

### DIFF
--- a/cmd/aileron/skill_install_oci.go
+++ b/cmd/aileron/skill_install_oci.go
@@ -64,7 +64,13 @@ func runSkillInstallOCI(ref string, stdin io.Reader, stdout, stderr io.Writer) i
 		case errors.Is(err, pull.ErrMissingVersionTag):
 			fmt.Fprintf(stderr, "error: %v; install a tagged reference like ghcr.io/owner/plan:<version>\n", err)
 		case errors.Is(err, pull.ErrNotAnArtifact):
+			// This ref resolves to a manifest with no Flight Plan artifactType:
+			// an image, or a GHCR `sha256-...` OCI referrers fallback tag. Point
+			// the operator at the signed plan's version coordinate instead.
 			fmt.Fprintf(stderr, "error: %v\n", err)
+			fmt.Fprintf(stderr, "hint: %q resolves to an image or an OCI referrers fallback tag (sha256-...), not the signed plan; "+
+				"install the plan's version tag, e.g. ghcr.io/owner/plan:<16-hex> (or omit the tag for :latest). "+
+				"The exact coordinate is the `artifact:` line printed by `aileron skill publish`.\n", ref)
 		case errors.Is(err, pull.ErrMissingArtifact):
 			fmt.Fprintf(stderr, "error: %v (no published Flight Plan at %q)\n", err, ref)
 		case errors.Is(err, pull.ErrNoName):

--- a/cmd/aileron/skill_install_oci_test.go
+++ b/cmd/aileron/skill_install_oci_test.go
@@ -199,6 +199,15 @@ func TestRunSkillInstallOCINotAnArtifactExits1(t *testing.T) {
 	if !strings.Contains(errb.String(), "does not resolve to a Flight Plan signed artifact") {
 		t.Errorf("stderr = %q, want the not-an-artifact message", errb.String())
 	}
+	// The error is actionable: it names the likely cause (an image / referrers
+	// fallback tag) and points at the plan's version coordinate and the
+	// `artifact:` line from publish.
+	msg := errb.String()
+	for _, want := range []string{"referrers fallback tag", "ghcr.io/owner/plan:<16-hex>", ":latest", "artifact:"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("stderr = %q, want the actionable hint to contain %q", msg, want)
+		}
+	}
 }
 
 func TestRunSkillInstallOCINoNameExits1(t *testing.T) {

--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -43,6 +43,14 @@ aileron skill install ghcr.io/acme/weekly-digest:v1a2b3c4d5e6f
 
 An OCI reference installs a Flight Plan that someone published with `aileron skill publish`. The reference has a registry host, a repository path, and a version tag. Aileron pulls the signed artifact (the frozen SKILL.md, its lockfile, the signature, and the author public key) from the registry over your existing Docker credentials.
 
+The version tag is optional. Omit it and Aileron installs the `latest` tag, which `aileron skill publish` always points at the newest published artifact:
+
+```sh
+aileron skill install ghcr.io/acme/weekly-digest
+```
+
+The 16-hex content-hash slug (for example `v1a2b3c4d5e6f`) is the canonical immutable coordinate. `latest` and any semver label the author froze with `aileron skill freeze --version` are mutable pointers that move as the author republishes. Whichever tag you install by, Aileron reads the content-hash slug from the artifact and keys the on-disk version off it, so an install by `latest` and an install by the matching content-hash tag land in the same directory and later launch identically. Pin the content-hash tag when you need a coordinate that never moves.
+
 The install verifies the artifact before anything lands on disk. It checks the author signature and the content hash, then the publisher-trust gate against your keyring, the same checks `aileron skill launch` runs. A tampered artifact fails the signature check. A plan from a publisher you have not trusted fails the trust gate. Either failure aborts the install and writes nothing to the store. A plan that declares no publisher installs on a valid signature alone.
 
 An OCI install writes a frozen version, so it appears under `~/.aileron/skills/<name>/versions/<id>/` and prints the version it installed:

--- a/docs/src/content/docs/guides/publishing-a-flight-plan.md
+++ b/docs/src/content/docs/guides/publishing-a-flight-plan.md
@@ -32,7 +32,18 @@ aileron skill publish <name> --registry <ref> [--version <id>]
 - `--registry` is the destination OCI repository, for example `ghcr.io/acme/my-plan`.
 - `--version` pins a specific frozen version id. Omit it to publish the newest.
 
-The published artifact is tagged at the version id, so the shareable reference is `<registry>:<version>`. That is the reference a second operator installs.
+The published artifact is tagged three ways. The 16-hex content-hash slug (the version id) is the canonical immutable coordinate, so the shareable reference is `<registry>:<version>`. Publish also (re)points the mutable `latest` tag at this newest artifact, and, when the frozen version carries a semver label (from `aileron skill freeze --version`), tags under that label too. A second operator can install by any of the three. Publish prints a copyable install hint with the content-hash coordinate:
+
+```
+published weekly-metrics-digest
+  image:    ghcr.io/acme/my-plan@sha256:…
+  artifact: ghcr.io/acme/my-plan:v1a2b3c4d5e6f (sha256:…)
+  binding:  config-digest
+Install with:
+  aileron skill install ghcr.io/acme/my-plan:v1a2b3c4d5e6f
+```
+
+If the semver label carries build metadata (a `+build` suffix) or any other character outside the OCI tag grammar, publish skips the semver tag with a warning and still publishes the content-hash and `latest` tags.
 
 ## Two binding kinds
 

--- a/internal/flightplan/publish/publish.go
+++ b/internal/flightplan/publish/publish.go
@@ -158,6 +158,9 @@ func run(ctx context.Context, opts Options) (Result, error) {
 	if opts.Stdout == nil {
 		opts.Stdout = io.Discard
 	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
 	if len(opts.Lock.ResolvedImages) == 0 {
 		return Result{}, ErrNoImage
 	}
@@ -212,9 +215,33 @@ func run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("publish: pack signed artifact: %w", err)
 	}
 
-	// 4. Tag the artifact so `skill install <registry>:<version>` resolves it.
+	// 4. Tag the artifact. The 16-hex content-hash slug (VersionID) is the
+	//    canonical immutable coordinate `skill install <registry>:<version>`
+	//    resolves. Additionally (re)point the mutable `latest` tag at this newest
+	//    artifact, and — when the frozen version carries a semver label — tag
+	//    under it too, so install can default to `latest` or resolve a
+	//    human-facing version. A moving tag records the content-hash slug in the
+	//    manifest's version annotation, so install keys the on-disk id off that
+	//    resolved slug rather than the mutable tag (which would break launch's
+	//    `<versionTag>-image` resolution and the no-op re-install).
 	if err := target.Tag(ctx, artifactDesc, opts.VersionID); err != nil {
 		return Result{}, fmt.Errorf("publish: tag artifact %s: %w", opts.VersionID, err)
+	}
+	if err := target.Tag(ctx, artifactDesc, "latest"); err != nil {
+		return Result{}, fmt.Errorf("publish: tag artifact latest: %w", err)
+	}
+	if label := opts.Lock.Version; label != "" {
+		// A semver `+build` metadata suffix (or any other character outside the
+		// OCI tag grammar) is not a legal tag. Skip the semver tag with a warning
+		// rather than hard-failing an otherwise-valid publish; the content-hash
+		// and latest tags still land.
+		if isValidOCITag(label) {
+			if err := target.Tag(ctx, artifactDesc, label); err != nil {
+				return Result{}, fmt.Errorf("publish: tag artifact %s: %w", label, err)
+			}
+		} else {
+			fmt.Fprintf(opts.Stderr, "warning: version label %q is not a valid OCI tag; skipping the semver tag (content-hash and latest tags still published)\n", label)
+		}
 	}
 
 	res := Result{
@@ -224,8 +251,11 @@ func run(ctx context.Context, opts Options) (Result, error) {
 		ArtifactDigest: artifactDesc.Digest.String(),
 		BindingKind:    bindingKind,
 	}
-	fmt.Fprintf(opts.Stdout, "published %s\n  image:    %s\n  artifact: %s (%s)\n  binding:  %s\n",
-		opts.Name, res.ImageRef, res.ArtifactRef, res.ArtifactDigest, res.BindingKind)
+	// Print the content-hash ArtifactRef as the source-of-truth install
+	// coordinate, plus a copyable install hint so the operator can hand the exact
+	// command to a second machine.
+	fmt.Fprintf(opts.Stdout, "published %s\n  image:    %s\n  artifact: %s (%s)\n  binding:  %s\nInstall with:\n  aileron skill install %s\n",
+		opts.Name, res.ImageRef, res.ArtifactRef, res.ArtifactDigest, res.BindingKind, res.ArtifactRef)
 	return res, nil
 }
 
@@ -326,6 +356,19 @@ func publishForeignBase(ctx context.Context, opts Options, pin freeze.ImagePin, 
 // anchors keep the numeric codes from misfiring on a digit run inside a digest,
 // size, or port that merely contains "401"/"403".
 var authScopeSignal = regexp.MustCompile(`(?i)\b(401|403|unauthorized|forbidden|denied|insufficient_scope|scopes)\b`)
+
+// ociTagPattern is the OCI distribution-spec tag grammar: an initial
+// [A-Za-z0-9_] followed by up to 127 of [A-Za-z0-9._-]. A semver `+build`
+// metadata suffix contains `+`, which is outside this set, so a version label
+// carrying build metadata is deliberately rejected as a tag.
+var ociTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
+
+// isValidOCITag reports whether label is a legal OCI tag, so publish can tag a
+// frozen version's semver label safely and skip an illegal one with a warning
+// rather than failing the whole publish.
+func isValidOCITag(label string) bool {
+	return ociTagPattern.MatchString(label)
+}
 
 // annotateRegistryAuthError wraps an auth/scope registry failure with an
 // actionable hint naming the registry host (and, for ghcr.io, the exact

--- a/internal/flightplan/publish/publish_test.go
+++ b/internal/flightplan/publish/publish_test.go
@@ -503,6 +503,49 @@ func TestRunInvalidSemverLabelWarnsAndSkips(t *testing.T) {
 	}
 }
 
+// tagFailTarget wraps a memory store but fails Tag for the tag named failOn,
+// standing in for a registry that rejects a specific tag write.
+type tagFailTarget struct {
+	*memory.Store
+	failOn string
+}
+
+func (t tagFailTarget) Tag(ctx context.Context, desc ocispec.Descriptor, ref string) error {
+	if ref == t.failOn {
+		return errors.New("registry rejected tag " + ref)
+	}
+	return t.Store.Tag(ctx, desc, ref)
+}
+
+// TestRunLatestTagError proves a failure writing the mutable `latest` tag
+// surfaces as a publish error rather than being swallowed.
+func TestRunLatestTagError(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	body := ociConfigBody(t, "composed")
+	seedComposedTarget(t, inner, "v1", body)
+	opts := composedOptions(inner, body)
+	opts.Target = tagFailTarget{Store: inner, failOn: "latest"}
+	if _, err := Run(ctx, opts); err == nil || !strings.Contains(err.Error(), "tag artifact latest") {
+		t.Fatalf("err = %v, want a tag-artifact-latest error", err)
+	}
+}
+
+// TestRunSemverTagError proves a failure writing a valid semver label tag
+// surfaces as a publish error.
+func TestRunSemverTagError(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	body := ociConfigBody(t, "composed")
+	seedComposedTarget(t, inner, "v1", body)
+	opts := composedOptions(inner, body)
+	opts.Lock.Version = "1.2.3"
+	opts.Target = tagFailTarget{Store: inner, failOn: "1.2.3"}
+	if _, err := Run(ctx, opts); err == nil || !strings.Contains(err.Error(), "tag artifact 1.2.3") {
+		t.Fatalf("err = %v, want a tag-artifact-1.2.3 error", err)
+	}
+}
+
 func TestRunNoImage(t *testing.T) {
 	_, err := Run(context.Background(), Options{
 		Name: "demo", VersionID: "v1", Registry: "example.com/demo",

--- a/internal/flightplan/publish/publish_test.go
+++ b/internal/flightplan/publish/publish_test.go
@@ -417,6 +417,92 @@ func TestRunIdempotentReferrerDigest(t *testing.T) {
 	}
 }
 
+// TestRunTagsLatestAndSemver is the ergonomics regression (#2027): after a run,
+// the mutable `latest` tag, the (valid) semver label, and the canonical
+// content-hash tag all resolve to the SAME artifact descriptor.
+func TestRunTagsLatestAndSemver(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	body := ociConfigBody(t, "composed")
+	seedComposedTarget(t, target, "v1", body)
+
+	opts := composedOptions(target, body)
+	opts.Lock.Version = "1.2.3" // a legal OCI tag
+	res, err := Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, tag := range []string{"v1", "latest", "1.2.3"} {
+		desc, err := target.Resolve(ctx, tag)
+		if err != nil {
+			t.Fatalf("resolve %q: %v", tag, err)
+		}
+		if desc.Digest.String() != res.ArtifactDigest {
+			t.Errorf("tag %q resolves to %q, want the artifact digest %q", tag, desc.Digest, res.ArtifactDigest)
+		}
+	}
+}
+
+// TestRunNoSemverLabelTagsLatestOnly proves that with no semver label set, only
+// the content-hash and `latest` tags are written (no spurious empty tag).
+func TestRunNoSemverLabelTagsLatestOnly(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	body := ociConfigBody(t, "composed")
+	seedComposedTarget(t, target, "v1", body)
+
+	res, err := Run(ctx, composedOptions(target, body)) // Lock.Version is empty
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, tag := range []string{"v1", "latest"} {
+		desc, err := target.Resolve(ctx, tag)
+		if err != nil {
+			t.Fatalf("resolve %q: %v", tag, err)
+		}
+		if desc.Digest.String() != res.ArtifactDigest {
+			t.Errorf("tag %q resolves to %q, want %q", tag, desc.Digest, res.ArtifactDigest)
+		}
+	}
+}
+
+// TestRunInvalidSemverLabelWarnsAndSkips proves an invalid semver label (semver
+// `+build` metadata is not a legal OCI tag) is skipped with a stderr warning
+// rather than failing publish; the content-hash and `latest` tags still land.
+func TestRunInvalidSemverLabelWarnsAndSkips(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	body := ociConfigBody(t, "composed")
+	seedComposedTarget(t, target, "v1", body)
+
+	opts := composedOptions(target, body)
+	opts.Lock.Version = "1.2.3+build.5" // '+' is outside the OCI tag grammar
+	var errb bytes.Buffer
+	opts.Stderr = &errb
+
+	res, err := Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("an invalid semver label must not fail publish: %v", err)
+	}
+	// The illegal label must NOT have been tagged.
+	if _, err := target.Resolve(ctx, "1.2.3+build.5"); err == nil {
+		t.Error("the invalid semver label was tagged; want it skipped")
+	}
+	// The valid tags still resolve.
+	for _, tag := range []string{"v1", "latest"} {
+		desc, err := target.Resolve(ctx, tag)
+		if err != nil {
+			t.Fatalf("resolve %q: %v", tag, err)
+		}
+		if desc.Digest.String() != res.ArtifactDigest {
+			t.Errorf("tag %q resolves to %q, want %q", tag, desc.Digest, res.ArtifactDigest)
+		}
+	}
+	if !strings.Contains(errb.String(), "not a valid OCI tag") {
+		t.Errorf("stderr = %q, want a warning that the label is not a valid OCI tag", errb.String())
+	}
+}
+
 func TestRunNoImage(t *testing.T) {
 	_, err := Run(context.Background(), Options{
 		Name: "demo", VersionID: "v1", Registry: "example.com/demo",

--- a/internal/flightplan/pull/pull.go
+++ b/internal/flightplan/pull/pull.go
@@ -42,10 +42,11 @@ import (
 // unauthenticated registry access surfaces as the wrapped oras Resolve/Fetch
 // error, which the CLI maps to a precise message.
 var (
-	// ErrMissingVersionTag is returned when the install ref carries no tag (or
-	// only a digest). The store version id must be a single path segment (the
-	// freeze content-hash slug that publish tagged the artifact under), so an
-	// untagged ref cannot yield a version id.
+	// ErrMissingVersionTag is returned when the install ref carries only a digest
+	// (@sha256:…). A digest is not a version tag, and the store version id is
+	// keyed off the artifact's resolved content-hash annotation, not a digest. An
+	// omitted tag is NOT an error: it defaults to `latest` (publish always points
+	// `latest` at the newest artifact).
 	ErrMissingVersionTag = errors.New("pull: OCI reference has no version tag")
 	// ErrNotAnArtifact is returned when the resolved manifest is not a Flight
 	// Plan signed artifact (its artifactType is not freeze.ArtifactType).
@@ -91,8 +92,10 @@ type Options struct {
 // Result reports what a pull run resolved and verified.
 type Result struct {
 	// Frozen is the four artifact bytes as a store.FrozenVersion. Its ID is the
-	// ref's tag (the freeze content-hash slug), so store.WriteFrozen lands it in
-	// the same content-addressed directory a local freeze would.
+	// freeze content-hash slug read from the artifact manifest's version
+	// annotation (falling back to the literal tag only when the annotation is
+	// absent), so a moving tag like `latest` still lands in the same
+	// content-addressed directory a local freeze would.
 	Frozen store.FrozenVersion
 	// Lock is the parsed standalone lockfile (the image pin carried into the
 	// store untouched, resolved lazily at launch).
@@ -110,8 +113,10 @@ type Result struct {
 	// (#1903) knows where to pull the published image; it is a fetch coordinate,
 	// never a verification trust anchor.
 	SourceRegistry string
-	// SourceTag is the version tag the artifact resolved under (the freeze slug
-	// that is also the store version id). Persisted alongside SourceRegistry.
+	// SourceTag is the RESOLVED freeze content-hash slug the artifact carries in
+	// its version annotation (== the store version id), NOT the literal install
+	// tag. Persisted alongside SourceRegistry as the origin launch resolves the
+	// composed image under (ComposedImageTag(SourceTag)).
 	SourceTag string
 }
 
@@ -130,9 +135,15 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("pull: parse reference %q: %w", opts.Ref, err)
 	}
 	tag := ref.Reference
-	// A digest-only reference (@sha256:…) is not a version tag; a valid version
-	// id must be a single path segment (the freeze slug publish tagged under).
-	if tag == "" || isDigestReference(tag) {
+	// An omitted tag defaults to `latest`, the mutable tag publish always points
+	// at the newest artifact. A digest-only reference (@sha256:…) is still not a
+	// version tag: the on-disk version id is keyed off the artifact's resolved
+	// content-hash annotation, and a digest carries no such coordinate to install
+	// or later launch by.
+	if tag == "" {
+		tag = "latest"
+	}
+	if isDigestReference(tag) {
 		return Result{}, fmt.Errorf("%w: %q", ErrMissingVersionTag, opts.Ref)
 	}
 
@@ -174,7 +185,13 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		Name:           name,
 		Verified:       verified,
 		SourceRegistry: ref.Registry + "/" + ref.Repository,
-		SourceTag:      tag,
+		// SourceTag is the RESOLVED content-hash slug (fv.ID), not the literal
+		// install tag. Persisting the resolved slug is load-bearing: launch
+		// resolves the composed image via ComposedImageTag(Origin.VersionTag) =
+		// `<slug>-image`, which publish pushes under the content-hash slug. Keying
+		// the origin off a moving tag like `latest` would make launch look for a
+		// non-existent `latest-image`.
+		SourceTag: fv.ID,
 	}, nil
 }
 
@@ -227,7 +244,18 @@ func fetchArtifact(ctx context.Context, src oras.ReadOnlyTarget, tag string) (st
 		}
 		return b, nil
 	}
-	fv := store.FrozenVersion{ID: tag}
+	// Key the on-disk version id off the manifest's content-hash version
+	// annotation, never the literal (possibly moving) tag. This keeps a `latest`
+	// or semver install landing in the same content-addressed directory a local
+	// freeze would, and keeps the persisted origin's VersionTag pointing at the
+	// slug launch resolves the composed image under. Fall back to the literal tag
+	// only when the annotation is absent (a pre-annotation or hand-built
+	// artifact).
+	resolvedID := tag
+	if v := m.Annotations[freeze.AnnotationVersion]; v != "" {
+		resolvedID = v
+	}
+	fv := store.FrozenVersion{ID: resolvedID}
 	if fv.SkillMD, err = get(freeze.MediaTypeSkillMD); err != nil {
 		return store.FrozenVersion{}, freeze.Lockfile{}, err
 	}

--- a/internal/flightplan/pull/pull_test.go
+++ b/internal/flightplan/pull/pull_test.go
@@ -91,10 +91,21 @@ func mintArtifact(t *testing.T, publisher string) (freeze.Result, string) {
 }
 
 // seedArtifact pushes the four signed-artifact layers and a referrers manifest
-// tagged at tag into st, mirroring how publish writes the artifact. layers lets
+// tagged at tag into st, mirroring how publish writes the artifact. It records
+// tag as the manifest's content-hash version annotation, so a straightforward
+// content-hash-tag install resolves the same id via the annotation. layers lets
 // a test omit or corrupt a specific media type; artifactType lets a test push a
 // wrong type. It returns the manifest descriptor.
 func seedArtifact(t *testing.T, st *memory.Store, tag, artifactType string, layers map[string][]byte) ocispec.Descriptor {
+	t.Helper()
+	return seedArtifactVersioned(t, st, tag, tag, artifactType, layers)
+}
+
+// seedArtifactVersioned is seedArtifact with an explicit content-hash version
+// annotation distinct from the tag, so a test can seed a MOVING tag (latest, a
+// semver) whose manifest still carries the immutable content-hash slug. An empty
+// version omits the annotation, exercising the literal-tag fallback.
+func seedArtifactVersioned(t *testing.T, st *memory.Store, tag, version, artifactType string, layers map[string][]byte) ocispec.Descriptor {
 	t.Helper()
 	ctx := context.Background()
 	var descs []ocispec.Descriptor
@@ -105,12 +116,17 @@ func seedArtifact(t *testing.T, st *memory.Store, tag, artifactType string, laye
 		}
 		descs = append(descs, d)
 	}
+	var annotations map[string]string
+	if version != "" {
+		annotations = map[string]string{freeze.AnnotationVersion: version}
+	}
 	m := ocispec.Manifest{
 		Versioned:    specs.Versioned{SchemaVersion: 2},
 		MediaType:    ocispec.MediaTypeImageManifest,
 		ArtifactType: artifactType,
 		Config:       ocispec.DescriptorEmptyJSON,
 		Layers:       descs,
+		Annotations:  annotations,
 	}
 	// The empty config blob must be present for FetchAll traversal parity.
 	if err := st.Push(ctx, ocispec.DescriptorEmptyJSON, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data)); err != nil {
@@ -309,10 +325,66 @@ func TestRunWrongArtifactType(t *testing.T) {
 	}
 }
 
-func TestRunNoTagIsMissingVersionTag(t *testing.T) {
-	_, err := Run(context.Background(), Options{Ref: "localhost:5000/demo", Source: memory.New()})
-	if !errors.Is(err, ErrMissingVersionTag) {
-		t.Fatalf("err = %v, want ErrMissingVersionTag", err)
+// TestRunNoTagResolvesLatest is the ergonomics regression (#2027): an install
+// ref with NO tag no longer errors; it defaults to the mutable `latest` tag
+// publish always points at the newest artifact, and the on-disk id resolves to
+// the content-hash slug carried in the manifest's version annotation.
+func TestRunNoTagResolvesLatest(t *testing.T) {
+	res, slug := mintArtifact(t, "")
+	st := memory.New()
+	// Publish points `latest` at the newest artifact; its version annotation is
+	// the immutable content-hash slug.
+	seedArtifactVersioned(t, st, "latest", slug, freeze.ArtifactType, allLayers(res))
+
+	got, err := Run(context.Background(), Options{Ref: "localhost:5000/demo", Source: st})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Frozen.ID != slug {
+		t.Errorf("frozen id = %q, want the resolved content-hash slug %q (not the moving tag)", got.Frozen.ID, slug)
+	}
+	if got.SourceTag != slug {
+		t.Errorf("source tag = %q, want the resolved slug %q (launch resolves the image under it)", got.SourceTag, slug)
+	}
+}
+
+// TestRunMovingTagKeysOffAnnotation proves a moving tag (latest or a semver
+// label) whose manifest annotation carries a DISTINCT content-hash slug yields
+// Frozen.ID and SourceTag equal to the annotation value, never the literal tag.
+// Keying the on-disk id and persisted origin off the annotation is what keeps
+// launch's `<slug>-image` resolution and the no-op re-install working.
+func TestRunMovingTagKeysOffAnnotation(t *testing.T) {
+	for _, movingTag := range []string{"latest", "1.4.2"} {
+		res, slug := mintArtifact(t, "")
+		st := memory.New()
+		seedArtifactVersioned(t, st, movingTag, slug, freeze.ArtifactType, allLayers(res))
+
+		got, err := Run(context.Background(), Options{Ref: "localhost:5000/demo:" + movingTag, Source: st})
+		if err != nil {
+			t.Fatalf("Run[%s]: %v", movingTag, err)
+		}
+		if got.Frozen.ID != slug {
+			t.Errorf("[%s] frozen id = %q, want the annotation slug %q, not the moving tag", movingTag, got.Frozen.ID, slug)
+		}
+		if got.SourceTag != slug {
+			t.Errorf("[%s] source tag = %q, want the annotation slug %q, not the moving tag", movingTag, got.SourceTag, slug)
+		}
+	}
+}
+
+// TestRunNoAnnotationFallsBackToTag proves a manifest without a version
+// annotation (a pre-annotation or hand-built artifact) still installs, keying
+// the id off the literal tag.
+func TestRunNoAnnotationFallsBackToTag(t *testing.T) {
+	res, tag := mintArtifact(t, "")
+	st := memory.New()
+	seedArtifactVersioned(t, st, tag, "", freeze.ArtifactType, allLayers(res)) // no annotation
+	got, err := Run(context.Background(), Options{Ref: "localhost:5000/demo:" + tag, Source: st})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Frozen.ID != tag {
+		t.Errorf("frozen id = %q, want the literal tag %q via fallback", got.Frozen.ID, tag)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes `aileron skill install <oci-ref>` tag semantics ergonomic per the operator-cleared option (c) in feedback #2027, across the Flight Plan publish/install surface.

- **publish** now (re)points a mutable `latest` tag at the newest artifact and, when the frozen version carries a semver label (`freeze --version` → `Lock.Version`), also tags under it. The label is validated against the OCI tag grammar (`[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`); an invalid label (e.g. semver `+build` metadata) is skipped with a stderr warning rather than hard-failing publish. The 16-hex content-hash slug remains the canonical immutable tag.
- **publish** prints a copyable `Install with:` hint using the content-hash `ArtifactRef` as the source of truth, alongside the existing `artifact:` line.
- **install** defaults an omitted tag to `latest`. A digest-only ref (`@sha256:...`) is still rejected via `isDigestReference`.
- **install** keys the on-disk version id off the manifest's content-hash version annotation (`ai.aileron.flightplan.version`), falling back to the literal tag only when the annotation is absent, and persists `SourceTag = fv.ID` (the resolved slug). This is load-bearing: launch resolves the composed image via `ComposedImageTag(Origin.VersionTag) = <slug>-image`, which publish pushes under the content-hash slug. Keying the origin off a moving tag like `latest` would make launch look for a non-existent `latest-image` and break the no-op re-install.
- **install** ErrNotAnArtifact is now actionable: it names the likely cause (an image or a GHCR `sha256-...` referrers fallback tag) and points at the plan's version coordinate and the `artifact:` line from `aileron skill publish`.
- Docs: the install and publish guides note that `latest` is the default and the 16-hex content-hash is the canonical immutable coordinate.

No OpenAPI/spec change (CLI + flightplan only).

## Test plan

- `pull`: omitted tag resolves `latest`; a moving `latest`/semver tag whose manifest annotation carries a distinct content-hash yields `Frozen.ID` and `SourceTag` == the annotation slug (not the moving tag); a manifest without the annotation falls back to the literal tag; `TestRunDigestOnlyRefIsMissingVersionTag` retained. The `seedArtifact` helper now records the version annotation (via `seedArtifactVersioned`).
- `publish`: after a run, `latest`, a valid semver label, and the content-hash tag all resolve to the same artifact descriptor; a `+build` label warns and is skipped without failing publish; no spurious empty tag when no label is set.
- CLI: the ErrNotAnArtifact path emits the actionable hint (cause, version-coordinate example, `:latest` note, `artifact:` reference).
- `go build`, `go vet`, `gofmt -l`, and `go test ./internal/flightplan/... ./cmd/aileron/...` all green.

Closes #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCI installs now work without an explicit tag, defaulting to `latest`.
  * Published artifacts are now tagged with both `latest` and the immutable content-hash version, with optional semver labels when valid.

* **Bug Fixes**
  * Improved install errors with a clearer hint for choosing the correct version tag.
  * Publishing now skips invalid tag labels instead of failing, while still completing the upload.

* **Documentation**
  * Expanded install and publishing guides with clearer tagging behavior and example commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->