### PR TITLE
test(flightplan): cross-arch multi-arch freeze/publish/launch e2e in a dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,9 +958,12 @@ jobs:
             exit 1
           fi
           cases="$(grep -o '<testcase' "$report" | wc -l | tr -d ' ')"
-          echo "multi-arch e2e executed $cases test(s)"
-          if [ "$cases" -eq 0 ]; then
-            echo "::error::multi-arch e2e executed 0 tests; refusing to pass on a silent skip" >&2
+          skipped="$(grep -o '<skipped' "$report" | wc -l | tr -d ' ')"
+          echo "multi-arch e2e executed $cases test(s), $skipped skipped"
+          # The e2e uses t.Fatalf (never t.Skip), so a skipped testcase is itself a
+          # regression: a run that skipped every case must not pass as "green".
+          if [ "$cases" -eq 0 ] || [ "$cases" -eq "$skipped" ]; then
+            echo "::error::multi-arch e2e ran 0 non-skipped tests; refusing to pass on a silent skip" >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,17 +780,12 @@ jobs:
         run: go test -tags=integration -race -run TestRunAuthGitHub_PUTReachesRealDaemonRoute .
         working-directory: cmd/aileron
 
-      # The composed-tools boot-guard integration test (#1863) moved to the
-      # `integration_sandbox_multiarch` build tag in #2036: the composed-tools
-      # freeze path now builds a REAL multi-architecture image (linux/amd64 +
-      # linux/arm64) via docker buildx, so running it needs a docker-container
-      # buildx builder, the QEMU binfmt emulators, and a multi-arch runner base on
-      # the registry. Provisioning that emulated build environment (and the
-      # multi-arch base) is owned by the S5 CI job, the last sub-issue of #2034;
-      # this base job no longer runs the boot-guard test so it stays green until
-      # that environment exists. S5 re-adds the @devcontainers/cli install, the
-      # `docker buildx create --driver docker-container --use`/`tonistiigi/binfmt`
-      # provisioning, and the `-tags=integration_sandbox_multiarch` run here.
+      # The composed-tools boot-guard (#1863) and the cross-arch multi-arch e2e
+      # (#2038) run under the `integration_sandbox_multiarch` tag in the dedicated
+      # `integration-multiarch` job below, which provisions the docker-container
+      # buildx builder, the QEMU binfmt emulators, a local registry, and the
+      # @devcontainers/cli the real linux/amd64+linux/arm64 build needs. This base
+      # job intentionally does not run them.
 
       - name: Stop server to flush coverage data
         if: ${{ !cancelled() }}
@@ -868,6 +863,106 @@ jobs:
           slug: ALRubinger/aileron
           files: internal/coverage-publish-e2e.txt
           flags: integration
+
+      - name: Registry logs on failure
+        if: failure()
+        run: docker logs registry || true
+
+  integration-multiarch:
+    name: Integration Tests (Multi-Arch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+
+      # A docker-container buildx builder is required for a REAL multi-platform
+      # build (`docker buildx build --platform linux/amd64,linux/arm64`); the
+      # default docker driver cannot emit a manifest list. This provisions and
+      # selects that builder.
+      - uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+
+      # Register the QEMU emulators so the non-native arch (arm64 on an amd64
+      # runner) actually builds under emulation. Without this the arm64 leg of
+      # the multi-arch build fails with an exec-format error.
+      - name: Register QEMU/binfmt emulators
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
+
+      - name: Start a local OCI registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:5000/v2/; then echo "registry up"; exit 0; fi
+            sleep 1
+          done
+          echo "registry did not come up"; exit 1
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: internal/go.mod
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      # The composer routes environment tools through Aileron's Builder, which
+      # invokes `npx --yes @devcontainers/cli@<pinned>`. Pin to the same version
+      # the Go source pins (container.DevcontainerCLIVersion) for parity with the
+      # other Feature jobs.
+      - name: Install @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.87.0
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      # The cross-arch multi-arch freeze -> publish -> launch e2e (#2038): a real
+      # buildx+QEMU linux/amd64+linux/arm64 freeze, a real manifest-list push to
+      # the local registry, and a real cross-arch pull+verify where an amd64
+      # runner is overridden to consume the arm64 child (the #2025 repro). This
+      # mirrors `task test:integration:multiarch` but runs through gotestsum so the
+      # JUnit report backs the anti-silent-skip guard below. The test drives the
+      # AILERON_FLIGHTPLAN_HOST_ARCH override itself and needs no daemon.
+      #
+      # KNOWN GAP (documented, not a silent skip): the pre-existing host-arch boot
+      # guard TestFlightPlanComposedToolsBootGuard shares this build tag but is NOT
+      # run here. It boots a real container that expects a live host daemon
+      # (AILERON_API_URL/AILERON_TOKEN); provisioning that daemon + a minted token
+      # + in-container networking is a separate lift with no established CI
+      # pattern. It stays runnable via `task test:integration:multiarch` where a
+      # daemon is available; wiring it into CI is a follow-up.
+      - name: Run cross-arch multi-arch e2e (#2038)
+        run: gotestsum --junitfile junit-multiarch.xml -- -tags=integration_sandbox_multiarch -run 'TestFlightPlanCrossArchMultiArchE2E' .
+        working-directory: cmd/aileron
+        env:
+          AILERON_TEST_REGISTRY: localhost:5000
+          AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base
+          AILERON_SANDBOX_FEATURES_CONTEXT: ${{ github.workspace }}/images/sandbox-features
+
+      # Anti-silent-skip guard (mirrors test-ui/test-webapp): a green result must
+      # mean the emulated test actually ran. A missing report or zero executed
+      # <testcase> elements fails the job rather than passing on a silent skip.
+      - name: Assert multi-arch e2e executed (anti-silent-skip)
+        working-directory: cmd/aileron
+        run: |
+          report="junit-multiarch.xml"
+          if [ ! -f "$report" ]; then
+            echo "::error::gotestsum JUnit report $report not found; the multi-arch e2e did not produce results" >&2
+            exit 1
+          fi
+          cases="$(grep -o '<testcase' "$report" | wc -l | tr -d ' ')"
+          echo "multi-arch e2e executed $cases test(s)"
+          if [ "$cases" -eq 0 ]; then
+            echo "::error::multi-arch e2e executed 0 tests; refusing to pass on a silent skip" >&2
+            exit 1
+          fi
 
       - name: Registry logs on failure
         if: failure()

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -518,6 +518,31 @@ tasks:
     cmds:
       - go test -tags=integration_sandbox -run TestSandboxAgentImageSmoke ./launch/...
 
+  test:integration:multiarch:
+    desc: >-
+      Run the cross-arch multi-arch freeze->publish->launch e2e plus the
+      host-arch composed-tools boot guard, both under the
+      integration_sandbox_multiarch tag (#2038). FAIL-FAST — requires: Docker; a
+      docker-container buildx builder (docker buildx create --driver
+      docker-container --use); the QEMU binfmt emulators (docker run --privileged
+      tonistiigi/binfmt --install all) for the real linux/amd64+linux/arm64 build;
+      @devcontainers/cli for the composer; a reachable OCI registry in
+      AILERON_TEST_REGISTRY (e.g. localhost:5000); the multi-arch runner base on
+      that registry/ghcr; and, for the boot guard, a live host daemon via
+      AILERON_API_URL/AILERON_TOKEN. The cross-arch test drives the consumer-arch
+      override (AILERON_FLIGHTPLAN_HOST_ARCH) itself, so it need not be set in the
+      environment. No self-skip: an absent prerequisite is a hard failure.
+    dir: cmd/aileron
+    cmds:
+      - go test -tags=integration_sandbox_multiarch -run 'TestFlightPlanComposedToolsBootGuard|TestFlightPlanCrossArchMultiArchE2E' .
+    env:
+      # The production composer builds the composed image onto the sandbox base
+      # from this context, exactly as the sandbox-features target does.
+      AILERON_SANDBOX_BASE_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
+      AILERON_SANDBOX_FEATURES_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-features" && pwd
+
   build:launch:
     desc: >-
       Build the binaries `aileron launch --sandbox=docker` needs: the CLI

--- a/cmd/aileron/skill_multiarch_e2e_test.go
+++ b/cmd/aileron/skill_multiarch_e2e_test.go
@@ -1,0 +1,303 @@
+//go:build integration_sandbox_multiarch
+
+// Real, emulated cross-arch end-to-end regression for the multi-arch Flight Plan
+// freeze -> publish -> launch chain (umbrella #2034, sub-issue #2038). It is the
+// #2025 repro the S2-S4 contract tests deliberately cannot cover: those prove the
+// per-arch pin schema, the multi-arch freeze, and the manifest-list publish +
+// per-arch re-verify against SYNTHETIC layouts and in-memory stores, so they
+// never run real `docker buildx --platform linux/amd64,linux/arm64`, real QEMU
+// emulation, or a genuine cross-arch consumer selection. This test does, in one
+// dedicated CI job (`integration-multiarch`) that provisions buildx + binfmt/QEMU
+// + a local registry.
+//
+// The #2025 bug is a publisher on one arch and a consumer on another: the
+// consumer must select ITS arch's child from the published manifest list, read
+// that child's serialization-agnostic config content digest, and match it to the
+// signed lock's per-arch entry. On a single-arch (amd64) runner the publisher
+// arch is always amd64, so the consumer is driven to the FOREIGN arch (arm64) via
+// the freeze.hostPlatform() override seam AILERON_FLIGHTPLAN_HOST_ARCH (#2038's
+// only production change). Running an arm64 aileron binary under QEMU is out of
+// scope; selection + boot re-check SUCCESS is the assertion, not running the
+// arm64 workload to completion.
+//
+// Real path, no fakes: the genuine buildx+QEMU multi-arch freeze (through the
+// CLI's production newDigestResolver/newFeatureComposer), a real manifest-list
+// push (publishRun = publish.Run, reading the freeze-produced OCI layout via the
+// production composedLayoutOpener), and the real pull+verify (through the
+// production launchRegistryImageResolver -> pull.PullImage -> ConfigContentDigest
+// index-unwrap). Two negative guards prove the job catches regressions: an arch
+// the artifact was NOT built for fails closed, and a tampered per-arch config is
+// refused. Per repo policy this test is FAIL-FAST (no t.Skip): absent Docker,
+// buildx, QEMU, the registry, or the multi-arch base is a job-config FAILURE.
+//
+// Run with (in the provisioned job):
+//
+//	go test -tags=integration_sandbox_multiarch -run TestFlightPlanCrossArchMultiArchE2E ./cmd/aileron/...
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
+	"github.com/ALRubinger/aileron/internal/flightplan/publish"
+	"github.com/ALRubinger/aileron/internal/flightplan/pull"
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// hostArchOverrideEnv mirrors freeze's unexported const: the consumer-arch
+// override the e2e drives so an amd64 runner selects the foreign arm64 child.
+const hostArchOverrideEnv = "AILERON_FLIGHTPLAN_HOST_ARCH"
+
+// recordingImageRunner is a runtime.ImageRunner that records the boot spec and
+// never boots, so the registry-origin boot re-check path runs end to end (load ->
+// pull -> per-arch verify -> resolve boot ref) WITHOUT running the arm64 workload
+// under QEMU. Capturing the resolved boot ref is the selection assertion.
+type recordingImageRunner struct {
+	spec runtime.ImageRunSpec
+}
+
+func (r *recordingImageRunner) Run(_ context.Context, spec runtime.ImageRunSpec) (runtime.ImageRunResult, error) {
+	r.spec = spec
+	return runtime.ImageRunResult{}, nil
+}
+
+// requireMultiArchToolchain fail-fasts (never skips) unless the emulated build +
+// registry environment the dedicated CI job provisions is present.
+func requireMultiArchToolchain(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Fatalf("docker not on PATH; the integration-multiarch job must provision it: %v", err)
+	}
+	// A docker-container buildx builder is required for a real multi-platform
+	// build; `docker buildx inspect` failing means the driver is not provisioned.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "buildx", "inspect").CombinedOutput(); err != nil {
+		t.Fatalf("docker buildx not usable; the job must `docker buildx create --driver docker-container --use`: %v\n%s", err, out)
+	}
+	registry := strings.TrimSpace(os.Getenv("AILERON_TEST_REGISTRY"))
+	if registry == "" {
+		t.Fatalf("AILERON_TEST_REGISTRY must point at the job's local registry (e.g. localhost:5000); required, not skipped")
+	}
+	return registry
+}
+
+// TestFlightPlanCrossArchMultiArchE2E freezes a composed-tools plan as a genuine
+// linux/amd64+linux/arm64 image, publishes it as a manifest list to a real
+// registry, installs it as a registry-origin plan, and proves an amd64 consumer
+// overridden to arm64 selects, verifies, and would boot the arm64 child (#2025),
+// plus two fail-closed negative guards.
+func TestFlightPlanCrossArchMultiArchE2E(t *testing.T) {
+	registryHost := requireMultiArchToolchain(t)
+	registry := registryHost + "/e2e/multiarch-plan"
+
+	// Persist the freeze into a fresh store the launch reads back from.
+	origStore := skillStoreDir
+	skillStoreDir = t.TempDir()
+	t.Cleanup(func() { skillStoreDir = origStore })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	// --- FREEZE (real multi-arch buildx + QEMU) -----------------------------
+	// The production composer routes the plan's environment tools through
+	// container.Builder, which runs `docker buildx build --platform
+	// linux/amd64,linux/arm64 --output type=oci`, reads each arch's config content
+	// digest back from the built OCI layout, and pins a per-arch config-digest set.
+	raw, err := os.ReadFile(exampleManifestPath(t))
+	if err != nil {
+		t.Fatalf("read composed-tools fixture: %v", err)
+	}
+	res, err := freeze.Run(ctx, raw, freeze.Options{
+		Version:        "1.0.0",
+		SigningKeyPath: writeSigningKey(t),
+		Resolver:       newDigestResolver(),
+		Composer:       newFeatureComposer(),
+	})
+	if err != nil {
+		t.Fatalf("multi-arch freeze through the production composer: %v", err)
+	}
+	if len(res.Lock.ResolvedImages) != 1 {
+		t.Fatalf("expected exactly one composed pin, got %+v", res.Lock.ResolvedImages)
+	}
+	pin := res.Lock.ResolvedImages[0]
+	if pin.LocalTag == "" {
+		t.Fatalf("composed pin must carry a bootable LocalTag; got %+v", pin)
+	}
+	// The pin must carry BOTH arches: a single-arch freeze would make the whole
+	// cross-arch premise vacuous, so this is the load-bearing S3 precondition.
+	amdDigest, amdOK := pin.ConfigDigestFor("linux", "amd64")
+	armDigest, armOK := pin.ConfigDigestFor("linux", "arm64")
+	if !amdOK || !armOK {
+		t.Fatalf("composed pin must carry both linux/amd64 and linux/arm64 config digests; got %+v", pin.ConfigDigests)
+	}
+	if amdDigest == armDigest {
+		t.Fatalf("the two arches must have distinct config content digests (a real per-arch build); both were %q", amdDigest)
+	}
+
+	// Persist the signed frozen version.
+	s := store.New(skillStoreDir)
+	versionID := frozenVersionID(res.ContentHash)
+	if err := s.WriteFrozen(res.Name, store.FrozenVersion{
+		ID:        versionID,
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}); err != nil {
+		t.Fatalf("persist frozen composed unit: %v", err)
+	}
+
+	// --- PUBLISH (real manifest-list push) ----------------------------------
+	// publishRun = publish.Run with NO ComposedLayout override, so the production
+	// composedLayoutOpener reads composition.OCILayoutDir(pin.LocalTag) — the exact
+	// layout the freeze above wrote. This is the production publish path.
+	fv, err := s.ReadFrozen(res.Name, versionID)
+	if err != nil {
+		t.Fatalf("read back frozen version: %v", err)
+	}
+	pubRes, err := publishRun(ctx, publish.Options{
+		Name:      res.Name,
+		VersionID: versionID,
+		Registry:  registry,
+		Frozen:    fv,
+		Lock:      res.Lock,
+	})
+	if err != nil {
+		t.Fatalf("publish the multi-arch composed image: %v", err)
+	}
+	if pubRes.BindingKind != freeze.BindingConfigContentDigest {
+		t.Errorf("published binding = %q, want %q (a composed pin binds by config content digest)", pubRes.BindingKind, freeze.BindingConfigContentDigest)
+	}
+
+	// The published tag must resolve to a manifest LIST carrying both platform
+	// children (an index), not a single-arch manifest. The production reader
+	// enumerates every runnable platform, so len==2 proves both arches shipped.
+	repo, err := ociremote.NewRepository(registry)
+	if err != nil {
+		t.Fatalf("connect published registry: %v", err)
+	}
+	composedTag := freeze.ComposedImageTag(versionID)
+	indexDesc, err := repo.Resolve(ctx, composedTag)
+	if err != nil {
+		t.Fatalf("resolve published composed image tag %q: %v", composedTag, err)
+	}
+	published, err := ociremote.AllPlatformConfigContentDigests(ctx, repo, indexDesc)
+	if err != nil {
+		t.Fatalf("read published per-arch config digests: %v", err)
+	}
+	if len(published) != 2 {
+		t.Fatalf("published artifact has %d runnable platforms, want the two-arch manifest list", len(published))
+	}
+
+	// --- INSTALL as a registry-origin plan ----------------------------------
+	// WriteOrigin makes LoadVerified report ImageOrigin.Present, so the launch
+	// takes the #1903 registry pull path rather than the local-tag boot path.
+	if err := s.WriteOrigin(res.Name, versionID, store.Origin{Registry: registry, VersionTag: versionID}); err != nil {
+		t.Fatalf("record registry install origin: %v", err)
+	}
+	origin := runtime.RegistryImageOrigin{Registry: registry, VersionTag: versionID, Present: true}
+
+	// The boot ref stays anchored to the resolved (index) MANIFEST digest — the
+	// per-arch config-content check binds the arch identity, while the boot ref is
+	// content-addressed to the index so the runner cannot boot a repointed tag.
+	wantBootRef := registry + "@" + indexDesc.Digest.String()
+
+	// --- POSITIVE: foreign-arch selection + verify --------------------------
+	t.Run("amd64 consumer overridden to arm64 selects and verifies the arm64 child", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "arm64")
+
+		// Drive pull.PullImage directly (the seam launchRegistryImageResolver wraps)
+		// so the per-arch selection is assertable: it must resolve the manifest list,
+		// unwrap to the arm64 child, read its config content digest, and match the
+		// lock's arm64 entry — never the amd64 entry the publisher ran on.
+		imgRes, err := pull.PullImage(ctx, pull.ImagePullOptions{Registry: registry, VersionTag: versionID, Pin: pin})
+		if err != nil {
+			t.Fatalf("cross-arch pull+verify (arm64 consumer of an amd64-published plan): %v", err)
+		}
+		if imgRes.BindingKind != freeze.BindingConfigContentDigest {
+			t.Errorf("binding = %q, want %q", imgRes.BindingKind, freeze.BindingConfigContentDigest)
+		}
+		if imgRes.ImageDigest != armDigest {
+			t.Errorf("verified config digest = %q, want the lock's arm64 entry %q (the arm64 child was selected)", imgRes.ImageDigest, armDigest)
+		}
+		if imgRes.ImageDigest == amdDigest {
+			t.Errorf("verified config digest is the amd64 entry %q; the consumer wrongly selected the publisher arch", amdDigest)
+		}
+		if imgRes.BootRef != wantBootRef {
+			t.Errorf("boot ref = %q, want the index-anchored %q", imgRes.BootRef, wantBootRef)
+		}
+
+		// The production resolver the runtime wires must return the same boot ref.
+		gotRef, err := launchRegistryImageResolver{}.Resolve(ctx, origin, pin)
+		if err != nil {
+			t.Fatalf("launchRegistryImageResolver.Resolve: %v", err)
+		}
+		if gotRef != wantBootRef {
+			t.Errorf("resolver boot ref = %q, want %q", gotRef, wantBootRef)
+		}
+	})
+
+	// --- POSITIVE: the registry-origin boot re-check selects the arm64 child --
+	t.Run("registry-origin boot re-check reaches the pull path and resolves the arm64 boot ref", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "arm64")
+		rec := &recordingImageRunner{}
+		if _, err := runtime.Run(ctx, runtime.Options{
+			Store:                 s,
+			Name:                  res.Name,
+			Version:               versionID,
+			ImageRunner:           rec,
+			RegistryImageResolver: launchRegistryImageResolver{},
+		}); err != nil {
+			t.Fatalf("boot the registry-origin plan (must pull+verify the arm64 child): %v", err)
+		}
+		if rec.spec.Image != wantBootRef {
+			t.Errorf("boot spec image = %q, want the verified arm64 boot ref %q", rec.spec.Image, wantBootRef)
+		}
+	})
+
+	// --- NEGATIVE (a): an arch the artifact was NOT built for fails closed ---
+	t.Run("a consumer arch absent from the artifact fails closed", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "ppc64le")
+		_, err := pull.PullImage(ctx, pull.ImagePullOptions{Registry: registry, VersionTag: versionID, Pin: pin})
+		if err == nil {
+			t.Fatal("pulling for an unbuilt arch must fail closed, never boot an unattested image")
+		}
+		if !errors.Is(err, pull.ErrImageDigestMismatch) {
+			t.Fatalf("err = %v, want ErrImageDigestMismatch", err)
+		}
+		if !strings.Contains(err.Error(), "not published for") {
+			t.Errorf("err = %q, want the 'not published for' fail-closed message", err.Error())
+		}
+	})
+
+	// --- NEGATIVE (b): a tampered per-arch config is refused ----------------
+	t.Run("a tampered arm64 config digest is refused", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "arm64")
+		tampered := pin
+		// Replace the arm64 entry with a digest the published image does not carry;
+		// the registry serves the honest image, but the (signed-lock) attestation
+		// for the selected arch no longer matches, so the per-arch verify must refuse.
+		tampered.ConfigDigests = append([]freeze.PlatformDigest(nil), pin.ConfigDigests...)
+		for i := range tampered.ConfigDigests {
+			if tampered.ConfigDigests[i].Arch == "arm64" {
+				tampered.ConfigDigests[i].Digest = "sha256:" + strings.Repeat("f", 64)
+			}
+		}
+		_, err := pull.PullImage(ctx, pull.ImagePullOptions{Registry: registry, VersionTag: versionID, Pin: tampered})
+		if err == nil {
+			t.Fatal("a pin attesting a different arm64 config digest must be refused")
+		}
+		if !errors.Is(err, pull.ErrImageDigestMismatch) {
+			t.Fatalf("err = %v, want ErrImageDigestMismatch", err)
+		}
+	})
+}

--- a/cmd/aileron/skill_multiarch_e2e_test.go
+++ b/cmd/aileron/skill_multiarch_e2e_test.go
@@ -15,8 +15,10 @@
 // that child's serialization-agnostic config content digest, and match it to the
 // signed lock's per-arch entry. On a single-arch (amd64) runner the publisher
 // arch is always amd64, so the consumer is driven to the FOREIGN arch (arm64) via
-// the freeze.hostPlatform() override seam AILERON_FLIGHTPLAN_HOST_ARCH (#2038's
-// only production change). Running an arm64 aileron binary under QEMU is out of
+// the AILERON_FLIGHTPLAN_HOST_ARCH override seam. That seam is honored in two
+// places that MUST agree on the arch: freeze.hostPlatform() (which lock per-arch
+// entry to attest) and ociremote's manifest-list child selection (which published
+// child to read config from). Running an arm64 aileron binary under QEMU is out of
 // scope; selection + boot re-check SUCCESS is the assertion, not running the
 // arm64 workload to completion.
 //

--- a/internal/flightplan/freeze/platform.go
+++ b/internal/flightplan/freeze/platform.go
@@ -1,6 +1,22 @@
 package freeze
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
+
+// hostArchOverrideEnv lets a consumer running on one architecture select and
+// verify a foreign architecture's child of a multi-arch composed artifact. When
+// set to a non-empty GOARCH string (e.g. "arm64"), hostPlatform() reports that
+// arch instead of runtime.GOARCH, so HostConfigDigest()/ConfigDigestFor pick the
+// override arch's entry from a composed pin's per-arch set. This is legitimate
+// operator behavior: an amd64 operator can pull and verify the arm64 child of a
+// multi-arch plan it will hand to an arm64 host. It is also the one honest way
+// to drive the cross-arch pull+verify path (issue #2025) end to end in a
+// dedicated CI job whose runner is a single architecture, without running a
+// foreign-arch aileron binary under QEMU. Empty (the default) selects the true
+// host arch.
+const hostArchOverrideEnv = "AILERON_FLIGHTPLAN_HOST_ARCH"
 
 // composedOS is the operating system a composed container image is always built
 // for. `imgconfig.CanonicalConfig.OS` for a container image is `"linux"`
@@ -20,9 +36,14 @@ var hostGOARCH = runtime.GOARCH
 // re-check, publish verify, pull verify) uses to select from it. Producer and
 // consumer share this one helper so they can never disagree on the platform
 // vocabulary. The os is always composedOS ("linux"); the arch is the host
-// GOARCH.
-func hostPlatform() (os, arch string) {
-	return composedOS, hostGOARCH
+// GOARCH, unless the hostArchOverrideEnv env var names a foreign arch, in which
+// case the consumer selects/verifies that arch's child of a multi-arch artifact.
+func hostPlatform() (platformOS, arch string) {
+	arch = hostGOARCH
+	if override := os.Getenv(hostArchOverrideEnv); override != "" {
+		arch = override
+	}
+	return composedOS, arch
 }
 
 // ConfigDigestFor returns the config content digest recorded for the given

--- a/internal/flightplan/freeze/platform_test.go
+++ b/internal/flightplan/freeze/platform_test.go
@@ -1,6 +1,9 @@
 package freeze
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 // withHostGOARCH overrides the hostGOARCH test seam for the duration of fn, so a
 // test can exercise both the present-arch and missing-arch selection branches
@@ -21,6 +24,81 @@ func TestHostPlatform(t *testing.T) {
 	if arch != "arm64" {
 		t.Errorf("hostPlatform arch = %q, want the host GOARCH arm64", arch)
 	}
+}
+
+// TestHostPlatformArchOverride pins the contract of the AILERON_FLIGHTPLAN_HOST_ARCH
+// consumer seam: unset, hostPlatform() reports the true runtime.GOARCH; set, it
+// reports the override arch so a consumer selects a foreign arch's child of a
+// multi-arch artifact. This is the seam the cross-arch e2e (#2038) drives to
+// exercise the #2025 path without a foreign-arch binary under QEMU.
+func TestHostPlatformArchOverride(t *testing.T) {
+	t.Run("unset selects the true host arch", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "")
+		os, arch := hostPlatform()
+		if os != "linux" {
+			t.Errorf("hostPlatform os = %q, want linux", os)
+		}
+		if arch != runtime.GOARCH {
+			t.Errorf("hostPlatform arch = %q, want the true host GOARCH %q", arch, runtime.GOARCH)
+		}
+	})
+	t.Run("override selects the foreign arch", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "arm64")
+		os, arch := hostPlatform()
+		if os != "linux" {
+			t.Errorf("hostPlatform os = %q, want linux", os)
+		}
+		if arch != "arm64" {
+			t.Errorf("hostPlatform arch = %q, want the override arm64", arch)
+		}
+	})
+}
+
+// TestHostConfigDigestArchOverrideSelectsForeignArch proves the override drives
+// the whole consumer selection path: an amd64-defaulting host with the override
+// set to arm64 selects the arm64 entry of a two-arch pin, and fails closed for a
+// pin that lacks the override arch.
+func TestHostConfigDigestArchOverrideSelectsForeignArch(t *testing.T) {
+	// Force the true host arch to amd64 so the override to arm64 is unambiguously
+	// a cross-arch selection regardless of the arch the test binary runs on.
+	withHostGOARCH(t, "amd64")
+	twoArch := ImagePin{
+		LocalTag: "aileron/sandbox-tools:x",
+		ConfigDigests: []PlatformDigest{
+			{OS: "linux", Arch: "amd64", Digest: "sha256:aaa"},
+			{OS: "linux", Arch: "arm64", Digest: "sha256:bbb"},
+		},
+	}
+	t.Run("override selects the arm64 entry", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "arm64")
+		got, platform, ok := twoArch.HostConfigDigest()
+		if !ok || got != "sha256:bbb" {
+			t.Errorf("HostConfigDigest with arm64 override = %q, %v; want sha256:bbb, true", got, ok)
+		}
+		if platform != "linux/arm64" {
+			t.Errorf("platform = %q, want linux/arm64", platform)
+		}
+	})
+	t.Run("override to an unbuilt arch fails closed", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "ppc64le")
+		got, platform, ok := twoArch.HostConfigDigest()
+		if ok {
+			t.Errorf("HostConfigDigest with ppc64le override = %q, ok=true; want a fail-closed miss", got)
+		}
+		if platform != "linux/ppc64le" {
+			t.Errorf("platform = %q, want linux/ppc64le for the fail-closed message", platform)
+		}
+	})
+	t.Run("empty override falls back to the host arch", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "")
+		got, platform, ok := twoArch.HostConfigDigest()
+		if !ok || got != "sha256:aaa" {
+			t.Errorf("HostConfigDigest with empty override = %q, %v; want the host amd64 entry sha256:aaa, true", got, ok)
+		}
+		if platform != "linux/amd64" {
+			t.Errorf("platform = %q, want linux/amd64", platform)
+		}
+	})
 }
 
 func TestConfigDigestFor(t *testing.T) {

--- a/internal/flightplan/ociremote/configdigest.go
+++ b/internal/flightplan/ociremote/configdigest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/imgconfig"
@@ -11,6 +12,29 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 )
+
+// hostArchOverrideEnv names the architecture a consumer selects a platform child
+// for, overriding the runner's native runtime.GOARCH. It is the SAME env var
+// freeze.hostPlatform() honors when it selects the lock's per-arch pin entry; the
+// two selectors MUST agree on the arch or a consumer's per-arch verify compares
+// the wrong child's config against the pin (the exact cross-arch mismatch #2025
+// guards). Honoring it here lets a consumer running on one arch faithfully select
+// AND verify a foreign arch's child of a multi-arch artifact — an amd64 operator
+// validating an arm64 plan, or the cross-arch launch path (#2025/#2039) — the way
+// a genuine host of that arch would. Empty (the default) selects runtime.GOARCH,
+// so production behavior on a native host is unchanged. The string is duplicated
+// (not imported) from freeze to avoid coupling the two leaf packages; both
+// document it as one public contract and both carry contract tests.
+const hostArchOverrideEnv = "AILERON_FLIGHTPLAN_HOST_ARCH"
+
+// hostArch is the architecture a single-child platform selection targets: the
+// hostArchOverrideEnv value when set, else the runner's runtime.GOARCH.
+func hostArch() string {
+	if a := os.Getenv(hostArchOverrideEnv); a != "" {
+		return a
+	}
+	return runtime.GOARCH
+}
 
 // Docker media type / annotation constants not exported by image-spec. A
 // containerd-backed `docker push` (Docker Desktop's default image store) emits
@@ -205,12 +229,16 @@ func selectPlatformManifest(raw []byte) (ocispec.Descriptor, error) {
 	if len(candidates) == 1 {
 		return candidates[0], nil
 	}
+	// Select the child for the consumer's target arch (hostArchOverrideEnv or the
+	// runner's native arch), matching freeze.hostPlatform()'s arch vocabulary so a
+	// cross-arch consumer verifies the child it actually attests (#2025).
+	wantArch := hostArch()
 	for _, m := range candidates {
-		if m.Platform != nil && m.Platform.OS == runtime.GOOS && m.Platform.Architecture == runtime.GOARCH {
+		if m.Platform != nil && m.Platform.OS == runtime.GOOS && m.Platform.Architecture == wantArch {
 			return m, nil
 		}
 	}
-	return ocispec.Descriptor{}, fmt.Errorf("image index has %d image manifests but none match host platform %s/%s", len(candidates), runtime.GOOS, runtime.GOARCH)
+	return ocispec.Descriptor{}, fmt.Errorf("image index has %d image manifests but none match host platform %s/%s", len(candidates), runtime.GOOS, wantArch)
 }
 
 // isAttestationManifest reports whether a child descriptor is a buildkit

--- a/internal/flightplan/ociremote/configdigest_test.go
+++ b/internal/flightplan/ociremote/configdigest_test.go
@@ -248,6 +248,53 @@ func TestConfigContentDigest_MultiPlatformMatchesHost(t *testing.T) {
 	}
 }
 
+// TestConfigContentDigest_ArchOverrideSelectsForeignChild pins the #2025 contract:
+// when hostArchOverrideEnv names a foreign arch, the single-child selection picks
+// THAT arch's manifest, not the runner's native arch. A cross-arch consumer's
+// per-arch verify reads the child it actually attests, matching
+// freeze.hostPlatform()'s arch vocabulary. Both children share the host GOOS
+// (composed images are linux-only) so only the arch distinguishes them.
+func TestConfigContentDigest_ArchOverrideSelectsForeignChild(t *testing.T) {
+	st := memory.New()
+	native, nativeBody := seedManifest(t, st, "native-arch")
+	native.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	const foreignArch = "s390x" // a stable arch distinct from any test runner's GOARCH
+	foreign, foreignBody := seedManifest(t, st, "foreign-arch")
+	foreign.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: foreignArch}
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, native, foreign)
+
+	t.Run("override selects the foreign child", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, foreignArch)
+		got, err := ConfigContentDigest(context.Background(), st, idx)
+		if err != nil {
+			t.Fatalf("ConfigContentDigest with %s override: %v", foreignArch, err)
+		}
+		if want := wantContentDigest(t, foreignBody); got != want {
+			t.Errorf("content digest = %q, want the foreign %s child's config %q", got, foreignArch, want)
+		}
+	})
+	t.Run("unset selects the native child", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "")
+		got, err := ConfigContentDigest(context.Background(), st, idx)
+		if err != nil {
+			t.Fatalf("ConfigContentDigest without override: %v", err)
+		}
+		if want := wantContentDigest(t, nativeBody); got != want {
+			t.Errorf("content digest = %q, want the native child's config %q", got, want)
+		}
+	})
+	t.Run("override to an arch absent from the index fails closed", func(t *testing.T) {
+		t.Setenv(hostArchOverrideEnv, "ppc64le")
+		_, err := ConfigContentDigest(context.Background(), st, idx)
+		if err == nil {
+			t.Fatal("want an error when the override arch is not in the index")
+		}
+		if !strings.Contains(err.Error(), "ppc64le") {
+			t.Errorf("err = %v, want the override arch named in the fail-closed message", err)
+		}
+	})
+}
+
 func TestConfigContentDigest_MultiPlatformNoHostMatchErrors(t *testing.T) {
 	st := memory.New()
 	a, _ := seedManifest(t, st, "arch-a")


### PR DESCRIPTION
## Summary

S5 of the multi-arch Flight Plan umbrella (#2034). Adds the real, emulated cross-arch end-to-end regression for #2025 that the S2–S4 contract tests deliberately cannot cover, plus a dedicated CI job that provisions the emulated build environment to run it fail-fast.

The #2025 bug is publisher-arch ≠ consumer-arch: the consumer must select ITS arch's child from the published manifest list, read that child's serialization-agnostic config content digest, and match it to the signed lock's per-arch entry. The S2–S4 tests prove the per-arch pin schema, the multi-arch freeze, and the manifest-list publish + per-arch re-verify against synthetic layouts and in-memory stores; none run real `docker buildx --platform linux/amd64,linux/arm64`, real QEMU, or a genuine cross-arch consumer selection. This one does — and it caught a real gap (see below).

### Changes

- **`internal/flightplan/freeze/platform.go`** — `hostPlatform()` honors `AILERON_FLIGHTPLAN_HOST_ARCH`, so a consumer on one arch can select/verify a foreign arch's child of a multi-arch artifact. It is a consumer-side selector only; the freeze producer pins every built arch, so the override cannot corrupt freeze-time pinning.
- **`internal/flightplan/ociremote/configdigest.go`** — the manifest-list single-child selection (`selectPlatformManifest`, used by the pull-verify config read) now honors the **same** override. This is required for correctness: on a genuine arm64 host, `freeze.hostPlatform()` and this selector both read arm64 and agree; under the override only the first shifted, so a cross-arch consumer read the wrong child's config and failed closed with a spurious mismatch. The first emulated run of the new e2e surfaced exactly this. Env unset keeps native `runtime.GOARCH` behavior. This also completes the legitimate "amd64 operator verifies an arm64 plan" path (#2025/#2039), not just the test.
- **`cmd/aileron/skill_multiarch_e2e_test.go`** (new, `//go:build integration_sandbox_multiarch`) — `freeze.Run` through the production composer → a genuine two-arch composed image + OCI layout + per-arch signed lock; `publishRun` (real manifest-list push, production layout opener) → asserts config-content-digest binding and a two-child manifest list; register a registry-origin install; then, with the override set to the non-publisher arch (arm64), drive `pull.PullImage` and `launchRegistryImageResolver` and assert the arm64 child is selected, its config content digest matches the lock's arm64 entry, and the boot ref is anchored to the resolved manifest digest. A recording `ImageRunner` proves `runtime.Run`'s registry-origin boot re-check resolves the arm64 boot ref without running the workload under QEMU. Two fail-closed negative guards: an arch absent from the artifact (`ppc64le`) and a tampered per-arch config.
- **`Taskfile.yml`** — `test:integration:multiarch` mirrors the `sandbox-features` prereqs and runs the shared tag.
- **`.github/workflows/ci.yml`** — new `integration-multiarch` job provisions the docker-container buildx builder, binfmt/QEMU, a local `registry:2`, and `@devcontainers/cli`, runs the e2e via gotestsum, and enforces an anti-silent-skip guard (fails when the report has zero executed or only skipped `<testcase>` elements). Removes the stale S5 placeholder comment in `integration-go`.

Both override seams carry contract unit tests (`hostPlatform`/`ConfigDigestFor`/`HostConfigDigest` and `selectPlatformManifest`/`hostArch` each at 100%).

## Test plan

- `go test ./internal/flightplan/...` — green (new override contract tests in `freeze` and `ociremote`; default selection unchanged when the env is unset).
- `go build ./...`, `go vet .`, `go test .` for `cmd/aileron` (untagged) — green.
- `go vet -tags=integration_sandbox_multiarch ./cmd/aileron` and a compile-only tagged run — the new e2e builds and links.
- `actionlint .github/workflows/ci.yml` — only pre-existing repo-wide `SC2034` `for i in $(seq…)` style warnings, matching the existing registry-start block.
- `task test:integration:multiarch --dry` — resolves to the expected `go test -tags=integration_sandbox_multiarch` invocation.
- The buildx+QEMU+registry e2e runs in the provisioned `integration-multiarch` CI job (it cannot run in a dev sandbox); the first run surfaced the ociremote selection gap now fixed, and the testcase-count guard makes "green" mean "the emulated test ran".

### Known gap (documented, not a silent skip)

The pre-existing host-arch boot guard `TestFlightPlanComposedToolsBootGuard` shares this build tag but is **not** run in the new CI job. It boots a real container that expects a live host daemon (`AILERON_API_URL`/`AILERON_TOKEN`); provisioning that daemon + a minted token + in-container networking is a separate lift with no established CI pattern. It stays runnable via `task test:integration:multiarch` where a daemon is available. Wiring it into CI is a follow-up; the cross-arch regression that is the heart of #2038 is fully covered by this job.

Closes #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)
