### PR TITLE
fix(flightplan): select the linux container-runtime manifest, not host GOOS (#2055)

### DIFF
--- a/internal/flightplan/ociremote/configdigest.go
+++ b/internal/flightplan/ociremote/configdigest.go
@@ -12,6 +12,15 @@ import (
 	"oras.land/oras-go/v2/content"
 )
 
+// composedOS is the operating system a composed container image always declares.
+// It mirrors freeze's composedOS: `imgconfig.CanonicalConfig.OS` for a container
+// image is "linux" regardless of the launching host GOOS (v4 supports
+// macOS/Windows/Linux hosts), and freeze keys its per-arch config-digest set on
+// this constant, so a consumer must select the index child by the container
+// runtime OS ("linux"), NOT the host GOOS. Matching the host GOOS would never hit
+// on a Mac or Windows host, refusing an otherwise-bootable linux image (#2055).
+const composedOS = "linux"
+
 // hostGOARCH is the architecture a single-child platform selection targets. It
 // mirrors freeze's hostGOARCH seam: a package var (not a direct runtime.GOARCH
 // read) so tests can exercise the foreign-arch child-selection branch
@@ -21,6 +30,14 @@ import (
 // genuinely foreign consumer (e.g. an arm64 binary under QEMU) reports its own
 // arch here naturally.
 var hostGOARCH = runtime.GOARCH
+
+// hostGOOS is the launching host's GOOS, exposed as a package var (not a direct
+// runtime.GOOS read) so tests can drive the non-linux-host selection branch
+// deterministically regardless of the OS the test binary runs on. It is used
+// only to name the host in the fail-closed message; selection itself keys on
+// composedOS, never on hostGOOS, so a Windows or macOS host still resolves the
+// linux child of a composed multi-arch artifact (#2055).
+var hostGOOS = runtime.GOOS
 
 // Docker media type / annotation constants not exported by image-spec. A
 // containerd-backed `docker push` (Docker Desktop's default image store) emits
@@ -60,8 +77,10 @@ const (
 // Selection inside an index skips attestation entries (platform os == "unknown"
 // or the docker attestation reference-type annotation). For the single-platform
 // composed image exactly one real manifest remains and is used; when several
-// real manifests exist the host runtime.GOOS/GOARCH match is chosen; when none
-// is usable an actionable error is returned rather than a silently-wrong digest.
+// real manifests exist the composedOS ("linux") + host-arch match is chosen (a
+// composed image always declares os="linux", so selection never keys on the host
+// GOOS); when none is usable an actionable error is returned rather than a
+// silently-wrong digest.
 func ConfigContentDigest(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) (string, error) {
 	blob, err := configBlob(ctx, fetcher, desc)
 	if err != nil {
@@ -204,9 +223,10 @@ func enumeratePlatformManifests(raw []byte) ([]ocispec.Descriptor, error) {
 
 // selectPlatformManifest picks the single runnable image manifest from an index's
 // raw bytes for the host-only config read: it enumerates the runnable children,
-// then returns the sole remaining manifest, or the host-platform match when
-// several remain. It shares enumeratePlatformManifests with the all-arch walk so
-// the two can never diverge on which children count as runnable.
+// then returns the sole remaining manifest, or the composedOS ("linux") +
+// host-arch match when several remain. It shares enumeratePlatformManifests with
+// the all-arch walk so the two can never diverge on which children count as
+// runnable.
 func selectPlatformManifest(raw []byte) (ocispec.Descriptor, error) {
 	candidates, err := enumeratePlatformManifests(raw)
 	if err != nil {
@@ -215,17 +235,21 @@ func selectPlatformManifest(raw []byte) (ocispec.Descriptor, error) {
 	if len(candidates) == 1 {
 		return candidates[0], nil
 	}
-	// Select the child for the consumer's target arch (the hostGOARCH seam,
-	// runtime.GOARCH in production), matching freeze.hostPlatform()'s arch
-	// vocabulary so a cross-arch consumer verifies the child it actually attests
-	// (#2025).
+	// Select the child for the container runtime platform: OS is always
+	// composedOS ("linux", what a composed image declares and what freeze keys
+	// its per-arch config-digest set on), and arch is the consumer's target arch
+	// (the hostGOARCH seam, runtime.GOARCH in production), matching
+	// freeze.hostPlatform()'s vocabulary so a cross-arch consumer verifies the
+	// child it actually attests (#2025). Keying OS on composedOS rather than the
+	// host GOOS is what lets a macOS or Windows host resolve the linux child
+	// instead of demanding a nonexistent darwin/windows manifest (#2055).
 	wantArch := hostGOARCH
 	for _, m := range candidates {
-		if m.Platform != nil && m.Platform.OS == runtime.GOOS && m.Platform.Architecture == wantArch {
+		if m.Platform != nil && m.Platform.OS == composedOS && m.Platform.Architecture == wantArch {
 			return m, nil
 		}
 	}
-	return ocispec.Descriptor{}, fmt.Errorf("image index has %d image manifests but none match host platform %s/%s", len(candidates), runtime.GOOS, wantArch)
+	return ocispec.Descriptor{}, fmt.Errorf("image index has %d image manifests but none targets the container runtime platform %s/%s (host %s/%s)", len(candidates), composedOS, wantArch, hostGOOS, wantArch)
 }
 
 // isAttestationManifest reports whether a child descriptor is a buildkit

--- a/internal/flightplan/ociremote/configdigest_test.go
+++ b/internal/flightplan/ociremote/configdigest_test.go
@@ -29,6 +29,18 @@ func withHostGOARCH(t *testing.T, arch string) {
 	t.Cleanup(func() { hostGOARCH = prev })
 }
 
+// withHostGOOS overrides the hostGOOS seam for the duration of the test, so a
+// test can simulate a non-linux launching host (Windows, macOS) deterministically
+// regardless of the OS the test binary runs on. Selection keys on composedOS, so
+// this only changes the host named in the fail-closed message; the point is to
+// prove a non-linux host still resolves the linux child (#2055).
+func withHostGOOS(t *testing.T, goos string) {
+	t.Helper()
+	prev := hostGOOS
+	hostGOOS = goos
+	t.Cleanup(func() { hostGOOS = prev })
+}
+
 // ociConfigBody builds a valid OCI image config blob whose Entrypoint carries
 // the given marker, so distinct markers yield distinct content digests. The
 // returned bytes are what a registry serves as the config blob.
@@ -144,7 +156,9 @@ func TestConfigContentDigest_OCIIndexUnwrapsToImageManifest(t *testing.T) {
 	// digest must resolve to the image manifest's config, not error out.
 	st := memory.New()
 	image, configBody := seedManifest(t, st, "composed")
-	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	// A composed container image always declares os="linux", independent of the
+	// launching host GOOS.
+	image.Platform = &ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 	att := attestationManifest(t, st)
 	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, image, att)
 
@@ -243,11 +257,12 @@ func TestConfigContentDigest_IndexWithOnlyAttestationErrors(t *testing.T) {
 
 func TestConfigContentDigest_MultiPlatformMatchesHost(t *testing.T) {
 	st := memory.New()
-	// A foreign-platform manifest plus the host-platform manifest; the host one wins.
+	// A foreign-platform manifest plus the composed linux/host-arch manifest; the
+	// linux one wins (a composed image always declares os="linux").
 	foreign, _ := seedManifest(t, st, "foreign-arch")
 	foreign.Platform = &ocispec.Platform{OS: "plan9", Architecture: "mips"}
 	host, hostBody := seedManifest(t, st, "host-arch")
-	host.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	host.Platform = &ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, foreign, host)
 
 	got, err := ConfigContentDigest(context.Background(), st, idx)
@@ -272,10 +287,10 @@ func TestConfigContentDigest_MultiPlatformMatchesHost(t *testing.T) {
 func TestConfigContentDigest_SelectsForeignArchChild(t *testing.T) {
 	st := memory.New()
 	native, nativeBody := seedManifest(t, st, "native-arch")
-	native.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	native.Platform = &ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 	const foreignArch = "s390x" // a stable arch distinct from any test runner's GOARCH
 	foreign, foreignBody := seedManifest(t, st, "foreign-arch")
-	foreign.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: foreignArch}
+	foreign.Platform = &ocispec.Platform{OS: "linux", Architecture: foreignArch}
 	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, native, foreign)
 
 	t.Run("a foreign-arch consumer selects the foreign child", func(t *testing.T) {
@@ -320,10 +335,46 @@ func TestConfigContentDigest_MultiPlatformNoHostMatchErrors(t *testing.T) {
 
 	_, err := ConfigContentDigest(context.Background(), st, idx)
 	if err == nil {
-		t.Fatal("want an error when no manifest matches the host platform")
+		t.Fatal("want an error when no manifest targets the container runtime platform")
 	}
-	if !strings.Contains(err.Error(), "host platform") {
-		t.Errorf("err = %v, want a host-platform mismatch message", err)
+	if !strings.Contains(err.Error(), "container runtime platform") {
+		t.Errorf("err = %v, want a container-runtime-platform mismatch message", err)
+	}
+}
+
+// TestConfigContentDigest_SelectsLinuxChildOnNonLinuxHost is the #2055 regression
+// guard: a composed multi-arch index declares os="linux" for every child, so a
+// non-linux launching host (Windows, macOS) must still resolve the linux child
+// for its own arch rather than refusing to boot because no windows/darwin manifest
+// exists. Before the fix selectPlatformManifest matched the child OS against the
+// host GOOS, so a linux/amd64+linux/arm64 index matched nothing on Windows/macOS.
+func TestConfigContentDigest_SelectsLinuxChildOnNonLinuxHost(t *testing.T) {
+	st := memory.New()
+	amd, amdBody := seedArchManifest(t, st, "linux", "amd64", "amd")
+	arm, armBody := seedArchManifest(t, st, "linux", "arm64", "arm")
+	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, amd, arm)
+
+	cases := []struct {
+		name     string
+		hostGOOS string
+		hostArch string
+		wantBody []byte
+	}{
+		{"windows/amd64 host resolves the linux/amd64 child", "windows", "amd64", amdBody},
+		{"darwin/arm64 host resolves the linux/arm64 child", "darwin", "arm64", armBody},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withHostGOOS(t, tc.hostGOOS)
+			withHostGOARCH(t, tc.hostArch)
+			got, err := ConfigContentDigest(context.Background(), st, idx)
+			if err != nil {
+				t.Fatalf("ConfigContentDigest as %s/%s: %v", tc.hostGOOS, tc.hostArch, err)
+			}
+			if want := wantContentDigest(t, tc.wantBody); got != want {
+				t.Errorf("content digest = %q, want the linux/%s child's config %q", got, tc.hostArch, want)
+			}
+		})
 	}
 }
 
@@ -404,7 +455,7 @@ func (s indexFetchFailStore) Fetch(ctx context.Context, desc ocispec.Descriptor)
 func TestConfigContentDigest_IndexChildFetchErrorPropagates(t *testing.T) {
 	inner := memory.New()
 	image, _ := seedManifest(t, inner, "child")
-	image.Platform = &ocispec.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	image.Platform = &ocispec.Platform{OS: "linux", Architecture: runtime.GOARCH}
 	idx := pushIndex(t, inner, ocispec.MediaTypeImageIndex, image)
 	boom := errors.New("child manifest read reset")
 	st := indexFetchFailStore{Store: inner, failDigest: image.Digest.String(), err: boom}
@@ -620,7 +671,7 @@ func TestAllPlatformConfigContentDigests_InvalidChildConfigErrors(t *testing.T) 
 func TestSelectPlatformManifest_HostOnlyUnchanged(t *testing.T) {
 	st := memory.New()
 	foreign, _ := seedArchManifest(t, st, "plan9", "mips", "foreign")
-	host, hostBody := seedArchManifest(t, st, runtime.GOOS, runtime.GOARCH, "host")
+	host, hostBody := seedArchManifest(t, st, "linux", runtime.GOARCH, "host")
 	idx := pushIndex(t, st, ocispec.MediaTypeImageIndex, foreign, host)
 	got, err := ConfigContentDigest(context.Background(), st, idx)
 	if err != nil {


### PR DESCRIPTION
## Summary

flightplan's pull-and-verify selected the composed-image manifest by the launching host's `runtime.GOOS`. A composed container image always declares `os="linux"` — freeze keys its per-arch config-digest set on the constant `composedOS="linux"` in `internal/flightplan/freeze/platform.go` — but `selectPlatformManifest` in `internal/flightplan/ociremote/configdigest.go` matched the index child's OS against `runtime.GOOS`. On Windows that is `"windows"` (macOS `"darwin"`), so a `linux/amd64`+`linux/arm64` index matched nothing and flightplan refused to boot ("none match host platform windows/amd64"). It only passed CI because CI runs on linux and every fixture set the child OS to `runtime.GOOS`, coupling the test to the bug.

### Fix (`internal/flightplan/ociremote/`)

- **configdigest.go**: added `const composedOS = "linux"` (mirroring freeze) and a `hostGOOS` seam (mirroring the existing `hostGOARCH` seam). `selectPlatformManifest` now matches `m.Platform.OS == composedOS && m.Platform.Architecture == hostGOARCH` — the container runtime target for the host arch, never host GOOS. The fail-closed message now reads `...none targets the container runtime platform linux/<arch> (host <goos>/<arch>)` so it names what the publisher must ship rather than demanding a nonexistent windows/darwin manifest.
- **configdigest_test.go**: decoupled composed-child fixtures from `runtime.GOOS` (composed children are `"linux"`), added a `withHostGOOS` helper, updated the no-match assertion, and added `TestConfigContentDigest_SelectsLinuxChildOnNonLinuxHost` proving a simulated `windows/amd64` and `darwin/arm64` host resolve the correct linux child.

The `docker run` path passes no `--platform`, so boot proceeds on WSL2/Docker Desktop once verify selects the linux child. The separate `cmd/aileron` hostPlatform GOOS/GOARCH seam (docker daemon cross-arch message, kept at the CLI boundary per #2052) does not fire in this scenario and is left out of scope.

## Test plan

- `go build ./internal/...` — green.
- `go test ./internal/flightplan/...` — all green (including `ociremote`).
- `go test ./cmd/aileron/...` — green.
- Regression proof (on darwin, where `GOOS != linux`): temporarily restored the pre-fix `OS == runtime.GOOS` selection line; `TestConfigContentDigest_SelectsLinuxChildOnNonLinuxHost` and `TestConfigContentDigest_MultiPlatformMatchesHost` **FAIL** (the linux children match nothing against a darwin host); with the fix they **PASS**.

Closes #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
