### PR TITLE
fix(flightplan): refuse tool-step-no-image before the interactive walk

### DIFF
--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -177,6 +177,20 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	if err := gatePublisher(opts.PublisherVerifier, lp); err != nil {
 		return RunResult{}, err
 	}
+	// A tool step requires the plan's declared environment: its argv is
+	// signed against the composed image the lock pinned, so executing it
+	// anywhere else (the operator's host, an unpinned in-process run) would
+	// enter an environment the attestation never certified. Refuse a
+	// tool-step plan with no pinned environment unless this run is ALREADY
+	// inside the booted pin (#1829). This fail-closed check precedes the
+	// interactive input walk below so a doomed tool-step run refuses BEFORE
+	// dragging the operator through a guided walk it can only discard; the
+	// refusal never reads opts.Inputs, so ordering it first is behavior-
+	// preserving for every run that does proceed.
+	if planHasToolSteps(lp.Plan) && len(lp.ResolvedImages) == 0 && !opts.InPinnedImage {
+		return RunResult{}, fmt.Errorf(
+			"flightplan: plan declares tool steps but pins no environment image; tool steps run only inside the declared environment")
+	}
 	// Host-side interactive input walk (#2063). It runs BEFORE the image-boot /
 	// in-process branch so the guided walk reaches the sealed-image mainline: a
 	// whole-plan-pinned unit short-circuits to runInImage before resolveInputs
@@ -193,16 +207,6 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 			return RunResult{}, err
 		}
 		opts.Inputs = walked
-	}
-	// A tool step requires the plan's declared environment: its argv is
-	// signed against the composed image the lock pinned, so executing it
-	// anywhere else (the operator's host, an unpinned in-process run) would
-	// enter an environment the attestation never certified. Refuse a
-	// tool-step plan with no pinned environment unless this run is ALREADY
-	// inside the booted pin (#1829).
-	if planHasToolSteps(lp.Plan) && len(lp.ResolvedImages) == 0 && !opts.InPinnedImage {
-		return RunResult{}, fmt.Errorf(
-			"flightplan: plan declares tool steps but pins no environment image; tool steps run only inside the declared environment")
 	}
 	// When the verified lock pins a WHOLE-PLAN image, boot that exact image
 	// and run the plan inside it (#1731). The image-boot re-entry

--- a/internal/flightplan/runtime/walk_test.go
+++ b/internal/flightplan/runtime/walk_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
@@ -106,6 +107,36 @@ func TestRun_InPinnedImageReentrySkipsWalker(t *testing.T) {
 	}
 	if walker.called {
 		t.Fatal("the image-boot re-entry (InPinnedImage) must never invoke the walker")
+	}
+}
+
+// A tool-step plan with no pinned environment refuses BEFORE the interactive
+// input walk runs (#2063). The fail-closed no-environment refusal (#1829) is
+// unconditional for such a plan, so dragging the operator through a guided walk
+// whose result can only be discarded is wasted work: the refusal must precede
+// the walk. The walker must never be called.
+func TestRun_ToolStepNoImageRefusesBeforeWalk(t *testing.T) {
+	fv := frozenToolStep(t, false)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("tool-step-plan", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	walker := &fakeWalker{collected: map[string]any{"window_days": 7}}
+	_, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "tool-step-plan",
+		Version:     "test",
+		ToolRunner:  &fakeToolStepRunner{},
+		InputWalker: walker,
+	})
+	if err == nil {
+		t.Fatal("a tool-step plan with no pinned environment must refuse")
+	}
+	if !strings.Contains(err.Error(), "pins no environment image") {
+		t.Errorf("error = %v, want the no-environment refusal", err)
+	}
+	if walker.called {
+		t.Fatal("the no-environment refusal must fire BEFORE the interactive walk; the walker must never run")
 	}
 }
 


### PR DESCRIPTION
## Summary

`runtime.Run` ran the host-side `InputWalker` *before* the tool-step-requires-pinned-environment refusal (#1829). A tool-step plan with no pinned image, run at a TTY, completed the entire interactive input walk and only then failed closed — dragging the operator through a guided walk whose collected values could only be discarded.

This moves the fail-closed refusal (`planHasToolSteps && len(ResolvedImages)==0 && !InPinnedImage`) to sit *ahead* of the `InputWalker` block, still before the whole-plan-image boot. The refusal never reads `opts.Inputs`, so the reordering is behavior-preserving for every run that does proceed; it only skips a walk that was guaranteed to be thrown away.

## Test plan

- Added `TestRun_ToolStepNoImageRefusesBeforeWalk` in `internal/flightplan/runtime/walk_test.go`: wires a `fakeWalker` on a tool-step plan with no pinned image and asserts the run refuses with the no-environment error **and** `walker.called == false`.
- Verified the test **fails** against the pre-fix ordering (walker runs first) and **passes** with the fix.
- `go test ./internal/flightplan/runtime/` green; `go build ./internal/flightplan/...` clean.

Relates to #2067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
