### PR TITLE
feat(progress): reusable CLI progress-indicator helper package

### DIFF
--- a/internal/cli/progress/driver.go
+++ b/internal/cli/progress/driver.go
@@ -1,0 +1,72 @@
+package progress
+
+import "io"
+
+// countingWriter is an io.Writer adapter that forwards bytes to an underlying
+// writer while reporting the running total written into an Indicator's
+// determinate display. It lets a copy or stream path (for example an oras
+// layer copy or a container-build output pump) drive progress simply by
+// writing through it, without knowing anything about rendering.
+//
+// The adapter is provided as a reusable seam and is intentionally not wired to
+// any caller in this package. A consumer constructs it with the total size it
+// expects to copy, tees its data through Write, and the Indicator renders the
+// percentage.
+type countingWriter struct {
+	ind     *Indicator
+	dst     io.Writer
+	total   int64
+	written int64
+}
+
+// NewCountingWriter returns an io.Writer that forwards to dst and reports
+// progress to ind as a fraction of total. When dst is nil the bytes are
+// counted and discarded, which is useful when the caller only needs the
+// progress side effect. A total of zero renders 0% and never divides by zero.
+func NewCountingWriter(ind *Indicator, dst io.Writer, total int64) io.Writer {
+	return &countingWriter{ind: ind, dst: dst, total: total}
+}
+
+// Write forwards p to the underlying writer (if any), accumulates the byte
+// count, and pushes the new running total into the Indicator. It returns the
+// number of bytes handled by the underlying writer so it composes correctly in
+// an io.Copy chain; when there is no underlying writer it reports all bytes
+// consumed.
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	var err error
+	if c.dst != nil {
+		n, err = c.dst.Write(p)
+	}
+	c.written += int64(n)
+	if c.ind != nil {
+		c.ind.Update(c.written, c.total)
+	}
+	return n, err
+}
+
+// Add reports that n additional units of work have completed and refreshes the
+// Indicator. It is the callback-style seam for paths that already track their
+// own byte or item counts (for example oras PreCopy/PostCopy hooks) and want
+// to feed increments rather than tee an io stream. A single countingWriter is
+// meant to be driven from one goroutine; the Indicator it feeds is what is
+// safe for concurrent use.
+func (c *countingWriter) Add(n int64) {
+	c.written += n
+	if c.ind != nil {
+		c.ind.Update(c.written, c.total)
+	}
+}
+
+// Adder is the callback seam exposed to copy paths that report increments of
+// completed work rather than streaming bytes. NewCountingWriter's result
+// satisfies it.
+type Adder interface {
+	Add(n int64)
+}
+
+// compile-time assertion that countingWriter satisfies both seams.
+var (
+	_ io.Writer = (*countingWriter)(nil)
+	_ Adder     = (*countingWriter)(nil)
+)

--- a/internal/cli/progress/driver_test.go
+++ b/internal/cli/progress/driver_test.go
@@ -1,0 +1,94 @@
+package progress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCountingWriterForwardsBytesAndReportsProgress(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+
+	var sink bytes.Buffer
+	cw := NewCountingWriter(ind, &sink, 100)
+
+	// Write 100 bytes in two halves; the sink must receive them verbatim and
+	// the indicator must render progress ending at 100%.
+	if _, err := cw.Write(bytes.Repeat([]byte("a"), 50)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := cw.Write(bytes.Repeat([]byte("b"), 50)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if sink.Len() != 100 {
+		t.Errorf("expected 100 forwarded bytes, got %d", sink.Len())
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected 100%% reported, got %q", display.String())
+	}
+}
+
+func TestCountingWriterReturnsUnderlyingCount(t *testing.T) {
+	ind := New(io.Discard)
+	var sink bytes.Buffer
+	cw := NewCountingWriter(ind, &sink, 10)
+	n, err := cw.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("expected Write to return 5, got %d", n)
+	}
+}
+
+func TestCountingWriterNilDstCountsAndDiscards(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	cw := NewCountingWriter(ind, nil, 4)
+	n, err := cw.Write([]byte("data"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("expected all bytes consumed, got %d", n)
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected 100%% with nil dst, got %q", display.String())
+	}
+}
+
+func TestCountingWriterAddIncrements(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	adder := NewCountingWriter(ind, nil, 100).(Adder)
+	adder.Add(25)
+	adder.Add(75)
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected Add to reach 100%%, got %q", display.String())
+	}
+}
+
+func TestCountingWriterComposesWithIOCopy(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	var sink bytes.Buffer
+	src := strings.NewReader(strings.Repeat("x", 200))
+	cw := NewCountingWriter(ind, &sink, 200)
+
+	n, err := io.Copy(cw, src)
+	if err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+	if n != 200 {
+		t.Errorf("expected io.Copy to move 200 bytes, got %d", n)
+	}
+	if sink.Len() != 200 {
+		t.Errorf("expected sink to receive 200 bytes, got %d", sink.Len())
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected 100%% after copy, got %q", display.String())
+	}
+}

--- a/internal/cli/progress/progress.go
+++ b/internal/cli/progress/progress.go
@@ -1,0 +1,338 @@
+// Package progress provides a small, self-contained CLI progress-indicator
+// helper for long-running commands. It renders live liveness (indeterminate
+// spinner) and percentage (determinate) feedback on an interactive terminal,
+// and degrades to plain, control-character-free lines when the destination is
+// not a TTY (a pipe, a file, or a captured buffer).
+//
+// The package intentionally has no command wiring. It exposes a writer-backed
+// Indicator plus a driver adapter so copy/stream paths can push updates into
+// it, leaving the choice of caller to the consumer.
+//
+// Concurrency: an Indicator is safe for concurrent use. Start launches a
+// redraw goroutine driven by a ticker; Update, Done, and Fail may be called
+// from other goroutines. All shared render state is guarded by a mutex, and a
+// resolve (Done/Fail) is idempotent and never writes after the line is
+// resolved.
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// isTerminalFn reports whether f is attached to an interactive terminal. It is
+// a package-level seam so tests can force either branch without a real TTY,
+// mirroring isTTYFn in cmd/aileron/claude_auth.go.
+var isTerminalFn = func(f *os.File) bool { return term.IsTerminal(int(f.Fd())) }
+
+// spinnerFrames are the successive glyphs drawn on the TTY liveness path.
+var spinnerFrames = []rune{'|', '/', '-', '\\'}
+
+// tickInterval is the default cadence of the indeterminate redraw when no
+// ticker is injected via WithTicker.
+const tickInterval = 120 * time.Millisecond
+
+// throttleInterval bounds how often the non-TTY determinate path emits a plain
+// percentage line, so a fast Update loop does not flood a log.
+const throttleInterval = 500 * time.Millisecond
+
+// Indicator renders progress feedback to a writer. Construct one with New.
+type Indicator struct {
+	w         io.Writer
+	tty       bool
+	ttyForced bool
+	quiet     bool
+
+	// ticker is the channel that drives indeterminate redraws. When nil, New
+	// installs a real time.Ticker on Start. A test may inject a deterministic
+	// channel via WithTicker.
+	ticker <-chan time.Time
+
+	mu sync.Mutex
+	// active is true between Start and Done/Fail on the indeterminate path.
+	active bool
+	// finished is set by the first Done/Fail and makes the indicator inert:
+	// every subsequent output method (Start, Update, Done, Fail) is a no-op, so
+	// nothing can ever be written after the resolved completion line.
+	finished bool
+	label    string
+	frame    int
+	// stop signals the redraw goroutine to exit; done is closed by the
+	// goroutine once it has returned so Done/Fail can join it.
+	stop chan struct{}
+	done chan struct{}
+
+	// determinate tracking.
+	lastEmit    time.Time
+	lastPercent int
+}
+
+// Option configures an Indicator at construction time.
+type Option func(*Indicator)
+
+// WithQuiet suppresses all output on both the TTY and non-TTY paths when q is
+// true. A quiet Indicator still tracks state so callers need no branching.
+func WithQuiet(q bool) Option {
+	return func(i *Indicator) { i.quiet = q }
+}
+
+// WithTicker injects the channel that drives the indeterminate redraw loop,
+// replacing the default wall-clock ticker. Tests send on the channel to step
+// the spinner deterministically. When set, the Indicator does not create or
+// stop a real ticker.
+func WithTicker(ch <-chan time.Time) Option {
+	return func(i *Indicator) { i.ticker = ch }
+}
+
+// WithForceTTY overrides TTY autodetection. Passing true selects the
+// terminal render path (carriage-return redraws, spinner); false selects the
+// plain path. It exists so tests can exercise both branches against a buffer.
+func WithForceTTY(tty bool) Option {
+	return func(i *Indicator) {
+		i.tty = tty
+		i.ttyForced = true
+	}
+}
+
+// ttyForced records whether WithForceTTY set tty explicitly, so New does not
+// override it with autodetection.
+//
+// It lives on the struct rather than in the closure so autodetection in New
+// can consult it after all options have run.
+func (i *Indicator) forcedTTY() bool { return i.ttyForced }
+
+// New builds an Indicator writing to w. It detects whether w is an interactive
+// terminal at construction time: if w is an *os.File it consults
+// term.IsTerminal on the file descriptor, otherwise w is treated as non-TTY.
+// WithForceTTY overrides this detection.
+func New(w io.Writer, opts ...Option) *Indicator {
+	i := &Indicator{w: w}
+	for _, opt := range opts {
+		opt(i)
+	}
+	if !i.forcedTTY() {
+		if f, ok := w.(*os.File); ok {
+			i.tty = isTerminalFn(f)
+		}
+	}
+	return i
+}
+
+// Start begins an indeterminate liveness indication under label. On the TTY
+// path it launches a redraw goroutine that advances the spinner on each tick.
+// On the non-TTY path it emits a single plain start line. Calling Start while
+// an indication is already active, or after the indicator has been resolved by
+// Done or Fail, is a no-op.
+func (i *Indicator) Start(label string) {
+	i.mu.Lock()
+	if i.quiet || i.active || i.finished {
+		i.mu.Unlock()
+		return
+	}
+	i.active = true
+	i.label = label
+	i.frame = 0
+
+	if !i.tty {
+		fmt.Fprintf(i.w, "%s...\n", label)
+		i.mu.Unlock()
+		return
+	}
+
+	// Draw the first frame immediately so callers see feedback before the
+	// first tick fires.
+	i.drawLocked()
+
+	ticker := i.ticker
+	var realTicker *time.Ticker
+	if ticker == nil {
+		realTicker = time.NewTicker(tickInterval)
+		ticker = realTicker.C
+	}
+	i.stop = make(chan struct{})
+	i.done = make(chan struct{})
+	stop := i.stop
+	done := i.done
+	i.mu.Unlock()
+
+	go func() {
+		if realTicker != nil {
+			defer realTicker.Stop()
+		}
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			case _, ok := <-ticker:
+				if !ok {
+					return
+				}
+				i.mu.Lock()
+				if !i.active {
+					i.mu.Unlock()
+					return
+				}
+				i.frame++
+				i.drawLocked()
+				i.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// Done resolves the indicator as successful, drawing "✓ <label>" on a fresh
+// line. It stops any redraw goroutine and marks the indicator finished, whether
+// the preceding feedback was an indeterminate spinner or a determinate bar. A
+// second call, a later Fail, a later Update, or a later Start is a no-op, so the
+// resolved line is the last thing the indicator ever writes.
+func (i *Indicator) Done(label string) {
+	i.resolve('✓', label)
+}
+
+// Fail resolves the active indication as failed, drawing "✗ <label>". It has
+// the same stop-and-idempotency semantics as Done.
+func (i *Indicator) Fail(label string) {
+	i.resolve('✗', label)
+}
+
+// resolve stops any redraw goroutine and writes the terminal completion line.
+// The goroutine is joined outside the lock to avoid deadlocking against a tick
+// that is waiting on the mutex.
+func (i *Indicator) resolve(mark rune, label string) {
+	i.mu.Lock()
+	if i.quiet || i.finished {
+		i.mu.Unlock()
+		return
+	}
+	// Mark finished and inactive first, under the lock, so a tick or a
+	// concurrent Update blocked on the mutex observes both and returns without
+	// writing anything after the resolved completion line. This resolves the
+	// indicator whether or not a spinner was active, so a determinate-only flow
+	// (Update... then Done) still emits a completion line and becomes inert.
+	i.finished = true
+	i.active = false
+	// Signal and join the redraw goroutine (TTY path only) before writing the
+	// resolved line, so no tick can interleave a redraw after it.
+	i.stopSpinnerLocked()
+
+	defer i.mu.Unlock()
+	if i.tty {
+		// Clear the current line, then draw the resolved state with a newline.
+		fmt.Fprintf(i.w, "\r\x1b[K%c %s\n", mark, label)
+	} else {
+		fmt.Fprintf(i.w, "%c %s\n", mark, label)
+	}
+}
+
+// stopSpinnerLocked signals the redraw goroutine to exit and joins it. It must
+// be called with i.mu held and returns with i.mu held. It releases the lock
+// only transiently to let the goroutine acquire it and return, avoiding a
+// deadlock against a tick blocked on the mutex. It is a no-op when no spinner
+// is running. Callers must set the state flags they want (active, finished)
+// before calling so a concurrently-blocked tick observes them and does not draw
+// after the join.
+func (i *Indicator) stopSpinnerLocked() {
+	stop := i.stop
+	done := i.done
+	i.stop = nil
+	i.done = nil
+	if stop == nil {
+		return
+	}
+	i.mu.Unlock()
+	close(stop)
+	if done != nil {
+		<-done
+	}
+	i.mu.Lock()
+}
+
+// percentOf returns current*100/total as an integer percentage without
+// overflowing when the counts are near the int64 ceiling. It assumes total > 0
+// and 0 <= current <= total, which Update guarantees, so the result is in
+// [0, 100].
+func percentOf(current, total int64) int {
+	// The direct multiply is exact and cheapest for realistic byte counts; fall
+	// back to divide-first only when current*100 would overflow int64.
+	const maxBeforeOverflow = (1<<63 - 1) / 100
+	if current <= maxBeforeOverflow {
+		return int(current * 100 / total)
+	}
+	return int(current / (total / 100))
+}
+
+// drawLocked renders the current spinner frame with a carriage return. The
+// caller must hold i.mu and must have verified the TTY path.
+func (i *Indicator) drawLocked() {
+	frame := spinnerFrames[i.frame%len(spinnerFrames)]
+	fmt.Fprintf(i.w, "\r\x1b[K%c %s", frame, i.label)
+}
+
+// barWidth is the number of cells in the determinate bar drawn on the TTY.
+const barWidth = 20
+
+// Update reports determinate progress: current of total units complete. On the
+// TTY path it redraws a percentage bar in place; on the non-TTY path it emits
+// throttled plain percentage lines. A total of zero renders 0% without
+// dividing by zero. Update does not require a prior Start, and is a no-op once
+// the indicator has been resolved by Done or Fail.
+func (i *Indicator) Update(current, total int64) {
+	i.mu.Lock()
+	if i.quiet || i.finished {
+		i.mu.Unlock()
+		return
+	}
+	// A determinate Update supersedes an indeterminate spinner: mark it inactive
+	// and stop the redraw goroutine (if Start launched one) before rendering the
+	// bar so the two do not race for the same line. stopSpinnerLocked releases
+	// and reacquires the lock to join the goroutine, so all shared state is read
+	// after it returns.
+	i.active = false
+	i.stopSpinnerLocked()
+	defer i.mu.Unlock()
+	if i.finished {
+		return
+	}
+
+	percent := 0
+	if total > 0 {
+		if current > total {
+			current = total
+		}
+		if current < 0 {
+			current = 0
+		}
+		percent = percentOf(current, total)
+	}
+
+	if i.tty {
+		filled := percent * barWidth / 100
+		if filled > barWidth {
+			filled = barWidth
+		}
+		bar := strings.Repeat("#", filled) + strings.Repeat("-", barWidth-filled)
+		fmt.Fprintf(i.w, "\r\x1b[K[%s] %3d%%", bar, percent)
+		return
+	}
+
+	// Non-TTY: throttle plain lines and only emit on a changed percentage so a
+	// tight Update loop does not flood a log.
+	now := time.Now()
+	first := i.lastEmit.IsZero()
+	if !first && percent == i.lastPercent {
+		return
+	}
+	if !first && percent != 100 && now.Sub(i.lastEmit) < throttleInterval {
+		return
+	}
+	fmt.Fprintf(i.w, "%d%%\n", percent)
+	i.lastEmit = now
+	i.lastPercent = percent
+}

--- a/internal/cli/progress/progress_test.go
+++ b/internal/cli/progress/progress_test.go
@@ -1,0 +1,359 @@
+package progress
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// hasControlChars reports whether s contains a carriage return, an ANSI escape
+// introducer, or any other C0 control character besides newline and tab. The
+// non-TTY contract forbids all of these.
+func hasControlChars(s string) bool {
+	if strings.ContainsRune(s, '\r') || strings.Contains(s, "\x1b[") {
+		return true
+	}
+	for _, r := range s {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNonTTYIndeterminateHasNoControlChars(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(false))
+
+	ind.Start("uploading")
+	ind.Done("uploading")
+
+	out := buf.String()
+	if hasControlChars(out) {
+		t.Fatalf("non-TTY output contains control chars: %q", out)
+	}
+	if !strings.Contains(out, "uploading...") {
+		t.Errorf("expected plain start line, got %q", out)
+	}
+	if !strings.Contains(out, "✓ uploading") {
+		t.Errorf("expected plain done line, got %q", out)
+	}
+}
+
+func TestNonTTYDeterminateHasNoControlChars(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(false))
+
+	ind.Update(0, 100)
+	ind.Update(50, 100)
+	ind.Update(100, 100)
+
+	out := buf.String()
+	if hasControlChars(out) {
+		t.Fatalf("non-TTY determinate output contains control chars: %q", out)
+	}
+	if !strings.Contains(out, "0%") || !strings.Contains(out, "100%") {
+		t.Errorf("expected plain percentage lines, got %q", out)
+	}
+}
+
+func TestTTYAdvancesFrames(t *testing.T) {
+	var buf bytes.Buffer
+	tick := make(chan time.Time)
+	ind := New(&buf, WithForceTTY(true), WithTicker(tick))
+
+	ind.Start("working")
+	// Drive several ticks; each should redraw with a carriage return and,
+	// across a full cycle, cycle through distinct spinner glyphs.
+	for i := 0; i < len(spinnerFrames); i++ {
+		tick <- time.Now()
+	}
+	ind.Done("working")
+
+	out := buf.String()
+	if !strings.Contains(out, "\r") {
+		t.Errorf("expected carriage-return redraws on TTY, got %q", out)
+	}
+	for _, f := range spinnerFrames {
+		if !strings.ContainsRune(out, f) {
+			t.Errorf("expected spinner frame %q in output %q", f, out)
+		}
+	}
+	if !strings.HasSuffix(out, "✓ working\n") {
+		t.Errorf("expected resolved done line at end, got %q", out)
+	}
+}
+
+func TestTTYDeterminateRedraws(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(true))
+
+	ind.Update(50, 100)
+	out := buf.String()
+	if !strings.Contains(out, "\r") {
+		t.Errorf("expected carriage return on TTY determinate, got %q", out)
+	}
+	if !strings.Contains(out, "50%") {
+		t.Errorf("expected 50%% rendered, got %q", out)
+	}
+	// A half-full bar: exactly half of the cells filled.
+	if !strings.Contains(out, strings.Repeat("#", barWidth/2)) {
+		t.Errorf("expected half-filled bar, got %q", out)
+	}
+}
+
+func TestStartThenUpdateStopsSpinner(t *testing.T) {
+	// A determinate Update after Start must stop the spinner goroutine so it
+	// cannot keep redrawing over the bar. Drive a tick before Update, then
+	// assert no further spinner frame is written after the bar even if we try
+	// to tick again.
+	var buf syncBuffer
+	tick := make(chan time.Time)
+	ind := New(&buf, WithForceTTY(true), WithTicker(tick))
+
+	ind.Start("copy")
+	tick <- time.Now() // one spinner frame
+	ind.Update(50, 100)
+
+	afterUpdate := buf.String()
+	// The spinner goroutine should be stopped; a send on tick must not block
+	// forever waiting to be received and must not add a spinner frame. Use a
+	// non-blocking send to prove nothing is listening.
+	select {
+	case tick <- time.Now():
+		t.Fatal("spinner goroutine still consuming ticks after Update")
+	default:
+	}
+	if !strings.Contains(afterUpdate, "50%") {
+		t.Errorf("expected bar rendered, got %q", afterUpdate)
+	}
+	ind.Done("copy")
+	if !strings.HasSuffix(buf.String(), "✓ copy\n") {
+		t.Errorf("expected clean resolve after Start->Update, got %q", buf.String())
+	}
+}
+
+func TestUpdateLargeByteCountsNoOverflow(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(true))
+	// Counts far beyond int64max/100 (~92 PB) must not overflow into a bogus
+	// percentage or a giant strings.Repeat.
+	const huge = int64(1) << 60 // ~1.15 EB
+	ind.Update(huge/2, huge)
+	out := buf.String()
+	if !strings.Contains(out, "50%") {
+		t.Errorf("expected 50%% for half of a huge total, got %q", out)
+	}
+	buf.Reset()
+	ind.Update(huge, huge)
+	if !strings.Contains(buf.String(), "100%") {
+		t.Errorf("expected 100%% for full huge total, got %q", buf.String())
+	}
+}
+
+func TestUpdateTotalZeroNoPanic(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(true))
+	// Must not divide by zero.
+	ind.Update(5, 0)
+	if !strings.Contains(buf.String(), "0%") {
+		t.Errorf("expected 0%% for zero total, got %q", buf.String())
+	}
+}
+
+func TestUpdateClampsOverAndUnder(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(true))
+	buf.Reset()
+	ind.Update(200, 100) // over 100%
+	if !strings.Contains(buf.String(), "100%") {
+		t.Errorf("expected clamp to 100%%, got %q", buf.String())
+	}
+	buf.Reset()
+	ind.Update(-5, 100) // negative
+	if !strings.Contains(buf.String(), "0%") {
+		t.Errorf("expected clamp to 0%%, got %q", buf.String())
+	}
+}
+
+func TestFailResolvesFailedState(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(false))
+	ind.Start("deploy")
+	ind.Fail("deploy")
+	out := buf.String()
+	if !strings.Contains(out, "✗ deploy") {
+		t.Errorf("expected failed line, got %q", out)
+	}
+}
+
+func TestResolveIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(true))
+	ind.Start("x")
+	ind.Done("x")
+	before := buf.String()
+	// A second Done and a Fail after resolution must be no-ops.
+	ind.Done("x")
+	ind.Fail("x")
+	if buf.String() != before {
+		t.Errorf("resolve was not idempotent: %q -> %q", before, buf.String())
+	}
+}
+
+func TestNoWriteAfterResolve(t *testing.T) {
+	// Once resolved, no method may write anything, so the completion line is
+	// always the last bytes emitted.
+	for _, tty := range []bool{true, false} {
+		var buf bytes.Buffer
+		ind := New(&buf, WithForceTTY(tty))
+		ind.Start("job")
+		ind.Update(50, 100)
+		ind.Done("job")
+		resolved := buf.String()
+		// Post-resolve calls must be inert.
+		ind.Update(75, 100)
+		ind.Start("job2")
+		ind.Fail("job")
+		ind.Done("job")
+		if buf.String() != resolved {
+			t.Errorf("tty=%v: wrote after resolve: %q -> %q", tty, resolved, buf.String())
+		}
+		mark := "✓ job"
+		if !strings.HasSuffix(strings.TrimRight(buf.String(), "\n"), mark) {
+			t.Errorf("tty=%v: resolved line is not last, got %q", tty, buf.String())
+		}
+	}
+}
+
+func TestStartTwiceIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf, WithForceTTY(false))
+	ind.Start("a")
+	ind.Start("b") // ignored while active
+	out := buf.String()
+	if strings.Contains(out, "b...") {
+		t.Errorf("second Start should be ignored, got %q", out)
+	}
+}
+
+func TestQuietSuppressesAllOutput(t *testing.T) {
+	for _, tty := range []bool{true, false} {
+		var buf bytes.Buffer
+		ind := New(&buf, WithForceTTY(tty), WithQuiet(true))
+		ind.Start("work")
+		ind.Update(50, 100)
+		ind.Update(100, 100)
+		ind.Done("work")
+		ind.Fail("work")
+		if buf.Len() != 0 {
+			t.Errorf("quiet (tty=%v) produced output: %q", tty, buf.String())
+		}
+	}
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer so the -race test can have the
+// redraw goroutine and the test goroutine write concurrently without a data
+// race in the buffer itself (which is what we are not testing).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestConcurrentUpdatesAndDone(t *testing.T) {
+	var buf syncBuffer
+	tick := make(chan time.Time)
+	ind := New(&buf, WithForceTTY(true), WithTicker(tick))
+
+	ind.Start("copy")
+
+	var wg sync.WaitGroup
+	// Concurrent ticks.
+	stopTicks := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopTicks:
+				return
+			case tick <- time.Now():
+			}
+		}
+	}()
+	// Concurrent updates.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := int64(0); i <= 100; i += 10 {
+			ind.Update(i, 100)
+		}
+	}()
+
+	ind.Done("copy") // stops the redraw goroutine
+	close(stopTicks)
+	wg.Wait()
+
+	if !strings.HasSuffix(buf.String(), "✓ copy\n") {
+		t.Errorf("expected resolved line after concurrent activity, got %q", buf.String())
+	}
+}
+
+func TestNonTTYAutoDetectViaPipe(t *testing.T) {
+	// A pipe's read/write ends are *os.File but not terminals; New must pick
+	// the non-TTY path via real detection (no force).
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ind := New(w)
+	if ind.tty {
+		t.Errorf("expected pipe write end to be detected as non-TTY")
+	}
+}
+
+func TestNonFileWriterIsNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	ind := New(&buf)
+	if ind.tty {
+		t.Errorf("expected non-*os.File writer to be non-TTY")
+	}
+}
+
+func TestForceTTYAutodetectSeam(t *testing.T) {
+	// Exercise the isTerminalFn seam by forcing it true against a pipe write
+	// end, proving New consults it when the writer is an *os.File.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	orig := isTerminalFn
+	isTerminalFn = func(f *os.File) bool { return true }
+	defer func() { isTerminalFn = orig }()
+
+	ind := New(w)
+	if !ind.tty {
+		t.Errorf("expected isTerminalFn seam to force TTY detection")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a self-contained progress-indicator package at `internal/cli/progress` (package `progress`), the foundation sub-issue of umbrella #2075. It provides:

- **Indeterminate liveness**: `Start(label)` runs a ticker-driven spinner redraw on a TTY; `Done(label)` / `Fail(label)` resolve to `✓ <label>` / `✗ <label>`.
- **Determinate progress**: `Update(current, total)` renders a percentage bar on a TTY (CR-redraw) and throttled plain percentage lines off-TTY. `total == 0` renders 0% without dividing by zero; over/under values are clamped.
- **TTY detection** at construction via an `isTerminalFn` seam (mirrors `cmd/aileron/claude_auth.go`): an `*os.File` writer is probed with `term.IsTerminal`; any other writer is non-TTY. Non-TTY output emits no `\r` and no ANSI escapes.
- **Quiet mode** (`WithQuiet`) suppresses all output on both paths.
- **Test seams**: `WithTicker` (deterministic frame stepping) and `WithForceTTY` (exercise both branches against a buffer).
- **Driver seam**: `NewCountingWriter` / `Adder` — an `io.Writer` + increment callback the future oras-copy and container-build paths can drive. Provided but intentionally **not wired** to any caller in this PR.

Concurrency: the redraw goroutine and caller `Update`/`Done`/`Fail` calls are guarded by a mutex; resolve is idempotent and joins the redraw goroutine before writing the completion line, so no tick can interleave after resolution and the goroutine never leaks.

### Scope

No command wiring. Nothing under `cmd/aileron/**` or `internal/flightplan/publish/**` is touched — those are #2075's later sub-issues. No new dependency and no `go.mod`/`go.sum` edits (`golang.org/x/term` is already a direct dep).

## Test plan

From the `internal` module dir:

- `go build ./...` — passes.
- `go vet ./cli/progress` — clean.
- `gofmt -l cli/progress` — clean.
- `go test -race -cover ./cli/progress` — passes, **97.4%** coverage.

Test scenarios cover: TTY frame advance via `WithTicker` (CR sequences + distinct spinner glyphs), non-TTY has no control chars (indeterminate + determinate), determinate render / `total==0` no-panic / clamping, `Done`/`Fail` resolution, idempotent resolve, quiet suppression on both paths, real TTY autodetection through an `os.Pipe`, the `isTerminalFn` seam, and a `-race` concurrent Start + Updates + ticks + Done. Driver tests cover byte forwarding, `io.Copy` composition, nil-dst counting, underlying-count return, and `Add` increments.

Closes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1DcnDZFwjCxxB4dQuR5p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI progress display with support for both spinner-style and percentage-based updates.
  * Progress output now works in terminals and non-terminal logs, with an option to silence output when needed.
  * Added a byte-counting helper so progress can be tracked during streaming operations.

* **Bug Fixes**
  * Improved progress handling for zero totals, out-of-range values, and repeated completion/failure updates.
  * Made progress rendering more reliable during concurrent updates and long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->