### PR TITLE
docs(skill): record why manifest-miss classification stays at CLI boundary

### DIFF
--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -31,6 +31,12 @@ var hostPlatform = func() string { return stdruntime.GOOS + "/" + stdruntime.GOA
 // bounded prefix reliably contains the classification signal while keeping
 // memory bounded on long successful runs. Writes always pass through to w in
 // full; only the recorded copy is capped.
+//
+// Correctness depends on that create-time emission ordering: a future change
+// that streams pull/progress output ahead of the container-create failure
+// could push the "no matching manifest for" signal past the bounded prefix
+// (crossArchStderrCaptureMax) and silently defeat cross-arch detection. If such
+// output is added, raise the cap or classify against the full stream.
 type prefixCaptureWriter struct {
 	w   io.Writer
 	max int
@@ -367,6 +373,12 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 	// error, so the specific signal lives in the captured text, not the error.
 	// Pass-through to os.Stderr is preserved in full; only the recorded prefix
 	// is bounded.
+	//
+	// Manifest-miss classification stays here at the CLI boundary rather than
+	// moving into Builder.Run: it keeps the classification dependency-free and
+	// leaves runtime.go untouched (unlike runtime.go's own tee-and-classify
+	// precedents at runBuildStep/StopContainer/Validate, which classify inside
+	// the runtime layer because their signals originate there).
 	stderrCapture := &prefixCaptureWriter{w: os.Stderr, max: crossArchStderrCaptureMax}
 	if _, err := containerRunFlightPlan(ctx, runtimeName, os.Stdout, stderrCapture, opts); err != nil {
 		if msg, ok := crossArchManifestMessage(spec.Image, stderrCapture.captured(), hostPlatform()); ok {


### PR DESCRIPTION
## Summary

Two comment-only additions in `cmd/aileron/skill_launch_container.go`, the two remaining actionable findings from cw-review-residual #2040 (sub-issue #2039). Both were explicitly authorized by the operator during triage.

1. **CLI-boundary rationale.** At the `stderrCapture` creation site, added a comment recording *why* cross-arch manifest-miss classification stays at the CLI boundary rather than moving into `Builder.Run`: it keeps classification dependency-free and leaves the runtime layer untouched. This contrasts with `internal/sandbox/container/runtime.go`'s own tee-and-classify precedents at `runBuildStep` / `StopContainer` / `Validate`, which classify inside the runtime layer because their signals originate there.

2. **Prefix-cap ordering warning.** Extended the `prefixCaptureWriter` doc comment to warn that a future change streaming pull/progress output ahead of the container-create failure could push the `no matching manifest for` signal past the 64 KiB bounded prefix (`crossArchStderrCaptureMax`) and silently defeat cross-arch detection.

No behavior change; documentation only.

## Test plan

- `go build ./cmd/aileron/` — passes
- `go vet ./cmd/aileron/` — clean
- `go test ./cmd/aileron/` — passes (10.5s)

Comment-only change, so no new tests: there is no new behavior to cover, and the existing cross-arch manifest classification tests remain green.

Closes #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance around cross-architecture manifest-miss detection.
  * Improved explanation of why the stderr capture approach is reliable today.
  * Added a note about future streaming behavior that could affect this signal.
  * Better explained why this classification stays at the CLI boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->