### PR TITLE
fix(skill): actionable cross-arch no-matching-manifest launch error

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -4,17 +4,76 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	stdruntime "runtime"
 	"sort"
+	"strings"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
 )
+
+// hostPlatform reports this host's container platform as GOOS/GOARCH (for
+// example "linux/amd64"). It is a package-level seam so the cross-arch launch
+// error test drives a deterministic platform independent of the test host's
+// real architecture.
+var hostPlatform = func() string { return stdruntime.GOOS + "/" + stdruntime.GOARCH }
+
+// prefixCaptureWriter tees writes to an underlying writer while recording a
+// bounded prefix of the bytes for later inspection. The docker daemon emits the
+// no-matching-manifest error at container-create, before any plan output, so a
+// bounded prefix reliably contains the classification signal while keeping
+// memory bounded on long successful runs. Writes always pass through to w in
+// full; only the recorded copy is capped.
+type prefixCaptureWriter struct {
+	w   io.Writer
+	max int
+	buf []byte
+}
+
+func (p *prefixCaptureWriter) Write(b []byte) (int, error) {
+	if remaining := p.max - len(p.buf); remaining > 0 {
+		if len(b) <= remaining {
+			p.buf = append(p.buf, b...)
+		} else {
+			p.buf = append(p.buf, b[:remaining]...)
+		}
+	}
+	return p.w.Write(b)
+}
+
+// captured returns the recorded prefix as a string.
+func (p *prefixCaptureWriter) captured() string { return string(p.buf) }
+
+// crossArchStderrCaptureMax bounds the recorded stderr prefix. The manifest
+// error is short and emitted first, so 64 KiB is generous headroom while
+// keeping the capture memory-bounded regardless of run length.
+const crossArchStderrCaptureMax = 64 * 1024
+
+// crossArchManifestMessage classifies a launch run error as a cross-arch
+// manifest miss and, when it matches, returns an actionable operator message.
+// The robust signal is the docker daemon's "no matching manifest for" stderr
+// text, captured from the run's stderr, not the returned error (which carries
+// only "exit status 125", a generic docker-daemon failure that would over-match
+// on exit code alone). The match is case-insensitive and tolerant of
+// surrounding daemon text. When the signal is absent it returns ("", false) so
+// the caller falls through to the generic wrap unchanged.
+func crossArchManifestMessage(image, capturedStderr, platform string) (string, bool) {
+	if !strings.Contains(strings.ToLower(capturedStderr), "no matching manifest for") {
+		return "", false
+	}
+	msg := fmt.Sprintf("skill launch: the pinned image %q has no build for this host's platform %s. "+
+		"The publisher must publish an image that includes a build for %s. "+
+		"This is a gap in what the publisher shipped, not a problem with your local configuration.",
+		image, platform, platform)
+	return msg, true
+}
 
 // containerImageRunner is the production runtime.ImageRunner: it boots the
 // verified pinned environment image and runs the frozen Flight Plan inside it
@@ -302,7 +361,17 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		}
 	}
 
-	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, os.Stderr, opts); err != nil {
+	// Tee the container's stderr so the run-error boundary can classify a
+	// cross-arch manifest miss. The docker daemon writes "no matching manifest
+	// for <platform> …" to stderr but returns only "exit status 125" as the
+	// error, so the specific signal lives in the captured text, not the error.
+	// Pass-through to os.Stderr is preserved in full; only the recorded prefix
+	// is bounded.
+	stderrCapture := &prefixCaptureWriter{w: os.Stderr, max: crossArchStderrCaptureMax}
+	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, stderrCapture, opts); err != nil {
+		if msg, ok := crossArchManifestMessage(spec.Image, stderrCapture.captured(), hostPlatform()); ok {
+			return runtime.ImageRunResult{}, errors.New(msg)
+		}
 		return runtime.ImageRunResult{}, fmt.Errorf("skill launch: run pinned image %q: %w", spec.Image, err)
 	}
 

--- a/cmd/aileron/skill_launch_crossarch_test.go
+++ b/cmd/aileron/skill_launch_crossarch_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// stubCrossArchBoot swaps the single real-Docker call site for a recorder that
+// writes stderrText to the stderr writer it is handed and returns runErr, so a
+// cross-arch manifest miss (daemon stderr text + a generic exit-125 error) is
+// reproducible with no live runtime. It also pins the CLI-version-skew preflight
+// to "" and the host operator id to a fixed value so every Run stays Docker-free
+// and deterministic, and records the writer it was given so the pass-through
+// contract is assertable. The recorded writer is returned via gotStderr.
+func stubCrossArchBoot(t *testing.T, stderrText string, runErr error, gotStderr *io.Writer) {
+	t.Helper()
+	stubBakedCLIVersion(t, "")
+	origActor := operatorActorID
+	operatorActorID = func() string { return stubHostOperatorID }
+	t.Cleanup(func() { operatorActorID = origActor })
+	orig := containerRunFlightPlan
+	containerRunFlightPlan = func(_ context.Context, _ string, _, stderr io.Writer, _ sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
+		if gotStderr != nil {
+			*gotStderr = stderr
+		}
+		if stderrText != "" {
+			_, _ = io.WriteString(stderr, stderrText)
+		}
+		return sandboxcontainer.RunResult{}, runErr
+	}
+	t.Cleanup(func() { containerRunFlightPlan = orig })
+}
+
+// stubHostPlatform pins the hostPlatform seam so the cross-arch message names a
+// deterministic platform independent of the test host's real architecture.
+func stubHostPlatform(t *testing.T, platform string) {
+	t.Helper()
+	orig := hostPlatform
+	hostPlatform = func() string { return platform }
+	t.Cleanup(func() { hostPlatform = orig })
+}
+
+func crossArchSpec(t *testing.T) runtime.ImageRunSpec {
+	t.Helper()
+	origStore := skillStoreDir
+	skillStoreDir = t.TempDir()
+	t.Cleanup(func() { skillStoreDir = origStore })
+	return runtime.ImageRunSpec{
+		Image:   "registry.example.com/runner:1.4@sha256:abc",
+		Name:    "weekly-metrics-digest",
+		Version: "1.0.0",
+	}
+}
+
+// TestCrossArch_ManifestMissRewritesError is the feature happy path: a realistic
+// daemon "no matching manifest for …" stderr line plus a generic exit-125 error
+// is rewritten into an actionable message that names the host platform and the
+// publisher's responsibility, and does not lead with the raw daemon/exit text.
+func TestCrossArch_ManifestMissRewritesError(t *testing.T) {
+	spec := crossArchSpec(t)
+	stubHostPlatform(t, "linux/amd64")
+	stubCrossArchBoot(t,
+		"docker: no matching manifest for linux/amd64 in the manifest list entries: no match for platform in manifest: not found\n",
+		errors.New("exit status 125"), nil)
+
+	_, err := containerImageRunner{}.Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("Run: expected an error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "linux/amd64") {
+		t.Errorf("message does not name the host platform: %q", msg)
+	}
+	if !strings.Contains(msg, "publisher must publish") {
+		t.Errorf("message lacks the publisher-must-publish guidance: %q", msg)
+	}
+	if !strings.Contains(msg, spec.Image) {
+		t.Errorf("message does not name the pinned image: %q", msg)
+	}
+	if strings.HasPrefix(msg, "no matching manifest") || strings.HasPrefix(msg, "exit status 125") {
+		t.Errorf("message leads with the raw daemon/exit text: %q", msg)
+	}
+	if strings.Contains(msg, "exit status 125") {
+		t.Errorf("message should not carry the uninformative exit status: %q", msg)
+	}
+}
+
+// TestCrossArch_UnrelatedFailureUnchanged proves no false rewrite: an unrelated
+// stderr line and an unrelated error fall through to the generic wrap unchanged.
+func TestCrossArch_UnrelatedFailureUnchanged(t *testing.T) {
+	spec := crossArchSpec(t)
+	stubHostPlatform(t, "linux/amd64")
+	stubCrossArchBoot(t, "some unrelated daemon noise\n", errors.New("some other failure"), nil)
+
+	_, err := containerImageRunner{}.Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("Run: expected an error, got nil")
+	}
+	want := `skill launch: run pinned image "registry.example.com/runner:1.4@sha256:abc": some other failure`
+	if err.Error() != want {
+		t.Errorf("generic wrap changed:\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+// TestCrossArch_ExitCodeAloneDoesNotOverMatch guards against exit-code-only
+// matching: an exit-125 failure with no manifest text must NOT be rewritten.
+func TestCrossArch_ExitCodeAloneDoesNotOverMatch(t *testing.T) {
+	spec := crossArchSpec(t)
+	stubHostPlatform(t, "linux/amd64")
+	stubCrossArchBoot(t,
+		"docker: Error response from daemon: could not select device driver\n",
+		errors.New("exit status 125"), nil)
+
+	_, err := containerImageRunner{}.Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("Run: expected an error, got nil")
+	}
+	if strings.Contains(err.Error(), "publisher must publish") {
+		t.Errorf("exit-125 without manifest text was wrongly rewritten: %q", err.Error())
+	}
+	want := `skill launch: run pinned image "registry.example.com/runner:1.4@sha256:abc": exit status 125`
+	if err.Error() != want {
+		t.Errorf("generic wrap changed:\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+// TestCrossArch_SignalMatchIsCaseInsensitive confirms the classifier tolerates
+// casing and surrounding daemon text, matching on the substring alone.
+func TestCrossArch_SignalMatchIsCaseInsensitive(t *testing.T) {
+	spec := crossArchSpec(t)
+	stubHostPlatform(t, "linux/arm64")
+	stubCrossArchBoot(t,
+		"DOCKER: NO MATCHING MANIFEST FOR linux/arm64 in the manifest list entries\n",
+		errors.New("exit status 125"), nil)
+
+	_, err := containerImageRunner{}.Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("Run: expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "linux/arm64") || !strings.Contains(err.Error(), "publisher must publish") {
+		t.Errorf("case-insensitive signal was not classified: %q", err.Error())
+	}
+}
+
+// TestCrossArch_StderrPassThroughPreserved confirms the capture tee forwards the
+// full stderr text to the writer the runner is handed, so terminal output is
+// unaffected regardless of classification.
+func TestCrossArch_StderrPassThroughPreserved(t *testing.T) {
+	spec := crossArchSpec(t)
+	stubHostPlatform(t, "linux/amd64")
+	var got io.Writer
+	line := "docker: no matching manifest for linux/amd64 in the manifest list entries: not found\n"
+	stubCrossArchBoot(t, line, errors.New("exit status 125"), &got)
+
+	// The runner writes to os.Stderr in production; the tee wraps it. We assert
+	// the stub received a writer and that writing to it reaches the underlying
+	// sink by exercising a fresh capture writer with a buffer sink directly.
+	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err == nil {
+		t.Fatal("Run: expected an error, got nil")
+	}
+	if got == nil {
+		t.Fatal("runner was not handed a stderr writer")
+	}
+
+	// Contract of the tee itself: full pass-through plus a bounded recorded copy.
+	var sink bytes.Buffer
+	pw := &prefixCaptureWriter{w: &sink, max: crossArchStderrCaptureMax}
+	if _, err := io.WriteString(pw, line); err != nil {
+		t.Fatalf("tee write: %v", err)
+	}
+	if sink.String() != line {
+		t.Errorf("tee did not pass through full text:\n got: %q\nwant: %q", sink.String(), line)
+	}
+	if pw.captured() != line {
+		t.Errorf("tee did not record the text:\n got: %q\nwant: %q", pw.captured(), line)
+	}
+}
+
+// TestPrefixCaptureWriter_CapsRecordingButPassesThrough proves the recorded copy
+// is bounded at max while the underlying writer still receives every byte.
+func TestPrefixCaptureWriter_CapsRecordingButPassesThrough(t *testing.T) {
+	var sink bytes.Buffer
+	pw := &prefixCaptureWriter{w: &sink, max: 4}
+	if _, err := io.WriteString(pw, "abcdefgh"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := io.WriteString(pw, "ijkl"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := pw.captured(); got != "abcd" {
+		t.Errorf("recorded copy not capped at max: got %q want %q", got, "abcd")
+	}
+	if got := sink.String(); got != "abcdefghijkl" {
+		t.Errorf("underlying writer lost bytes: got %q want %q", got, "abcdefghijkl")
+	}
+}


### PR DESCRIPTION
## Summary

When `aileron skill launch` boots a pinned image whose manifest list has no build for the host CPU architecture, the docker daemon writes `no matching manifest for <platform> …` to stderr and returns a generic `exit status 125` error. The launch previously surfaced an opaque `run pinned image "…": exit status 125` wrap that told the operator nothing about what was wrong or who could fix it.

This detects that specific failure at the launch run-error boundary in `cmd/aileron/skill_launch_container.go` and replaces it with an actionable message that names the host platform and states the publisher must publish an image built for that architecture. Any other failure surfaces its original error unchanged.

### How it works
- The daemon's `no matching manifest for …` text is written to the stderr writer, not carried in the returned error (which is only `exit status 125`, a generic docker-daemon failure). Matching on exit code 125 alone would over-match and produce false rewrites.
- A bounded `prefixCaptureWriter` tees the container stderr: it forwards every byte to `os.Stderr` in full while recording a capped 64 KiB prefix. The manifest error is emitted at container-create before any plan output, so the prefix reliably contains the signal while keeping memory bounded on long successful runs.
- `crossArchManifestMessage` classifies on the `no matching manifest for` substring (case-insensitive, tolerant of surrounding daemon text). Absent the signal, the existing generic wrap is returned unchanged.
- `hostPlatform` is a package-level seam (`GOOS/GOARCH`) so the contract test drives a deterministic platform.

### Scope
Error-message-only change. No `--platform` emulation, QEMU, fallback run, lockfile/freeze/publish changes, or container-runtime edits (those are separate sub-issues). The actionable message is the whole error and intentionally does not `%w`-wrap the uninformative `exit status 125`; the error is terminal (printed to the operator) and nothing upstream inspects it for the exit code.

## Test plan
New `cmd/aileron/skill_launch_crossarch_test.go`:
- Manifest miss rewrites the error to name the host platform and publisher guidance, and does not carry the raw daemon/exit text.
- Unrelated failure falls through to the unchanged generic wrap (no false rewrite).
- Exit-125 without manifest text does NOT over-match (guards exit-code-only matching).
- Case-insensitive / surrounding-text signal is still classified.
- Stderr pass-through preserved; `prefixCaptureWriter` caps the recorded copy while forwarding every byte.

`go test ./cmd/aileron/` green; new classifier/capture/message lines at 100% coverage; `go vet ./cmd/aileron/...` and `task build` clean. CodeRabbit review run; its one finding (preserve error chain via `%w`) declined as intentional per the design: wrapping would reintroduce the `exit status 125` noise the actionable message replaces.

Closes #2039
