### PR TITLE
fix(publish): hint to re-run freeze when composed layout cache is missing

### DIFF
--- a/internal/flightplan/publish/publish.go
+++ b/internal/flightplan/publish/publish.go
@@ -41,6 +41,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"regexp"
 	"strings"
 
@@ -279,6 +280,13 @@ func publishComposed(ctx context.Context, opts Options, pin freeze.ImagePin, tar
 	}
 	store, root, err := openLayout(ctx, pin)
 	if err != nil {
+		// The composed layout is produced by `aileron skill freeze` into a
+		// tag-keyed OCI-layout cache dir. If that dir is missing or was evicted,
+		// the open fails with a not-exist error that names no remedy on its own;
+		// point the operator at the command that rebuilds it.
+		if errors.Is(err, fs.ErrNotExist) {
+			return ocispec.Descriptor{}, "", fmt.Errorf("publish: composed image layout for %q not found (run `aileron skill freeze %s` to rebuild it): %w", pin.LocalTag, opts.Name, err)
+		}
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: open composed image layout for %q: %w", pin.LocalTag, err)
 	}
 

--- a/internal/flightplan/publish/publish_test.go
+++ b/internal/flightplan/publish/publish_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -523,6 +524,31 @@ func TestRunComposedLayoutOpenError(t *testing.T) {
 	}
 	if _, err := Run(ctx, opts); err == nil || !strings.Contains(err.Error(), "open composed image layout") {
 		t.Fatalf("err = %v, want an open-composed-image-layout error", err)
+	}
+}
+
+// TestRunComposedLayoutMissingSuggestsFreeze proves that when the composed
+// layout's cache dir is missing or evicted (the open fails with a not-exist
+// error), publish surfaces an actionable remediation naming `aileron skill
+// freeze <name>` rather than a bare generic open failure. This is the
+// missing/absent-layout-dir contract: the operator must be told how to rebuild.
+func TestRunComposedLayoutMissingSuggestsFreeze(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	layout := twoArch(t)
+	opts := composedOptions(target, layout)
+	opts.ComposedLayout = func(context.Context, freeze.ImagePin) (oras.ReadOnlyTarget, ocispec.Descriptor, error) {
+		return nil, ocispec.Descriptor{}, fmt.Errorf("open OCI layout /cache/missing: %w", os.ErrNotExist)
+	}
+	_, err := Run(ctx, opts)
+	if err == nil {
+		t.Fatal("err = nil, want a missing-composed-layout error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want it to wrap fs.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), "aileron skill freeze demo") {
+		t.Fatalf("err = %v, want it to name the `aileron skill freeze demo` remediation", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`publish`'s composed path took a hard dependency on the freeze-produced OCI-layout cache dir, but a missing or evicted dir surfaced only as a generic `publish: open composed image layout for %q: %w` error with no remediation. Operators hitting an evicted/absent cache had no actionable next step.

This detects the not-exist case at the `publishComposed` call site (`internal/flightplan/publish/publish.go`) with `errors.Is(err, fs.ErrNotExist)` and wraps it with a hint to re-run `aileron skill freeze <name>`. `ociremote.OpenOCILayout` is left generic per the triage — the operator-facing remediation belongs at the publish boundary that knows the skill name.

## Test plan

- Added `TestRunComposedLayoutMissingSuggestsFreeze`: injects a ComposedLayout seam returning an `fs.ErrNotExist`-wrapping error and asserts the surfaced error both wraps `fs.ErrNotExist` and names `aileron skill freeze demo`. Verified it FAILS before the production change and PASSES after.
- `go test ./internal/flightplan/publish/` green; `go vet` clean.

Closes #2046
