### PR TITLE
docs(freeze): correct stale S4 comment on retained host-arch load

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -378,8 +378,8 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 	// LocalTag; buildx reuses the layer cache, so it is cheap. This host-arch daemon
 	// image is intentionally retained: local `launch` of an un-published Flight Plan
 	// resolves the composed image straight from the daemon under LocalTag, with no
-	// publish step in between. (Publish itself no longer needs it — as of S4 (#2047)
-	// it consumes the OCI layout directly.) Dropping this second build is a documented
+	// publish step in between. Publish itself no longer needs it: as of S4 (#2047)
+	// it consumes the OCI layout directly. Dropping this second build is a documented
 	// launch-side follow-up, not done here.
 	loadOpts := buildOpts
 	loadOpts.Platforms = nil

--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -373,12 +373,14 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		return nil, fmt.Errorf("read composed per-arch config digests from %q: %w", result.OCILayoutDir, err)
 	}
 
-	// The multi-arch OCI-layout build does not load into the daemon, but publish's
-	// host-arch verify (`docker image inspect <LocalTag>`) still needs the image
-	// present locally between the S3 and S4 merges. Run the same composed build
-	// once more for the host architecture with a daemon load under LocalTag; buildx
-	// reuses the layer cache, so it is cheap. S4 turns publish into a manifest-list
-	// push that consumes the OCI layout directly and drops this second build.
+	// The multi-arch OCI-layout build does not load into the daemon. Run the same
+	// composed build once more for the host architecture with a daemon load under
+	// LocalTag; buildx reuses the layer cache, so it is cheap. This host-arch daemon
+	// image is intentionally retained: local `launch` of an un-published Flight Plan
+	// resolves the composed image straight from the daemon under LocalTag, with no
+	// publish step in between. (Publish itself no longer needs it — as of S4 (#2047)
+	// it consumes the OCI layout directly.) Dropping this second build is a documented
+	// launch-side follow-up, not done here.
 	loadOpts := buildOpts
 	loadOpts.Platforms = nil
 	loadOpts.OCILayoutDest = ""


### PR DESCRIPTION
## Summary

Fixes a stale code comment in `cmd/aileron/skill_freeze.go` (the `composeAndPinFrozenImage` path). The comment above the second host-arch `--load` build claimed:

> S4 turns publish into a manifest-list push that consumes the OCI layout directly and drops this second build.

S4 (PR #2047) has since merged and **deliberately retained** the second host-arch daemon load. Publish now consumes the OCI layout directly and no longer needs the daemon image, but local `launch` of an un-published Flight Plan still resolves the composed image from the daemon under `LocalTag`, so the build stays. PR #2047's own description confirms it: "Removing freeze's second host-arch daemon load (still feeds local `launch`) is a documented launch-side follow-up, out of scope."

The rewritten comment now:
- Drops the outdated claim that publish's host-arch verify needs the local image (S4 removed that dependency).
- States the host-arch daemon image is intentionally retained because local `launch` of an un-published plan resolves it from the daemon under `LocalTag`.
- Notes that dropping this second build is a documented launch-side follow-up, not something S4 did.

Comment-only change. No behavior change.

## Test plan

- `go build ./cmd/aileron/` — passes.
- `go vet ./cmd/aileron/` — passes.
- `gofmt -l cmd/aileron/skill_freeze.go` — clean.
- No behavior changed, so no new test is warranted (there is nothing new to exercise; the surrounding build/pin logic is unchanged and already covered).

Relates to #2046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal build behavior notes to better reflect how local launch resolution works and how publishing now uses the OCI layout directly.
  * Updated explanatory text to match the current release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->