### PR TITLE
feat(skill): show live build/pull progress during aileron skill freeze

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ALRubinger/aileron/internal/cli/progress"
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
 	"github.com/ALRubinger/aileron/internal/flightplan/imgconfig"
@@ -29,12 +30,27 @@ import (
 var newDigestResolver = func() freeze.DigestResolver { return runtimeDigestResolver{} }
 var newFeatureComposer = func() freeze.FeatureComposer { return builderFeatureComposer{} }
 
+// freezeProgress carries a factory that mints a fresh progress.Indicator for a
+// single bracketed step in the in-flight freeze run. It exists because a
+// progress.Indicator is single-shot (the first Done/Fail marks it finished and
+// inert), so pull, the multi-arch build, and the daemon-load build each need
+// their own indicator over the same destination and quiet setting. The
+// production newImageInspector (a no-arg package var reached from inside the
+// stateless runtimeDigestResolver / builderFeatureComposer) reads this factory
+// and installs it on the inspector it builds. runSkillFreeze sets it before
+// freeze.Run and resets it on return. It is nil outside a run and in tests that
+// do not opt in, so every inspector method nil-guards it and stays a no-op.
+// This keeps runtimeDigestResolver{} / builderFeatureComposer{} zero-value
+// constructible and leaves the runtime-free freeze core untouched.
+var freezeProgress func() *progress.Indicator
+
 func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("skill freeze", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	signingKey := flags.String("signing-key", "", "Path to the PEM ed25519 signing key (falls back to $"+freeze.SigningKeyEnv+")")
 	version := flags.String("version", "", "Semver label recorded in the lock (for example 1.0.0)")
 	publisher := flags.String("publisher", "", "Publisher authority to attribute the plan to (github://owner/repo or github://owner). When set, launch enforces publisher trust against the keyring.")
+	quiet := flags.Bool("quiet", false, "Suppress the live build and pull progress feedback (the freeze summary still prints)")
 	positionals, err := parseInterspersedFlags(flags, args)
 	if err != nil {
 		return 1
@@ -63,6 +79,21 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
+
+	// Install a progress-indicator factory over stdout for the whole run. Each
+	// bracketed step (pull, multi-arch build, daemon-load build) mints its own
+	// indicator because an indicator is single-shot. TTY autodetection fires only
+	// when stdout is an *os.File attached to a terminal (animated spinner); a
+	// captured bytes.Buffer is non-*os.File, so it degrades to plain,
+	// control-character-free lines with no force flag. --quiet suppresses output
+	// on both paths. The factory is threaded to the pull/build sites through
+	// freezeProgress so the runtime-free freeze core and the zero-value
+	// resolver/composer stay untouched.
+	prev := freezeProgress
+	freezeProgress = func() *progress.Indicator {
+		return progress.New(stdout, progress.WithQuiet(*quiet))
+	}
+	defer func() { freezeProgress = prev }()
 
 	res, err := freeze.Run(context.Background(), raw, freeze.Options{
 		Version:        *version,
@@ -167,6 +198,12 @@ func frozenVersionID(contentHash string) string {
 type imageInspector struct {
 	runner  container.Runner
 	runtime string
+	// newProgress mints a fresh single-shot progress indicator for one bracketed
+	// step. The production newImageInspector installs freezeProgress here, so the
+	// pull and both build sites can each bracket their blocking step with liveness
+	// feedback. It is nil in tests that do not opt in and in the zero-value
+	// inspector, so every call site nil-guards it.
+	newProgress func() *progress.Indicator
 }
 
 // newImageInspector builds an inspector over the real container runtime,
@@ -178,14 +215,25 @@ var newImageInspector = func() (imageInspector, error) {
 	if err != nil {
 		return imageInspector{}, fmt.Errorf("resolve container runtime: %w", err)
 	}
-	return imageInspector{runner: container.DefaultRunner(), runtime: runtimeName}, nil
+	return imageInspector{runner: container.DefaultRunner(), runtime: runtimeName, newProgress: freezeProgress}, nil
 }
 
 // pull best-effort pulls ref. A failure is intentionally non-fatal: the
 // image may already be local, in which case the inspect still yields a
 // digest.
 func (in imageInspector) pull(ctx context.Context, ref string) {
+	var ind *progress.Indicator
+	if in.newProgress != nil {
+		ind = in.newProgress()
+		ind.Start("Pulling base image")
+	}
 	_ = in.runner.Run(ctx, in.runtime, []string{"pull", ref}, io.Discard, io.Discard)
+	// Resolve to done even on a pull error: the pull is best-effort and the
+	// image may already be local, so inspect still proceeds. A Fail here would
+	// mislead, since the freeze is not failing at this step.
+	if ind != nil {
+		ind.Done("Pulled base image")
+	}
 }
 
 // inspectFormat runs `image inspect --format <format> <image>` and returns
@@ -324,6 +372,21 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		Stdout:  io.Discard,
 		Stderr:  io.Discard,
 	}
+	// setBuildSinks points the Builder's stdout/stderr at the liveness sink for
+	// the given indicator (falling back to io.Discard when no indicator is
+	// active). The stderr sink stays the OUTER argument of runBuildStep's
+	// io.MultiWriter(stderr, &buf) tee, so the daemon-unreachable capture buffer
+	// still sees every byte and the sink never consumes the stream. It emits no
+	// bytes itself, so the non-TTY/quiet plain-line contract holds.
+	setBuildSinks := func(ind *progress.Indicator) {
+		if ind == nil {
+			b.Stdout = io.Discard
+			b.Stderr = io.Discard
+			return
+		}
+		b.Stdout = progress.NewLivenessWriter(ind)
+		b.Stderr = progress.NewLivenessWriter(ind)
+	}
 	// Wire the managed provisioner only on the managed branch; the host-npx
 	// opt-out must never carry a provisioner (its no-network/no-provision
 	// contract), matching the sandbox and launch callers.
@@ -369,9 +432,21 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		// driver and lands the image in the local daemon (issue #2054).
 		BuildxBuilder: container.FreezeBuilderName,
 	}
+	var buildInd *progress.Indicator
+	if in.newProgress != nil {
+		buildInd = in.newProgress()
+		buildInd.Start("Building environment image")
+	}
+	setBuildSinks(buildInd)
 	result, err := b.Build(ctx, buildOpts)
 	if err != nil {
+		if buildInd != nil {
+			buildInd.Fail("Building environment image")
+		}
 		return nil, fmt.Errorf("compose environment tools (multi-arch): %w", err)
+	}
+	if buildInd != nil {
+		buildInd.Done("Built environment image")
 	}
 	perArch, err := readOCILayoutConfigDigests(ctx, result.OCILayoutDir)
 	if err != nil {
@@ -389,8 +464,20 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 	loadOpts := buildOpts
 	loadOpts.Platforms = nil
 	loadOpts.OCILayoutDest = ""
+	var loadInd *progress.Indicator
+	if in.newProgress != nil {
+		loadInd = in.newProgress()
+		loadInd.Start("Loading image into local daemon")
+	}
+	setBuildSinks(loadInd)
 	if _, err := b.Build(ctx, loadOpts); err != nil {
+		if loadInd != nil {
+			loadInd.Fail("Loading image into local daemon")
+		}
 		return nil, fmt.Errorf("load composed image into the local daemon under %q: %w", localTag, err)
+	}
+	if loadInd != nil {
+		loadInd.Done("Loaded image into local daemon")
 	}
 
 	out := make([]freeze.PlatformDigest, 0, len(perArch))

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -13,8 +13,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/cli/progress"
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
 	"github.com/ALRubinger/aileron/internal/flightplan/imgconfig"
 	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
@@ -232,6 +234,227 @@ func TestRunSkillFreeze_MultiArchRecordsBothArchesInLock(t *testing.T) {
 			t.Errorf("lockfile must record %q for the multi-arch pin:\n%s", want, lf)
 		}
 	}
+}
+
+// genericInspectRunner wraps a fakeRunner and answers any `image inspect
+// --format {{json .RepoDigests}} <ref>` with a single RepoDigests entry under
+// the requested ref's repository, so the REAL runtimeDigestResolver resolves a
+// digest for whatever default base ref the version maps to without the test
+// scripting the exact tag. Every other command falls through to the fakeRunner,
+// so the buildx preflight and both builds behave as scripted. It also records
+// whether a `pull` command was seen, so a test can prove the pull step ran.
+type genericInspectRunner struct {
+	*fakeRunner
+	pulledMu   sync.Mutex
+	pulled     bool
+	repoDigest string
+}
+
+func (r *genericInspectRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdout, stderr)
+}
+
+func (r *genericInspectRunner) RunWithEnv(ctx context.Context, name string, args, env []string, stdout, stderr io.Writer) error {
+	joined := strings.Join(args, " ")
+	if len(args) > 0 && args[0] == "pull" {
+		r.pulledMu.Lock()
+		r.pulled = true
+		r.pulledMu.Unlock()
+		return nil
+	}
+	if strings.Contains(joined, "image inspect") && strings.Contains(joined, "RepoDigests") {
+		ref := args[len(args)-1]
+		repo := repoOfRef(ref)
+		_, _ = stdout.Write([]byte(`["` + repo + `@` + r.repoDigest + `"]`))
+		return nil
+	}
+	return r.fakeRunner.RunWithEnv(ctx, name, args, env, stdout, stderr)
+}
+
+func (r *genericInspectRunner) sawPull() bool {
+	r.pulledMu.Lock()
+	defer r.pulledMu.Unlock()
+	return r.pulled
+}
+
+// TestRunSkillFreeze_IndicatorDrivenAcrossPullAndBuilds proves the acceptance
+// bar: a full freeze of a tools-declaring skill drives the progress indicator
+// across the base-image pull and BOTH composed builds, and on the non-TTY path
+// the captured stdout carries the plain start/done lines for each step with no
+// control characters. It runs the REAL runtimeDigestResolver (so pull fires) and
+// the REAL builderFeatureComposer (so both builds fire) through a fake runner.
+func TestRunSkillFreeze_IndicatorDrivenAcrossPullAndBuilds(t *testing.T) {
+	t.Setenv(container.ToolchainModeEnv, container.ToolchainModeHostNPX)
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	key := writeSigningKey(t)
+
+	stubOCILayoutDigests(t, []ociremote.PlatformConfigDigest{
+		{OS: "linux", Arch: "amd64", Digest: "sha256:" + strings.Repeat("a", 64)},
+		{OS: "linux", Arch: "arm64", Digest: "sha256:" + strings.Repeat("b", 64)},
+	})
+	gr := &genericInspectRunner{
+		fakeRunner: &fakeRunner{outputs: buildxPreflightOK()},
+		repoDigest: "sha256:" + strings.Repeat("c", 64),
+	}
+
+	var stdout, stderr bytes.Buffer
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{
+			runner:  gr,
+			runtime: "docker",
+			newProgress: func() *progress.Indicator {
+				return progress.New(&stdout, progress.WithForceTTY(false))
+			},
+		}, nil
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+	if !gr.sawPull() {
+		t.Error("the base-image pull step must have run")
+	}
+
+	out := stdout.String()
+	// Scenario 1: the indicator was driven across pull and both builds.
+	for _, want := range []string{
+		"Pulling base image", "Pulled base image",
+		"Building environment image", "Built environment image",
+		"Loading image into local daemon", "Loaded image into local daemon",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout must contain progress label %q:\n%s", want, out)
+		}
+	}
+	// Scenario 2: non-TTY output is plain (no ESC, no carriage return).
+	if strings.ContainsAny(out, "\x1b\r") {
+		t.Errorf("non-TTY progress output must contain no ESC or CR:\n%q", out)
+	}
+	// Scenario 4: the freeze summary is preserved.
+	if !strings.Contains(out, "Froze skill \"weekly-metrics-digest\"") {
+		t.Errorf("stdout must still print the freeze summary:\n%s", out)
+	}
+	if !strings.Contains(out, "ContentHash: sha256:") {
+		t.Errorf("stdout must still print the ContentHash line:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_QuietSuppressesProgress proves --quiet suppresses every
+// progress label while the freeze summary still prints. It runs the same real
+// pull + build path with a quiet indicator factory.
+func TestRunSkillFreeze_QuietSuppressesProgress(t *testing.T) {
+	t.Setenv(container.ToolchainModeEnv, container.ToolchainModeHostNPX)
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	key := writeSigningKey(t)
+
+	stubOCILayoutDigests(t, []ociremote.PlatformConfigDigest{
+		{OS: "linux", Arch: "amd64", Digest: "sha256:" + strings.Repeat("a", 64)},
+		{OS: "linux", Arch: "arm64", Digest: "sha256:" + strings.Repeat("b", 64)},
+	})
+	gr := &genericInspectRunner{
+		fakeRunner: &fakeRunner{outputs: buildxPreflightOK()},
+		repoDigest: "sha256:" + strings.Repeat("c", 64),
+	}
+
+	var stdout, stderr bytes.Buffer
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{
+			runner:  gr,
+			runtime: "docker",
+			newProgress: func() *progress.Indicator {
+				return progress.New(&stdout, progress.WithForceTTY(false), progress.WithQuiet(true))
+			},
+		}, nil
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+
+	if code := runSkillFreeze([]string{"--quiet", "--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("quiet freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, label := range []string{
+		"Pulling base image", "Building environment image", "Loading image into local daemon",
+	} {
+		if strings.Contains(out, label) {
+			t.Errorf("--quiet must suppress progress label %q:\n%s", label, out)
+		}
+	}
+	// The summary still prints under --quiet.
+	if !strings.Contains(out, "Froze skill \"weekly-metrics-digest\"") {
+		t.Errorf("--quiet must not suppress the freeze summary:\n%s", out)
+	}
+}
+
+// TestBuilderFeatureComposer_DaemonUnreachableTeeIntact proves the liveness
+// writer freeze installs as Builder.Stderr does not displace runBuildStep's
+// stderr capture buffer: a build whose stderr emits the docker-daemon-unreachable
+// marker still yields the translated error. This is the must-not-break tee
+// requirement, asserted at the composer level through the real ComposeDigest and
+// the real container.Builder.
+func TestBuilderFeatureComposer_DaemonUnreachableTeeIntact(t *testing.T) {
+	t.Setenv(container.ToolchainModeEnv, container.ToolchainModeHostNPX)
+	stubOCILayoutDigests(t, []ociremote.PlatformConfigDigest{
+		{OS: "linux", Arch: "amd64", Digest: "sha256:" + strings.Repeat("a", 64)},
+	})
+	// A runner that passes the buildx preflight but emits the daemon-unreachable
+	// marker to stderr and fails the multi-arch build.
+	fr := daemonDownBuildRunner{fakeRunner: &fakeRunner{outputs: buildxPreflightOK()}}
+
+	var stdout bytes.Buffer
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{
+			runner:  fr,
+			runtime: "docker",
+			newProgress: func() *progress.Indicator {
+				return progress.New(&stdout, progress.WithForceTTY(false))
+			},
+		}, nil
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+
+	_, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), "base@"+fakeFreezeDigest, []string{"aws-cli"})
+	if err == nil {
+		t.Fatal("a daemon-unreachable build must surface an error")
+	}
+	// The container package translates the captured daemon-unreachable stderr; the
+	// liveness writer sitting as the outer MultiWriter arg must not have consumed
+	// it. The composer wraps the build error with its compose message.
+	if !strings.Contains(err.Error(), "compose environment tools") {
+		t.Errorf("err = %v, want the composer's multi-arch wrap", err)
+	}
+	// The container package only emits this headline when its stderr capture
+	// buffer observed the daemon-unreachable marker, so its presence proves the
+	// liveness writer sitting as the outer MultiWriter arg did not consume the
+	// stream out from under the capture buffer.
+	if !strings.Contains(err.Error(), "Docker isn't reachable") {
+		t.Errorf("err = %v, want the daemon-unreachable translation to survive the tee", err)
+	}
+}
+
+// daemonDownBuildRunner passes the buildx preflight but emits the
+// docker-daemon-unreachable marker to stderr and fails any build command, so the
+// composer's stderr tee + daemon-unreachable translation is exercised end to end.
+// It overrides both Run and RunWithEnv because the multi-arch build carries a
+// scoped BUILDX_BUILDER env and thus routes through the envRunner path.
+type daemonDownBuildRunner struct{ *fakeRunner }
+
+func (r daemonDownBuildRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdout, stderr)
+}
+
+func (r daemonDownBuildRunner) RunWithEnv(ctx context.Context, name string, args, env []string, stdout, stderr io.Writer) error {
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "build") && (strings.Contains(joined, "--output") || strings.Contains(joined, "--image-name")) {
+		_, _ = stderr.Write([]byte("cannot connect to the docker daemon at unix:///var/run/docker.sock"))
+		return errors.New("build failed")
+	}
+	return r.fakeRunner.RunWithEnv(ctx, name, args, env, stdout, stderr)
 }
 
 // TestRunSkillFreeze_MissingBuildxAbortsWithNoPin proves the freeze aborts with the

--- a/docs/src/content/docs/guides/freezing-a-flight-plan.md
+++ b/docs/src/content/docs/guides/freezing-a-flight-plan.md
@@ -43,6 +43,8 @@ The signing key is a PEM-encoded ed25519 private key. Pass it with `--signing-ke
 
 The `--version` flag records a human-facing semver label in the lock. It is optional.
 
+Freeze can pull a base image and run a multi-architecture build, so it shows live progress for each long-running step: pulling the base image, building the environment image, and loading it into the local daemon. On an interactive terminal the progress advances in place. When the output is piped or captured it degrades to plain lines with no control characters. Pass `--quiet` to suppress the progress feedback entirely. The freeze summary always prints.
+
 Freeze prints the skill name, the version label, the content hash, and the on-disk location of the frozen version.
 
 ## The frozen version

--- a/internal/cli/progress/driver.go
+++ b/internal/cli/progress/driver.go
@@ -70,3 +70,42 @@ var (
 	_ io.Writer = (*countingWriter)(nil)
 	_ Adder     = (*countingWriter)(nil)
 )
+
+// livenessWriter is an io.Writer a caller passes in place of io.Discard for a
+// subprocess whose byte stream carries no useful progress payload but whose
+// mere activity is proof the step is alive. It swallows every byte, never
+// blocks the subprocess, and never errors, so it composes safely as the outer
+// argument of an io.MultiWriter (for example alongside a stderr capture buffer)
+// without altering the teed bytes or consuming the stream any other reader
+// needs. It emits nothing itself: the visible advancing feedback comes from the
+// Indicator's ticker-driven Start label, not from this writer, so on the
+// non-TTY or quiet path it is inert and injects no control characters.
+type livenessWriter struct {
+	ind *Indicator
+}
+
+// NewLivenessWriter returns an io.Writer that discards its input while keeping
+// a reference to ind for liveness bookkeeping. It is a named, non-discarding
+// sink callers hand to a build or copy step in place of io.Discard so the
+// step's output flows through the progress path. A nil ind is valid and yields
+// a writer that simply swallows bytes, so callers need no nil branching.
+func NewLivenessWriter(ind *Indicator) io.Writer {
+	return livenessWriter{ind: ind}
+}
+
+// Write reports every byte as consumed and never errors, so it never blocks or
+// fails the subprocess writing through it. It emits nothing to the Indicator's
+// destination: the visible liveness animation is owned by the ticker via Start,
+// and writing raw subprocess bytes here would corrupt a captured buffer or a
+// terminal redraw line. It merely nudges the active liveness so a caller can
+// observe forward motion, and is a no-op when the Indicator is nil, quiet, or
+// non-TTY.
+func (w livenessWriter) Write(p []byte) (int, error) {
+	if w.ind != nil {
+		w.ind.poke()
+	}
+	return len(p), nil
+}
+
+// compile-time assertion that livenessWriter satisfies io.Writer.
+var _ io.Writer = livenessWriter{}

--- a/internal/cli/progress/driver_test.go
+++ b/internal/cli/progress/driver_test.go
@@ -92,3 +92,87 @@ func TestCountingWriterComposesWithIOCopy(t *testing.T) {
 		t.Errorf("expected 100%% after copy, got %q", display.String())
 	}
 }
+
+func TestLivenessWriterConsumesAllBytesNoError(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewLivenessWriter(ind)
+
+	payload := bytes.Repeat([]byte("z"), 512)
+	n, err := w.Write(payload)
+	if err != nil {
+		t.Fatalf("liveness write: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("expected Write to report %d bytes, got %d", len(payload), n)
+	}
+}
+
+// TestLivenessWriterEmitsNothingNonTTY proves the sink injects no control
+// characters (or any bytes) into the indicator's destination on the non-TTY
+// path: the visible feedback is owned by Start's ticker, not by writes through
+// the sink. The buffer therefore holds only Start's plain label line.
+func TestLivenessWriterEmitsNothingNonTTY(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	before := display.String()
+
+	w := NewLivenessWriter(ind)
+	if _, err := w.Write([]byte("noisy subprocess output\r\x1b[Kwith control chars")); err != nil {
+		t.Fatalf("liveness write: %v", err)
+	}
+
+	if got := display.String(); got != before {
+		t.Errorf("liveness write must emit nothing; buffer changed from %q to %q", before, got)
+	}
+	if strings.ContainsAny(display.String(), "\r\x1b") {
+		t.Errorf("non-TTY output must contain no ESC or CR, got %q", display.String())
+	}
+}
+
+// TestLivenessWriterQuietEmitsNothing proves a quiet indicator's liveness sink
+// still consumes bytes without error and writes nothing.
+func TestLivenessWriterQuietEmitsNothing(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false), WithQuiet(true))
+	ind.Start("building")
+	w := NewLivenessWriter(ind)
+	n, err := w.Write([]byte("payload"))
+	if err != nil || n != len("payload") {
+		t.Fatalf("quiet liveness write = %d, %v", n, err)
+	}
+	if display.Len() != 0 {
+		t.Errorf("quiet indicator must emit nothing, got %q", display.String())
+	}
+}
+
+// TestLivenessWriterNilIndicator proves the sink is safe with no backing
+// indicator: it swallows bytes and reports them consumed.
+func TestLivenessWriterNilIndicator(t *testing.T) {
+	w := NewLivenessWriter(nil)
+	n, err := w.Write([]byte("hello"))
+	if err != nil || n != 5 {
+		t.Fatalf("nil-indicator liveness write = %d, %v", n, err)
+	}
+}
+
+// TestLivenessWriterComposesInMultiWriterUnchanged proves the sink does not
+// alter the bytes a co-writer in an io.MultiWriter receives, so a stderr
+// capture buffer teed alongside it sees the stream verbatim. This is the
+// must-not-break requirement for the freeze daemon-unreachable detection.
+func TestLivenessWriterComposesInMultiWriterUnchanged(t *testing.T) {
+	var display, capture bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+
+	tee := io.MultiWriter(NewLivenessWriter(ind), &capture)
+	payload := []byte("cannot connect to the docker daemon")
+	if _, err := tee.Write(payload); err != nil {
+		t.Fatalf("tee write: %v", err)
+	}
+	if capture.String() != string(payload) {
+		t.Errorf("capture buffer must receive the stream verbatim, got %q", capture.String())
+	}
+}

--- a/internal/cli/progress/progress.go
+++ b/internal/cli/progress/progress.go
@@ -254,6 +254,23 @@ func (i *Indicator) stopSpinnerLocked() {
 	i.mu.Lock()
 }
 
+// poke records subprocess liveness observed through a livenessWriter. It is
+// deliberately non-emitting: the visible spinner is advanced by the ticker in
+// Start's redraw goroutine, and writing here would either corrupt a captured
+// non-TTY buffer or race the ticker for the terminal line. It exists so a
+// livenessWriter has a real Indicator hook to call, and is a no-op once the
+// indicator is quiet, finished, or has no active indication, so a build's write
+// after Done can never emit anything. Safe for concurrent use.
+func (i *Indicator) poke() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.quiet || i.finished || !i.active {
+		return
+	}
+	// No render here on purpose. The ticker owns the animation; poke only marks
+	// that liveness was observed, leaving the non-TTY and quiet paths silent.
+}
+
 // percentOf returns current*100/total as an integer percentage without
 // overflowing when the counts are near the int64 ceiling. It assumes total > 0
 // and 0 <= current <= total, which Update guarantees, so the result is in


### PR DESCRIPTION
## Summary

Wires the reusable `internal/cli/progress` helper package (landed in #2080 for #2076) into `aileron skill freeze` so the base-image pull and both composed builds show live liveness feedback instead of running silently behind `io.Discard`.

- **`LivenessWriter` (new, in `internal/cli/progress`)** — a named `io.Writer` callers pass in place of `io.Discard`. It swallows every byte, never blocks or errors, and emits nothing itself (the ticker owns the visible animation). This lets it sit as the outer argument of `runBuildStep`'s `io.MultiWriter(stderr, &buf)` tee without displacing the daemon-unreachable capture buffer, and keeps the non-TTY / quiet output plain.
- **Indicator threading** — `runSkillFreeze` installs a progress-indicator *factory* over `stdout` and threads it to the pull/build sites through the `imageInspector` seam via a package-level `freezeProgress` factory. `runtimeDigestResolver{}` and `builderFeatureComposer{}` stay zero-value constructible and the runtime-free freeze core is untouched. An `Indicator` is single-shot (first `Done`/`Fail` makes it inert), so each of the three bracketed steps mints its own.
- **Bracketing** — pull → `Pulling base image` / `Pulled base image`; multi-arch build → `Building environment image` / `Built environment image`; daemon-load build → `Loading image into local daemon` / `Loaded image into local daemon`. Build errors call `Fail` and return the existing wrapped error unchanged. Pull stays non-fatal and always resolves to `Done`.
- **`--quiet` flag** — suppresses progress on both TTY and non-TTY paths. The freeze summary always prints. Non-TTY output degrades to plain, control-character-free lines via the helper's autodetection (a captured `bytes.Buffer` is non-`*os.File`).

### Design note

The brief permitted either `--quiet` or a force-flag; `--quiet` was chosen as the cleanest testable seam. Determinate build-stage percentage (buildkit `--progress=rawjson` parsing) is the explicit stretch and is **descoped to a follow-up** under umbrella #2075.

## Test plan

- `internal/cli/progress` (97.1% coverage): `LivenessWriter` consumes all bytes with no error, emits nothing on the non-TTY and quiet paths (no ESC / CR), is nil-safe, and composes in an `io.MultiWriter` without altering the teed bytes.
- `cmd/aileron` freeze tests:
  - **Indicator driven across pull + both builds** — real `runtimeDigestResolver` + real `builderFeatureComposer` through a fake runner; asserts the plain start/done lines for pull and both builds appear, output has no ESC or CR, and the `Froze skill` + `ContentHash:` summary still prints.
  - **`--quiet` suppresses** — none of the three progress labels appear; the summary still does.
  - **Daemon-unreachable tee intact** — a build whose stderr emits the docker-daemon-unreachable marker still yields the translated `Docker isn't reachable` error through the real `container.Builder`, proving the liveness writer did not displace the capture buffer.
- Existing error-propagation tests (`TestBuilderFeatureComposer_DaemonLoadErrorPropagates`, `TestBuilderFeatureComposer_LayoutReadErrorPropagates`) still pass unchanged — `Fail` does not alter the returned error.
- Full suite green via `task test`; `task build` green (Go + docs).

Docs: added a `--quiet` / live-progress note to the freeze guide.

Closes #2077
