### PR TITLE
feat(flightplan): guided interactive input walk on launch + --accept-defaults

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -220,7 +220,10 @@ func (p linePrompter) PromptInput(in runtime.Input) (string, error) {
 		fmt.Fprintf(&b, " %s", hint)
 	}
 	b.WriteString(": ")
-	return promptLine(p.stdin, p.stdout, b.String()), nil
+	// Use the EOF-aware helper (not the shared promptLine, which collapses EOF
+	// to "" and swallows the error) so a drained or closed stdin propagates a
+	// read error to the launch instead of silently resolving to an empty value.
+	return readPromptLine(p.stdin, p.stdout, b.String())
 }
 
 // inputConstraintHint renders a short, parenthesized hint for a declared input
@@ -284,6 +287,12 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	// (#1888). -v is an alias.
 	verbose := flags.Bool("verbose", false, "Print full resolved input values instead of a type+size summary")
 	flags.BoolVar(verbose, "v", false, "Shorthand for --verbose")
+	// acceptDefaults reproduces today's silent-default one-shot launch: it skips
+	// the interactive guided input walk that is otherwise the default on a TTY,
+	// resolving every literal to its --input override or declared default without
+	// prompting (#2063). A non-TTY launch (piped stdin, CI) implies it: the walk
+	// only wires on an interactive terminal, so a scripted launch is unaffected.
+	acceptDefaults := flags.Bool("accept-defaults", false, "Skip the interactive input walk; resolve every input to its override or declared default")
 	positionals, err := parseInterspersedFlags(flags, args)
 	if err != nil {
 		return 1
@@ -299,6 +308,21 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
+	}
+
+	// The launch is interactive when stdin is a TTY and --accept-defaults was
+	// not passed (#2063). Only then are BOTH interactive seams wired: the
+	// InputWalker (the host-side guided walk that reaches the sealed-image
+	// mainline) and the InputPrompter (retained but preempted by the walk). When
+	// not interactive (piped/CI stdin, or --accept-defaults on a TTY) BOTH stay
+	// nil, so resolveInputs fail-fasts on a missing-required-no-default literal
+	// without prompting, exactly as a scripted launch does today.
+	interactive := isTTYFn() && !*acceptDefaults
+	var inputWalker runtime.InputWalker
+	var inputPrompter runtime.InputPrompter
+	if interactive {
+		inputWalker = newLaunchInputWalker(bufio.NewReader(os.Stdin), stdout)
+		inputPrompter = newLaunchInputPrompter(stdout)
 	}
 
 	res, err := runtime.Run(context.Background(), runtime.Options{
@@ -350,11 +374,18 @@ func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
 		// the current (pinned) environment (#1829). No sibling container is
 		// ever dispatched.
 		ToolRunner: newLaunchToolStepRunner(),
+		// InputWalker is the host-side guided input walk (#2063). It runs before
+		// the image-boot / in-process branch and collects a value for every
+		// declared literal, so the walk reaches the sealed-image mainline the
+		// in-container prompter never sees. Nil unless the launch is interactive.
+		InputWalker: inputWalker,
 		// InputPrompter resolves a missing required literal input (no --input
-		// override, no declared default) interactively when stdin is a TTY, and
-		// is nil for a piped or CI launch so the runtime keeps its fail-fast
-		// error. Dynamic and source inputs are never prompted.
-		InputPrompter: newLaunchInputPrompter(stdout),
+		// override, no declared default) interactively. It is retained but
+		// preempted on the interactive path: the walker resolves every literal
+		// into Inputs first, so a still-wired prompter is never consulted. Nil
+		// unless the launch is interactive, so a piped/CI or --accept-defaults
+		// launch keeps the runtime's fail-fast error.
+		InputPrompter: inputPrompter,
 		OutDir:        *outDir,
 	})
 	if err != nil {

--- a/cmd/aileron/skill_launch_container.go
+++ b/cmd/aileron/skill_launch_container.go
@@ -256,12 +256,20 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 	// re-entry (#1802). Without this the inner binary sees no overrides and every
 	// input silently resolves to its default, while the runner still echoes
 	// spec.Inputs as ResolvedInputs, falsely telling the operator the overrides
-	// applied. CLI-path values arrive as strings via inputFlag.Set, and the inner
-	// re-entry parses them with the same inputFlag, so the string round-trip is
-	// exact. Keys are appended in sorted order so the emitted command is
-	// deterministic. A non-string value in the map[string]any seam type has no
-	// exact name=value round-trip, so refuse the boot with an explicit error
-	// rather than coerce or drop it (the issue's never-silently-drop requirement).
+	// applied. Keys are appended in sorted order so the emitted command is
+	// deterministic.
+	//
+	// Values serialize through fmt.Sprintf("%v", v) (#2063). CLI-path overrides
+	// arrive as strings via inputFlag.Set, but the host-side guided input walk
+	// injects an Enter-accepted default as its NATIVE typed value (a number, a
+	// bool), so spec.Inputs may now hold a non-string. The %v serialization is
+	// faithful: the inner re-entry re-parses every --input value as a string via
+	// the same inputFlag, and every downstream check (EnforceConstraint,
+	// host/command interpolation) already compares via %v, so a typed default and
+	// its %v string form are indistinguishable to the plan. See the walker's
+	// typing-asymmetry note in skill_launch_walk.go. This replaces the earlier
+	// refuse-non-string guard, which predated the walk and would have rejected an
+	// Enter-accepted typed default outright.
 	if len(spec.Inputs) > 0 {
 		keys := make([]string, 0, len(spec.Inputs))
 		for k := range spec.Inputs {
@@ -269,11 +277,7 @@ func (r containerImageRunner) Run(ctx context.Context, spec runtime.ImageRunSpec
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			s, ok := spec.Inputs[k].(string)
-			if !ok {
-				return runtime.ImageRunResult{}, fmt.Errorf("skill launch: image-boot re-entry cannot pass non-string override for input %q (got %T): refusing to boot rather than drop or coerce it", k, spec.Inputs[k])
-			}
-			command = append(command, "--input", k+"="+s)
+			command = append(command, "--input", k+"="+fmt.Sprintf("%v", spec.Inputs[k]))
 		}
 	}
 

--- a/cmd/aileron/skill_launch_container_test.go
+++ b/cmd/aileron/skill_launch_container_test.go
@@ -219,41 +219,43 @@ func TestContainerImageRunner_NoOverridesLeavesCommandUnchanged(t *testing.T) {
 	}
 }
 
-// TestContainerImageRunner_NonStringOverrideRefusesBoot proves a non-string value
-// in the map[string]any seam type has no exact name=value round-trip, so the
-// runner refuses the boot with an explicit error rather than coercing or dropping
-// it (#1802's never-silently-drop requirement). The boot must not fire.
-func TestContainerImageRunner_NonStringOverrideRefusesBoot(t *testing.T) {
+// TestContainerImageRunner_TypedOverrideSerializesViaSprintf proves a non-string
+// value in the map[string]any seam type (a typed default the host-side input walk
+// injects on Enter-accept, #2063) serializes to --input k=<%v> and the boot
+// FIRES. The %v round-trip is faithful: the inner re-entry re-parses it as a
+// string and every downstream check compares via %v, so a typed default and its
+// string form are indistinguishable to the plan. This replaces the earlier
+// refuse-non-string guard, which predated the walk.
+func TestContainerImageRunner_TypedOverrideSerializesViaSprintf(t *testing.T) {
 	storeDir := t.TempDir()
 	origStore := skillStoreDir
 	skillStoreDir = storeDir
 	t.Cleanup(func() { skillStoreDir = origStore })
 
-	booted := false
-	orig := containerRunFlightPlan
-	stubBakedCLIVersion(t, "")
-	containerRunFlightPlan = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.RunOptions) (sandboxcontainer.RunResult, error) {
-		booted = true
-		return sandboxcontainer.RunResult{}, nil
-	}
-	t.Cleanup(func() { containerRunFlightPlan = orig })
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
 
 	spec := runtime.ImageRunSpec{
 		Image: "registry.example.com/runner:1.4@sha256:abc",
 		Name:  "weekly-metrics-digest",
 		Inputs: runtime.LaunchArgs{
-			"window_days": 7, // non-string: no exact CLI round-trip
+			"window_days": 7,      // number: an Enter-accepted typed default
+			"enabled":     true,   // bool: another native typed value
+			"account":     "acme", // string: the CLI-override case still works
 		},
 	}
-	_, err := (containerImageRunner{}).Run(context.Background(), spec)
-	if err == nil {
-		t.Fatal("a non-string override must refuse the boot with an error")
+	if _, err := (containerImageRunner{}).Run(context.Background(), spec); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
-	if !strings.Contains(err.Error(), "window_days") {
-		t.Errorf("error must name the offending input, got %v", err)
-	}
-	if booted {
-		t.Error("the image must NOT boot when an override cannot be passed exactly")
+	joined := strings.Join(got.Command, " ")
+	for _, want := range []string{
+		"--input account=acme",
+		"--input enabled=true",
+		"--input window_days=7",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("command %v must carry %q (typed value serialized via %%v)", got.Command, want)
+		}
 	}
 }
 

--- a/cmd/aileron/skill_launch_prompt_test.go
+++ b/cmd/aileron/skill_launch_prompt_test.go
@@ -52,6 +52,19 @@ func TestLinePrompter_PromptInput(t *testing.T) {
 	}
 }
 
+// A drained stdin makes PromptInput propagate a read error rather than silently
+// returning an empty string: the shared promptLine collapses EOF to "", but the
+// interactive prompter uses the EOF-aware readPromptLine so a closed or drained
+// terminal fails the launch instead of resolving a required input to "" (#2063).
+func TestLinePrompter_EOFPropagatesError(t *testing.T) {
+	var out bytes.Buffer
+	p := linePrompter{stdin: strings.NewReader(""), stdout: &out} // immediate EOF
+	in := runtime.Input{Name: "req", Description: "a required value"}
+	if _, err := p.PromptInput(in); err == nil {
+		t.Fatal("a drained stdin must propagate a read error, not a silent empty string")
+	}
+}
+
 func TestInputConstraintHint(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cmd/aileron/skill_launch_walk.go
+++ b/cmd/aileron/skill_launch_walk.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+)
+
+// newLaunchInputWalker constructs the interactive input walker wired into the
+// runtime on an interactive launch (#2063). It is a package-level seam so CLI
+// tests inject a deterministic stdin/stdout and drive the walk without a live
+// TTY, mirroring newLaunchInputPrompter. The caller (runSkillLaunch) decides
+// whether to wire it: it is passed only when the launch is interactive
+// (isTTYFn() && !--accept-defaults), so this constructor never re-checks the
+// TTY.
+var newLaunchInputWalker = func(stdin *bufio.Reader, stdout io.Writer) runtime.InputWalker {
+	return launchInputWalker{stdin: stdin, stdout: stdout}
+}
+
+// launchInputWalker is the guided interactive input walk: it walks every
+// declared input in declaration order, prompting once per literal input
+// (name+description, required/optional marker, current default with
+// Enter-to-accept, enum/pattern hint), re-prompting on an invalid entry. It
+// runs host-side, before container boot, so it feeds inputs into the sealed
+// (frozen-plan) mainline where the in-container prompter is never consulted.
+//
+// The stdin is a persistent *bufio.Reader so bytes buffered past one prompt
+// remain for the next; a fresh wrapper per prompt would buffer-ahead and drop
+// the rest of the input.
+type launchInputWalker struct {
+	stdin  *bufio.Reader
+	stdout io.Writer
+}
+
+// maxDefaultInlineLen bounds the string form of a default rendered inline in a
+// prompt. A default whose string form is larger renders as the same type+size
+// summary the result banner uses (#1888), so a big default never floods the
+// terminal.
+const maxDefaultInlineLen = 256
+
+// Walk resolves every declared literal input into the returned launch args. It
+// starts from the caller's args (the `--input` overrides), leaves those inputs
+// untouched (rendering an "already set" line), prompts for every other literal,
+// and renders a read-only informational line for dynamic and source inputs
+// (never editable). The returned args carry a value for every literal: an
+// operator-typed entry as a string, an Enter-accepted default as its native
+// typed value. On EOF or a read error mid-walk it returns the error and the
+// launch fails, rather than spinning on a drained reader.
+func (w launchInputWalker) Walk(inputs []runtime.Input, args runtime.LaunchArgs) (runtime.LaunchArgs, error) {
+	out := runtime.LaunchArgs{}
+	for k, v := range args {
+		out[k] = v
+	}
+	for _, in := range inputs {
+		if in.Resolution.Rule != runtime.ResolutionLiteral {
+			// Dynamic and source inputs resolve automatically at the boundary;
+			// render a read-only line and never prompt for them.
+			fmt.Fprintln(w.stdout, w.readOnlyLine(in))
+			continue
+		}
+		if _, ok := out[in.Name]; ok {
+			// A literal already supplied via --input keeps its value; show it as
+			// already set and skip the prompt so an override is never re-asked.
+			fmt.Fprintln(w.stdout, w.alreadySetLine(in))
+			continue
+		}
+		val, err := w.walkLiteral(in)
+		if err != nil {
+			return nil, err
+		}
+		// Typing asymmetry (#2063): an operator-typed entry enters the args as a
+		// string (walkLiteral returns the trimmed line); an Enter-accepted
+		// default enters as its NATIVE typed value (walkLiteral returns
+		// in.Resolution.Default verbatim). This is faithful because every
+		// downstream check compares via fmt.Sprintf("%v", v) (EnforceConstraint,
+		// host/command interpolation) and the container `--input` re-entry
+		// serializes both through %v, where every value is a string anyway.
+		out[in.Name] = val
+	}
+	return out, nil
+}
+
+// walkLiteral prompts for one literal input, re-prompting until it reads a valid
+// value or an Enter-accepted default. It returns the native default value on an
+// Enter keypress against a defaulted input, the validated typed string on a
+// non-empty entry, and an error on EOF/read failure.
+func (w launchInputWalker) walkLiteral(in runtime.Input) (any, error) {
+	prompt := w.literalPrompt(in)
+	for {
+		line, err := readPromptLine(w.stdin, w.stdout, prompt)
+		if err != nil {
+			return nil, fmt.Errorf("input %q: read value: %w", in.Name, err)
+		}
+		if line == "" {
+			if in.Resolution.HasDefault {
+				// Enter accepts the declared default as its native typed value.
+				return in.Resolution.Default, nil
+			}
+			// Empty entry on a required-no-default literal: a value is required,
+			// so re-prompt. An empty string can never be entered for such an
+			// input; this routing is intentional (#2063). EOF is distinct from
+			// Enter (readPromptLine returns an error for EOF), so this does not
+			// spin on a drained reader.
+			fmt.Fprintln(w.stdout, "  a value is required")
+			continue
+		}
+		// Validate a typed entry against the declared constraint using the SAME
+		// authoritative pass the final resolveInputs check runs (EnforceConstraint,
+		// #2063), so the walk and the final pass can never disagree. An
+		// unconstrained input (nil Constraint) is accepted as-is, matching
+		// resolveInputs, which skips the enforcement pass for it.
+		if in.Constraint != nil {
+			if err := runtime.EnforceConstraint(in.Name, line, in.Constraint); err != nil {
+				fmt.Fprintf(w.stdout, "  %v\n", err)
+				continue
+			}
+		}
+		return line, nil
+	}
+}
+
+// literalPrompt renders the one-line prompt for a literal input: its name, the
+// declared description, the required/optional marker, the current default with
+// an Enter-to-accept note (optional inputs only), and any enum/pattern hint.
+func (w launchInputWalker) literalPrompt(in runtime.Input) string {
+	var b strings.Builder
+	b.WriteString(in.Name)
+	if in.Description != "" {
+		fmt.Fprintf(&b, " (%s)", in.Description)
+	}
+	if in.Resolution.HasDefault {
+		b.WriteString(" [optional]")
+		fmt.Fprintf(&b, " (default: %s, Enter to accept)", defaultDisplay(in.Resolution.Default))
+	} else {
+		b.WriteString(" [required]")
+	}
+	if hint := inputConstraintHint(in.Constraint); hint != "" {
+		fmt.Fprintf(&b, " %s", hint)
+	}
+	b.WriteString(": ")
+	return b.String()
+}
+
+// readOnlyLine renders the informational line for a dynamic or source input: it
+// is not editable, so the walk shows how it resolves and moves on.
+func (w launchInputWalker) readOnlyLine(in runtime.Input) string {
+	var b strings.Builder
+	b.WriteString(in.Name)
+	if in.Description != "" {
+		fmt.Fprintf(&b, " (%s)", in.Description)
+	}
+	switch in.Resolution.Rule {
+	case runtime.ResolutionDynamic:
+		fmt.Fprintf(&b, " [resolved at launch: %s]", in.Resolution.DynamicValue)
+	case runtime.ResolutionSource:
+		fmt.Fprintf(&b, " [resolved from source: %s]", in.Resolution.SourceActionRef)
+	default:
+		b.WriteString(" [resolved automatically]")
+	}
+	return b.String()
+}
+
+// alreadySetLine renders the line for a literal already supplied via --input: it
+// keeps its override value and is not re-prompted.
+func (w launchInputWalker) alreadySetLine(in runtime.Input) string {
+	var b strings.Builder
+	b.WriteString(in.Name)
+	if in.Description != "" {
+		fmt.Fprintf(&b, " (%s)", in.Description)
+	}
+	b.WriteString(" [already set via --input]")
+	return b.String()
+}
+
+// defaultDisplay renders a declared default for the prompt: its string form when
+// short, or the type+size summary (#1888) when its string form is large, so a
+// big default never floods the terminal.
+func defaultDisplay(v any) string {
+	s := fmt.Sprintf("%v", v)
+	if len(s) > maxDefaultInlineLen {
+		return summarizeInputValue(v)
+	}
+	return s
+}
+
+// readPromptLine writes prompt to stdout and reads one newline-terminated line
+// from stdin, returning it (newline-stripped) and any read error. Unlike the
+// shared promptLine in main.go (which collapses EOF to "" and swallows the
+// error), it PROPAGATES the read error so an interactive walk terminates on a
+// drained reader or a mid-walk stdin close instead of spinning: an Enter
+// keypress returns ("", nil) while EOF on an empty read returns ("", err), so
+// the two are distinguishable. A partial final line with content but no trailing
+// newline is returned as the value (the error surfaces on the next, empty read).
+//
+// stdin is wrapped in a *bufio.Reader only when it isn't one already, so a
+// caller that prompts more than once (the walker, the multi-prompt binding
+// flows) passes a persistent *bufio.Reader and subsequent reads see the buffered
+// remainder rather than a fresh buffer-ahead dropping it.
+func readPromptLine(stdin io.Reader, stdout io.Writer, prompt string) (string, error) {
+	fmt.Fprint(stdout, prompt)
+	br, ok := stdin.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(stdin)
+	}
+	line, err := br.ReadString('\n')
+	trimmed := strings.TrimRight(line, "\r\n")
+	if err != nil && trimmed == "" {
+		return "", err
+	}
+	return trimmed, nil
+}

--- a/cmd/aileron/skill_launch_walk_e2e_test.go
+++ b/cmd/aileron/skill_launch_walk_e2e_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// stubLaunchTTY forces isTTYFn to report the given interactivity for the test.
+func stubLaunchTTY(t *testing.T, tty bool) {
+	t.Helper()
+	orig := isTTYFn
+	isTTYFn = func() bool { return tty }
+	t.Cleanup(func() { isTTYFn = orig })
+}
+
+// stubLaunchWalkerStdin swaps the walker seam for one reading a scripted stdin,
+// recording whether it was ever constructed (the launch is interactive) so a
+// test can assert the walk ran or was skipped.
+func stubLaunchWalkerStdin(t *testing.T, script string) *bool {
+	t.Helper()
+	constructed := false
+	orig := newLaunchInputWalker
+	newLaunchInputWalker = func(_ *bufio.Reader, stdout io.Writer) runtime.InputWalker {
+		constructed = true
+		return launchInputWalker{stdin: bufio.NewReader(strings.NewReader(script)), stdout: stdout}
+	}
+	t.Cleanup(func() { newLaunchInputWalker = orig })
+	return &constructed
+}
+
+// usePassthroughImageRunner routes launch through the REAL containerImageRunner
+// (zero-value passthrough) so the boot command is recorded via
+// containerRunFlightPlan, rather than the fake image runner that bypasses
+// serialization.
+func usePassthroughImageRunner(t *testing.T) {
+	t.Helper()
+	orig := newLaunchImageRunner
+	newLaunchImageRunner = func() runtime.ImageRunner { return containerImageRunner{} }
+	t.Cleanup(func() { newLaunchImageRunner = orig })
+}
+
+// TestRunSkillLaunch_TTYWalkFeedsSealedBoot is the contract-level proof the
+// guided walk is LIVE on the image-pinned mainline (#2063): on a faked TTY the
+// host-side walk runs before container boot, and its Enter-accepted typed
+// default (window_days=7, a native number) reaches the recorded boot command as
+// --input window_days=7. The in-container prompter is never consulted for a
+// sealed plan, so only the host-side walk can feed this input.
+func TestRunSkillLaunch_TTYWalkFeedsSealedBoot(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	usePassthroughImageRunner(t)
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	stubLaunchTTY(t, true)
+	walked := stubLaunchWalkerStdin(t, "\n") // Enter-accept the window_days default
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !*walked {
+		t.Fatal("an interactive TTY launch must run the guided walk")
+	}
+	joined := strings.Join(got.Command, " ")
+	if !strings.Contains(joined, "--input window_days=7") {
+		t.Errorf("boot command must carry the walk's Enter-accepted typed default, got %v", got.Command)
+	}
+}
+
+// TestRunSkillLaunch_AcceptDefaultsSkipsWalk proves --accept-defaults reproduces
+// today's silent-default one-shot launch even on a TTY: the walk never runs, no
+// prompt is emitted, and the boot command carries no walked --input.
+func TestRunSkillLaunch_AcceptDefaultsSkipsWalk(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	usePassthroughImageRunner(t)
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	stubLaunchTTY(t, true)
+	walked := stubLaunchWalkerStdin(t, "should-not-be-read\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--accept-defaults", "--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if *walked {
+		t.Fatal("--accept-defaults must skip the guided walk even on a TTY")
+	}
+	for _, a := range got.Command {
+		if a == "--input" {
+			t.Errorf("--accept-defaults must emit no walked --input flags, got %v", got.Command)
+		}
+	}
+}
+
+// TestRunSkillLaunch_NonTTYSkipsWalk proves a non-TTY launch (piped stdin, CI)
+// implies --accept-defaults: the walk never runs.
+func TestRunSkillLaunch_NonTTYSkipsWalk(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	usePassthroughImageRunner(t)
+
+	var got sandboxcontainer.RunOptions
+	stubContainerBoot(t, &got, nil)
+	stubLaunchTTY(t, false)
+	walked := stubLaunchWalkerStdin(t, "should-not-be-read\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if *walked {
+		t.Fatal("a non-TTY launch must not run the guided walk")
+	}
+}
+
+// freezeRequiredInputForLaunch installs a no-environment variant of the worked
+// example with window_days's default removed, so window_days becomes a required
+// literal (no default) resolved on the in-process path. The launch fails fast if
+// the input is neither overridden nor prompted.
+func freezeRequiredInputForLaunch(t *testing.T, storeDir string) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripped := stripEnvironmentBlock(t, string(raw))
+	// Remove the window_days default so it becomes a required-no-default literal.
+	required := strings.Replace(stripped, "\n        default: 7", "", 1)
+	if required == stripped {
+		t.Fatal("failed to remove the window_days default from the worked example")
+	}
+	dir := filepath.Join(storeDir, "weekly-metrics-digest")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(required), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	var out, errOut bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &out, &errOut); code != 0 {
+		t.Fatalf("freeze required-input variant failed: %s", errOut.String())
+	}
+}
+
+// TestRunSkillLaunch_AcceptDefaultsFailFastOnRequired is the round-2 P0
+// regression: a required-with-no-default literal under --accept-defaults on a
+// TTY must fail fast WITHOUT prompting (both interactive seams nil, so
+// resolveLiteral fail-fasts), rather than blocking on a prompt or silently
+// resolving to empty.
+func TestRunSkillLaunch_AcceptDefaultsFailFastOnRequired(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeRequiredInputForLaunch(t, storeDir)
+	stubLaunchSeams(t, &fakeLaunchDispatcher{results: map[string]map[string]any{}})
+	stubLaunchTTY(t, true)
+	walked := stubLaunchWalkerStdin(t, "would-satisfy-it\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--accept-defaults", "--out-dir", t.TempDir(), "weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("a required-no-default input under --accept-defaults must fail fast, stdout=%s", stdout.String())
+	}
+	if *walked {
+		t.Fatal("--accept-defaults must not prompt for the required input")
+	}
+	if !strings.Contains(stderr.String(), "is required") {
+		t.Errorf("failure must name the missing required input, stderr=%s", stderr.String())
+	}
+}

--- a/cmd/aileron/skill_launch_walk_test.go
+++ b/cmd/aileron/skill_launch_walk_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+)
+
+// newWalker builds a launchInputWalker over a scripted stdin and a capture
+// buffer, returning both so a test drives the walk and inspects the rendered
+// prompts.
+func newWalker(input string) (launchInputWalker, *strings.Builder) {
+	var out strings.Builder
+	return launchInputWalker{stdin: bufio.NewReader(strings.NewReader(input)), stdout: &out}, &out
+}
+
+func litDefault(name, desc string, def any) runtime.Input {
+	return runtime.Input{Name: name, Description: desc, Resolution: runtime.Resolution{Rule: runtime.ResolutionLiteral, HasDefault: true, Default: def}}
+}
+
+func litRequired(name, desc string) runtime.Input {
+	return runtime.Input{Name: name, Description: desc, Resolution: runtime.Resolution{Rule: runtime.ResolutionLiteral}}
+}
+
+// The walk prompts literals in declaration order.
+func TestWalk_DeclarationOrder(t *testing.T) {
+	w, out := newWalker("\n\n\n") // accept all three defaults
+	inputs := []runtime.Input{
+		litDefault("alpha", "first", "a"),
+		litDefault("bravo", "second", "b"),
+		litDefault("charlie", "third", "c"),
+	}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	s := out.String()
+	iA, iB, iC := strings.Index(s, "alpha"), strings.Index(s, "bravo"), strings.Index(s, "charlie")
+	if !(iA >= 0 && iA < iB && iB < iC) {
+		t.Errorf("prompts must appear in declaration order, got:\n%s", s)
+	}
+}
+
+// A required input renders [required]; an optional (defaulted) input renders
+// [optional] with the default and an Enter-to-accept note.
+func TestWalk_RequiredOptionalMarkers(t *testing.T) {
+	w, out := newWalker("typed\n\n") // required: "typed", optional: Enter-accept
+	inputs := []runtime.Input{
+		litRequired("req", "a required one"),
+		litDefault("opt", "an optional one", "d7"),
+	}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "[required]") {
+		t.Errorf("required input must render [required]:\n%s", s)
+	}
+	if !strings.Contains(s, "[optional]") || !strings.Contains(s, "default: d7") || !strings.Contains(s, "Enter to accept") {
+		t.Errorf("optional input must render [optional] + default + Enter note:\n%s", s)
+	}
+}
+
+// Enter on an optional input injects the declared default as its NATIVE typed
+// value (a number stays a number); a typed entry enters as a string.
+func TestWalk_EnterAcceptsTypedDefault(t *testing.T) {
+	w, _ := newWalker("\ncustom\n") // accept default, then type a value
+	inputs := []runtime.Input{
+		litDefault("window_days", "days", 7), // native number default
+		litRequired("account", "acct"),
+	}
+	got, err := w.Walk(inputs, nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got["window_days"] != 7 {
+		t.Errorf("Enter-accepted default must inject the native typed value 7, got %#v", got["window_days"])
+	}
+	if got["account"] != "custom" {
+		t.Errorf("typed entry must enter as a string, got %#v", got["account"])
+	}
+}
+
+// A literal already supplied via --input keeps its value, is shown as already
+// set, and is never prompted.
+func TestWalk_OverrideSkipsPrompt(t *testing.T) {
+	w, out := newWalker("") // no stdin needed: the only input is pre-set
+	inputs := []runtime.Input{litDefault("account", "acct", "default-acct")}
+	got, err := w.Walk(inputs, runtime.LaunchArgs{"account": "given"})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got["account"] != "given" {
+		t.Errorf("override must be preserved, got %#v", got["account"])
+	}
+	if !strings.Contains(out.String(), "already set") {
+		t.Errorf("an overridden input must render an already-set line:\n%s", out.String())
+	}
+}
+
+// An entry violating a constraint re-prompts; a subsequent valid entry succeeds
+// with no final-pass failure.
+func TestWalk_InvalidReprompts(t *testing.T) {
+	w, out := newWalker("dev\nprod\n") // "dev" is rejected, "prod" accepted
+	inputs := []runtime.Input{{
+		Name:       "env",
+		Resolution: runtime.Resolution{Rule: runtime.ResolutionLiteral},
+		Constraint: &runtime.Constraint{Enum: []string{"prod", "staging"}},
+	}}
+	got, err := w.Walk(inputs, nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got["env"] != "prod" {
+		t.Errorf("re-prompt must accept the valid entry, got %#v", got["env"])
+	}
+	// The rejected value's constraint message must have surfaced.
+	if !strings.Contains(out.String(), "allowed values") {
+		t.Errorf("an invalid entry must print the constraint failure:\n%s", out.String())
+	}
+}
+
+// A drained reader terminates the walk with an error rather than spinning.
+func TestWalk_EOFTerminates(t *testing.T) {
+	w, _ := newWalker("") // required input, immediate EOF
+	inputs := []runtime.Input{litRequired("req", "needs a value")}
+	if _, err := w.Walk(inputs, nil); err == nil {
+		t.Fatal("a drained reader on a required input must return an error, not spin")
+	}
+}
+
+// Dynamic and source inputs are never prompted: the walk renders a read-only
+// line and reads no stdin for them.
+func TestWalk_DynamicAndSourceNeverPrompted(t *testing.T) {
+	w, out := newWalker("") // no stdin: nothing may read
+	inputs := []runtime.Input{
+		{Name: "as_of", Resolution: runtime.Resolution{Rule: runtime.ResolutionDynamic, DynamicValue: "now"}},
+		{Name: "live", Resolution: runtime.Resolution{Rule: runtime.ResolutionSource, SourceActionRef: "aileron:m.q"}},
+	}
+	got, err := w.Walk(inputs, nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if _, ok := got["as_of"]; ok {
+		t.Error("a dynamic input must not be collected into the walk args")
+	}
+	s := out.String()
+	if !strings.Contains(s, "as_of") || !strings.Contains(s, "resolved at launch") {
+		t.Errorf("dynamic input must render a read-only line:\n%s", s)
+	}
+	if !strings.Contains(s, "resolved from source") {
+		t.Errorf("source input must render a read-only line:\n%s", s)
+	}
+}
+
+// A default whose string form is large renders as a type+size summary, not the
+// raw value.
+func TestWalk_LargeDefaultSummarized(t *testing.T) {
+	big := strings.Repeat("x", maxDefaultInlineLen+1)
+	w, out := newWalker("\n") // accept the large default
+	inputs := []runtime.Input{litDefault("blob", "a big one", big)}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	s := out.String()
+	if strings.Contains(s, big) {
+		t.Errorf("a large default must not be rendered raw:\n%s", s)
+	}
+	if !strings.Contains(s, "<string,") {
+		t.Errorf("a large default must render as a type+size summary:\n%s", s)
+	}
+}
+
+// Enter on a required-no-default literal routes to "a value is required" and
+// re-prompts; an empty string can never be entered for such an input
+// (documented intentional, #2063).
+func TestWalk_EmptyRequiredReprompts(t *testing.T) {
+	w, out := newWalker("\nfinally\n") // Enter (rejected), then a value
+	inputs := []runtime.Input{litRequired("token", "a secret")}
+	got, err := w.Walk(inputs, nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if got["token"] != "finally" {
+		t.Errorf("re-prompt must accept the eventual value, got %#v", got["token"])
+	}
+	if !strings.Contains(out.String(), "a value is required") {
+		t.Errorf("an empty entry on a required input must print the required message:\n%s", out.String())
+	}
+}
+
+// A pattern-constrained input shows its hint in the prompt.
+func TestWalk_ConstraintHintShown(t *testing.T) {
+	w, out := newWalker("us-east-1\n")
+	inputs := []runtime.Input{{
+		Name:       "region",
+		Resolution: runtime.Resolution{Rule: runtime.ResolutionLiteral},
+		Constraint: &runtime.Constraint{Pattern: regexp.MustCompile("^us-[a-z]+-[0-9]$")},
+	}}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !strings.Contains(out.String(), "^us-[a-z]+-[0-9]$") {
+		t.Errorf("prompt must carry the pattern hint:\n%s", out.String())
+	}
+}

--- a/docs/src/content/docs/guides/launching-a-flight-plan.md
+++ b/docs/src/content/docs/guides/launching-a-flight-plan.md
@@ -17,7 +17,19 @@ aileron skill launch weekly-metrics-digest --out-dir ./run
 
 The runtime loads the most recent frozen version of that skill from the canonical store. Pass `--version` to launch a specific version id. Pass `--input name=value` once per literal input you want to override. File-target outputs are written under `--out-dir`.
 
-When you run an interactive launch from a terminal and a required literal input has no `--input` override and no declared default, the launch prompts you for its value instead of failing. The prompt shows the input name, its declared description, and any enum or pattern constraint so you know the accepted shape. The value you type is validated by the same constraint check as an `--input` override, so an out-of-constraint answer still fails the launch closed. A non-interactive launch, one with piped stdin or a launch run in CI, never prompts. There, a missing required literal fails fast with the same error as before, so a scripted launch never blocks waiting on input.
+## The guided input walk
+
+When you launch from a terminal, the runtime walks every declared input with you before it boots the plan. This guided walk is the default on an interactive terminal. It runs host-side, before any container boots, so it works the same for a plan that pins a sealed environment image as for one that runs in process.
+
+The walk visits each input in declaration order and prompts once per literal input. Each prompt shows the input name, its declared description, a `[required]` or `[optional]` marker, and any enum or pattern constraint hint so you know the accepted shape. An optional input also shows its current default and accepts it when you press Enter. Enter on an optional input keeps the declared default as its native typed value, so a number default stays a number.
+
+A value you type is validated against the input's declared constraint using the same check the final resolution pass runs. An out-of-constraint entry prints the reason and re-prompts, so you correct it in place rather than failing the whole launch. A default whose text form is large renders as a compact `<type, size>` summary instead of flooding the terminal.
+
+An input you already set with `--input name=value` is shown as already set and is not re-prompted. Dynamic and source inputs are never editable. The walk renders a read-only line explaining how each one resolves and moves on.
+
+A required literal that declares no default has no default to accept. Pressing Enter on it prints `a value is required` and re-prompts. You cannot enter an empty string for such an input; this routing is intentional, so a required value is always supplied deliberately.
+
+Pass `--accept-defaults` to skip the walk and reproduce the silent one-shot launch. Every input then resolves to its `--input` override or its declared default with no prompting, and a required literal with neither fails fast with a clear error. A non-interactive launch, one with piped stdin or a launch run in CI, implies `--accept-defaults`: the walk only runs on an interactive terminal, so a scripted launch never blocks waiting on input.
 
 The launch prints a result summary: the version, the content hash, the written artifacts, and the audit-record count. The resolved inputs are listed by name with a compact `<type, size>` summary rather than their full values, so a plan that passes a large input (such as an inlined document) does not bury the result under a wall of text. Pass `--verbose` (or `-v`) to print the full resolved-input values.
 
@@ -42,7 +54,7 @@ The single marked seam is the `llm-seam` step. It is the only kind that may reac
 
 ## Input resolution at the launch boundary
 
-Every declared input resolves once, at the launch boundary, into a concrete value. The resolution rule decides how. A `literal` input takes its launch override, then its declared default. A required literal with neither is prompted for interactively when the launch runs from a terminal, and is an error otherwise. A `dynamic` input reads the launch clock once. `now` resolves to the launch timestamp and `today` resolves to the launch date. The runtime reads the clock a single time and reuses that value for every dynamic input, so two steps that read the same dynamic input always see one value. A `source` input is read live from a declared action through the sealed boundary. The runtime records the read by its resolved binding, the action ref and the selector, never the dataset inline.
+Every declared input resolves once, at the launch boundary, into a concrete value. The resolution rule decides how. A `literal` input takes its launch override, then a value collected by the guided walk, then its declared default. A required literal with none of these is an error under `--accept-defaults` or a non-interactive launch, and is collected by the walk on an interactive terminal. A `dynamic` input reads the launch clock once. `now` resolves to the launch timestamp and `today` resolves to the launch date. The runtime reads the clock a single time and reuses that value for every dynamic input, so two steps that read the same dynamic input always see one value. A `source` input is read live from a declared action through the sealed boundary. The runtime records the read by its resolved binding, the action ref and the selector, never the dataset inline.
 
 A `source` input that reads from the same action a step calls is not a step and not a graph edge. The acyclicity check covers `steps.*` edges only. The source read happens in the resolution phase, before the step graph walks.
 

--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -88,7 +88,7 @@ func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *
 		if in.Constraint == nil {
 			continue
 		}
-		if err := enforceConstraint(in.Name, ri.Values[in.Name], in.Constraint); err != nil {
+		if err := EnforceConstraint(in.Name, ri.Values[in.Name], in.Constraint); err != nil {
 			return ResolvedInputs{}, err
 		}
 	}
@@ -112,13 +112,17 @@ func capResolvedValue(s string) string {
 	return s[:maxResolvedValueInError] + "...(truncated)"
 }
 
-// enforceConstraint checks a resolved value against its declared constraint.
+// EnforceConstraint checks a resolved value against its declared constraint.
 // The comparison is over the value's string form (fmt.Sprintf("%v", v)), so a
 // number or timestamp input stays checkable: enum requires equality with one
 // allowed string, pattern requires the compiled regexp to match. A violation
 // names the input, the (capped) value, and the constraint so the failure is
 // actionable without echoing an unbounded resolved value back to the operator.
-func enforceConstraint(name string, v any, c *Constraint) error {
+//
+// It is exported so the CLI's interactive input walk validates a typed entry
+// against the SAME authoritative constraint pass the final resolveInputs check
+// runs (#2063), rather than mirroring the logic and risking drift.
+func EnforceConstraint(name string, v any, c *Constraint) error {
 	s := fmt.Sprintf("%v", v)
 	capped := capResolvedValue(s)
 	if c.Pattern != nil {

--- a/internal/flightplan/runtime/interp.go
+++ b/internal/flightplan/runtime/interp.go
@@ -23,7 +23,7 @@ func commandInputRefs(s string) ([]string, error) {
 // instantiateCommand resolves a tool step's TEMPLATE argv into the argv the
 // runner execs, substituting each `{{ inputs.<name> }}` token with the string
 // form of the resolved plan input (fmt.Sprintf("%v", v), matching the constraint
-// enforcement in enforceConstraint). It returns the resolved argv plus the
+// enforcement in EnforceConstraint). It returns the resolved argv plus the
 // sorted-by-appearance indices of the elements that carried a token (the
 // input-derived marker the audit records).
 //
@@ -77,7 +77,7 @@ var hostShapePattern = regexp.MustCompile(`^[a-zA-Z0-9.-]+(:[0-9]+)?$`)
 // concrete hosts the step-scope mint enforces (#1959), substituting each
 // `{{ inputs.<name> }}` token with the string form of the resolved plan input
 // (fmt.Sprintf("%v", v), matching instantiateCommand and the constraint
-// enforcement in enforceConstraint). Host tokens reference PLAN inputs, so the
+// enforcement in EnforceConstraint). Host tokens reference PLAN inputs, so the
 // lookup is against values (ResolvedInputs.Values), the same source
 // instantiateCommand uses.
 //

--- a/internal/flightplan/runtime/interp_test.go
+++ b/internal/flightplan/runtime/interp_test.go
@@ -61,7 +61,7 @@ func TestInstantiateCommand_TokenFreePassthrough(t *testing.T) {
 }
 
 // TestInstantiateCommand_NonStringValue proves a non-string resolved value is
-// substituted via its %v string form, matching enforceConstraint.
+// substituted via its %v string form, matching EnforceConstraint.
 func TestInstantiateCommand_NonStringValue(t *testing.T) {
 	resolved, _, err := instantiateCommand(
 		[]string{"--limit={{inputs.n}}"},

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -115,7 +115,27 @@ type Options struct {
 	// treated identically to a `--input name=value` override: it is deep-copied
 	// into the frozen resolved set and validated by the same final constraint
 	// pass.
+	//
+	// On the interactive path the InputWalker (below) resolves every literal into
+	// Inputs before either branch runs, so a still-wired InputPrompter is never
+	// consulted there; the seam is retained for the non-walk path and its own
+	// tests.
 	InputPrompter InputPrompter
+
+	// InputWalker runs a host-side interactive pass over every declared literal
+	// input BEFORE the image-boot / in-process branch (#2063), collecting a value
+	// for each into Inputs. It is the only interactive seam that reaches the
+	// sealed-image mainline: the in-container prompter is never consulted for a
+	// whole-plan-pinned unit (Run short-circuits to the boot before resolveInputs
+	// runs), so wiring only InputPrompter would ship the guided walk inert on the
+	// primary path. Run consults it only when it is non-nil AND this run is NOT
+	// the in-container image-boot re-entry (InPinnedImage): the re-entry runs
+	// non-TTY and must never re-walk, so gating on InPinnedImage makes
+	// no-recursion structural rather than dependent on the container's TTY state.
+	// Nil (the default) skips the walk and keeps today's silent-default one-shot
+	// launch. The CLI wires it only on an interactive TTY without
+	// `--accept-defaults`.
+	InputWalker InputWalker
 
 	// OutDir is the directory file-target artifacts are written to. Empty
 	// skips writing (artifacts are still recorded in the result).
@@ -156,6 +176,23 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	// verifier on the image-boot re-entry, where the host already gated).
 	if err := gatePublisher(opts.PublisherVerifier, lp); err != nil {
 		return RunResult{}, err
+	}
+	// Host-side interactive input walk (#2063). It runs BEFORE the image-boot /
+	// in-process branch so the guided walk reaches the sealed-image mainline: a
+	// whole-plan-pinned unit short-circuits to runInImage before resolveInputs
+	// (the InputPrompter caller) ever runs, so the walk is the only interactive
+	// surface that can collect inputs on the boot path. The collected values are
+	// merged into opts.Inputs, and BOTH downstream branches then consume them
+	// identically (the image path threads them onto the container `--input`
+	// re-entry; the in-process path resolves them as overrides). Gated on
+	// !InPinnedImage so the in-container re-entry never re-walks (structural
+	// no-recursion, not dependent on the container's non-TTY state).
+	if opts.InputWalker != nil && !opts.InPinnedImage {
+		walked, err := opts.InputWalker.Walk(lp.Plan.Inputs, opts.Inputs)
+		if err != nil {
+			return RunResult{}, err
+		}
+		opts.Inputs = walked
 	}
 	// A tool step requires the plan's declared environment: its argv is
 	// signed against the composed image the lock pinned, so executing it

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -168,6 +168,26 @@ type InputPrompter interface {
 	PromptInput(in Input) (string, error)
 }
 
+// InputWalker resolves EVERY declared literal input into a launch-args set by
+// walking the declared inputs in declaration order, one interactive prompt each
+// (#2063). Unlike InputPrompter (which the runtime consults only for a missing
+// required literal), the walker is a host-side pre-pass Run runs BEFORE the
+// image-boot / in-process branch, so it reaches the sealed-image (frozen-plan)
+// mainline where the in-container prompter is never consulted. The runtime hands
+// it the plan's declared inputs and the launch args parsed from `--input`, and
+// the walker returns a merged LaunchArgs carrying a value for every literal:
+// an operator-typed entry as a string, an Enter-accepted default as its native
+// typed value. Both downstream paths then consume the merged args identically
+// (the image path serializes them onto the `--input` container re-entry, the
+// in-process path resolves them as overrides in resolveInputs). Dynamic and
+// source inputs are never editable; the walker renders a read-only line and
+// resolves them normally at the boundary. Nil (the default) skips the walk, so a
+// non-interactive launch keeps today's silent-default one-shot behavior. The CLI
+// wires it only on an interactive TTY that did not pass `--accept-defaults`.
+type InputWalker interface {
+	Walk(inputs []Input, args LaunchArgs) (LaunchArgs, error)
+}
+
 // ImageRunSpec is the input to the ImageRunner seam. It carries the verified
 // pinned image (the `ref@digest` string the runtime booted from the signed
 // lock) plus everything the in-container launch needs to run the plan to

--- a/internal/flightplan/runtime/walk_test.go
+++ b/internal/flightplan/runtime/walk_test.go
@@ -1,0 +1,150 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// fakeWalker is a test InputWalker that merges a canned set of collected values
+// into the launch args and records the inputs it was handed, so a test asserts
+// both that the walk ran and that its output reached the downstream boot/resolve
+// path. A nil collected map records the call without changing the args.
+type fakeWalker struct {
+	collected map[string]any
+	gotInputs []Input
+	called    bool
+}
+
+func (f *fakeWalker) Walk(inputs []Input, args LaunchArgs) (LaunchArgs, error) {
+	f.called = true
+	f.gotInputs = inputs
+	out := LaunchArgs{}
+	for k, v := range args {
+		out[k] = v
+	}
+	for k, v := range f.collected {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// A wired InputWalker runs host-side on the SEALED-IMAGE path and its collected
+// values reach the ImageRunner's spec.Inputs. This is the acceptance-critical
+// proof the walk is NOT inert on the boot mainline: the in-container prompter is
+// never consulted for a whole-plan-pinned unit, so only the host-side walk can
+// feed inputs into the boot.
+func TestRun_InputWalkerFeedsSealedImageBoot(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	fake := &fakeImageRunner{result: ImageRunResult{ContentHash: "sha256:booted"}}
+	// window_days is the plan's one literal input; the walk collects a typed
+	// default-native value for it (14, a number), which must reach the boot.
+	walker := &fakeWalker{collected: map[string]any{"window_days": 14}}
+	_, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "weekly-metrics-digest",
+		Version:     "test",
+		ImageRunner: fake,
+		InputWalker: walker,
+	})
+	if err != nil {
+		t.Fatalf("Run boot path: %v", err)
+	}
+	if !walker.called {
+		t.Fatal("the InputWalker must run host-side before the image boot")
+	}
+	if !fake.called {
+		t.Fatal("Run did not delegate to the ImageRunner")
+	}
+	if got := fake.spec.Inputs["window_days"]; got != 14 {
+		t.Errorf("walked value did not reach the boot spec: spec.Inputs = %v", fake.spec.Inputs)
+	}
+	// The walk was handed the plan's declared inputs so it can render every one.
+	if len(walker.gotInputs) == 0 {
+		t.Error("the walker must be handed the plan's declared inputs")
+	}
+}
+
+// The in-container image-boot re-entry (InPinnedImage) must NOT invoke the
+// walker: the structural no-recursion guard is the InPinnedImage gate, not the
+// container's non-TTY state.
+func TestRun_InPinnedImageReentrySkipsWalker(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	walker := &fakeWalker{collected: map[string]any{"window_days": 99}}
+	_, err := Run(context.Background(), Options{
+		Store:         s,
+		Name:          "weekly-metrics-digest",
+		Version:       "test",
+		InPinnedImage: true,
+		InputWalker:   walker,
+		Dispatcher:    disp,
+		Approver:      &fakeApprover{decision: Decision{Approved: true}},
+		Seam:          fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:         FixedClock{},
+		Transforms:    reg,
+		OutDir:        t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run in-container re-entry: %v", err)
+	}
+	if walker.called {
+		t.Fatal("the image-boot re-entry (InPinnedImage) must never invoke the walker")
+	}
+}
+
+// On the in-process path (no pinned image) the walked values flow through
+// resolveInputs as overrides and land in the resolved-input set.
+func TestRun_InputWalkerFeedsInProcessResolve(t *testing.T) {
+	fv := frozenNoImage(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-exec-env", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	walker := &fakeWalker{collected: map[string]any{"window_days": "30"}}
+	res, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "no-exec-env",
+		Version:     "test",
+		InputWalker: walker,
+		Dispatcher:  disp,
+		Approver:    &fakeApprover{decision: Decision{Approved: true}},
+		Seam:        fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:       FixedClock{},
+		Transforms:  reg,
+		OutDir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run in-process path: %v", err)
+	}
+	if !walker.called {
+		t.Fatal("the InputWalker must run on the in-process path")
+	}
+	if got := res.ResolvedInputs["window_days"]; got != "30" {
+		t.Errorf("walked override did not reach the resolved inputs: got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

On a TTY, a **guided input walk** is now the default for `aileron skill launch`. It walks every declared **literal** input in declaration order, prompting once per input (name + description, `[required]`/`[optional]` marker, current default with Enter-to-accept, enum/pattern hint) and re-prompting on an invalid entry. Crucially the walk runs **host-side, before container boot**, so it works on the sealed-image (frozen-plan) mainline — where the in-container prompter is never consulted (`Run` short-circuits to `runInImage` before `resolveInputs`). `--accept-defaults` (implied by a non-TTY launch) reproduces today's silent-default one-shot launch.

No flight-plan schema change (the `example`/`prompt` fields are #2064). Required-ness stays derived from `!HasDefault`.

### What changed
- **`internal/flightplan/runtime`**
  - New `InputWalker` SPI (`spi.go`) and `Options.InputWalker` field.
  - `Run` runs the walk after the publisher gate and **before** the image/in-process branch, gated on `!InPinnedImage` so the in-container re-entry never re-walks (structural no-recursion). Collected values merge into `opts.Inputs`; both downstream paths consume them.
  - Exported `EnforceConstraint` (was `enforceConstraint`) so the walk's re-prompt validation and the final `resolveInputs` pass call the **same** authoritative check.
- **`cmd/aileron`**
  - New `skill_launch_walk.go`: `launchInputWalker` implementing the walk, an EOF-aware `readPromptLine` that terminates on a drained/closed stdin instead of spinning, and the `newLaunchInputWalker` seam.
  - `--accept-defaults` flag; `interactive := isTTYFn() && !--accept-defaults` wires **both** interactive seams (`InputWalker` + `InputPrompter`, the walk preempts the prompter) or **neither**.
  - `linePrompter.PromptInput` switched to the EOF-aware helper so it propagates read errors.
  - Container re-entry serialization relaxed from refuse-non-string to `%v`, so an Enter-accepted **typed** default round-trips faithfully (every downstream check compares via `%v`).
- **Docs**: launch guide describes the walk, `--accept-defaults` + non-TTY implication, read-only dynamic/source lines, large-default `<type, size>` summary, and the intentional empty-required behavior. No top-level `README.md` change (it has 0 `skill launch` mentions).

## Test plan
- `go test ./internal/flightplan/runtime/...` and `go test ./cmd/aileron/` — both green.
- `go vet` clean on both modules; `gofmt` clean.
- New tests:
  - Runtime: walker feeds the **sealed-image** boot (`fakeImageRunner.spec.Inputs`), `InPinnedImage` re-entry skips the walker, walker feeds the in-process resolve.
  - Walker unit: declaration order, required/optional markers, Enter-accepts-typed-default, `--input` override skips-and-shows-already-set, invalid re-prompts then succeeds, EOF terminates (no infinite loop on a drained reader), dynamic/source never prompted, large default summarized, empty-required re-prompts, constraint hint shown.
  - Container: typed override serializes via `%v` and boots (replaces the old non-string-refusal test).
  - CLI e2e: TTY walk feeds the recorded sealed boot command (`--input window_days=7`, a typed Enter-accepted default); `--accept-defaults` and non-TTY both skip the walk; round-2 P0 regression — a required-no-default input under `--accept-defaults` on a TTY fails fast **without** prompting.
  - Prompter EOF-propagation test.
- Coverage on new walk/serialization/wiring code is 88–100% per function.

Closes #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive launches now guide users through required inputs on TTYs, including defaults, validation hints, and re-prompts for invalid values.
  * Added `--accept-defaults` to skip interactive prompts and use defaults or provided values automatically.
  * Typed override values are now accepted and passed through correctly in launches.

* **Bug Fixes**
  * EOF or closed input now returns an error instead of being treated as an empty response.
  * Required inputs without defaults now fail clearly in non-interactive or `--accept-defaults` runs.

* **Documentation**
  * Updated launch guidance to describe the new interactive input flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->