### PR TITLE
feat(publish): show live registry-push progress during aileron skill publish

### DIFF
--- a/cmd/aileron/skill_publish.go
+++ b/cmd/aileron/skill_publish.go
@@ -27,6 +27,7 @@ func runSkillPublish(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	version := flags.String("version", "", "frozen version id to publish (default: newest)")
 	registryRef := flags.String("registry", "", "destination OCI repository, e.g. ghcr.io/acme/plan")
+	quiet := flags.Bool("quiet", false, "Suppress the live push progress feedback (the publish summary still prints)")
 	positionals, err := parseInterspersedFlags(flags, args)
 	if err != nil {
 		return 1
@@ -70,6 +71,7 @@ func runSkillPublish(args []string, stdout, stderr io.Writer) int {
 		Lock:      lock,
 		Stdout:    stdout,
 		Stderr:    stderr,
+		Quiet:     *quiet,
 	})
 	if err != nil {
 		switch {

--- a/cmd/aileron/skill_publish_test.go
+++ b/cmd/aileron/skill_publish_test.go
@@ -75,6 +75,40 @@ func TestRunSkillPublishHappyPath(t *testing.T) {
 	}
 }
 
+// TestRunSkillPublishQuietPlumbed proves the --quiet flag threads through into
+// publish.Options.Quiet, and that its absence leaves Quiet false.
+func TestRunSkillPublishQuietPlumbed(t *testing.T) {
+	dir := t.TempDir()
+	skillStoreDir = dir
+	t.Cleanup(func() { skillStoreDir = "" })
+	pin := freeze.ImagePin{Ref: "docker.io/library/python", Digest: "sha256:abc"}
+	writeFrozenFixture(t, dir, "demo", "v1", freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}})
+
+	var got publish.Options
+	withStubPublish(t, func(_ context.Context, o publish.Options) (publish.Result, error) {
+		got = o
+		return publish.Result{}, nil
+	})
+
+	var out, errBuf bytes.Buffer
+	if code := runSkillPublish([]string{"demo", "--registry", "ghcr.io/acme/demo", "--quiet"}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%s)", code, errBuf.String())
+	}
+	if !got.Quiet {
+		t.Errorf("Quiet = false, want true when --quiet is passed")
+	}
+
+	got = publish.Options{}
+	out.Reset()
+	errBuf.Reset()
+	if code := runSkillPublish([]string{"demo", "--registry", "ghcr.io/acme/demo"}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%s)", code, errBuf.String())
+	}
+	if got.Quiet {
+		t.Errorf("Quiet = true, want false when --quiet is omitted")
+	}
+}
+
 func TestRunSkillPublishUnfrozen(t *testing.T) {
 	dir := t.TempDir()
 	skillStoreDir = dir

--- a/internal/flightplan/publish/progress.go
+++ b/internal/flightplan/publish/progress.go
@@ -1,0 +1,120 @@
+package publish
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ALRubinger/aileron/internal/cli/progress"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+)
+
+// sumSubDAGSize returns the total byte weight of the sub-DAG rooted at root:
+// root.Size plus the Size of every transitive successor reachable via
+// content.Successors, counting each distinct digest exactly once. An OCI graph
+// is a DAG (a shared config or layer blob can be pointed at by several
+// manifests), so deduping by digest is required to avoid double-counting a
+// shared child. It is the precomputed determinate `total` a push settles
+// against: a fully-fresh push settles it via PostCopy, a fully-already-present
+// push via OnCopySkipped, and both land at exactly this value (100%).
+func sumSubDAGSize(ctx context.Context, fetcher content.Fetcher, root ocispec.Descriptor) (int64, error) {
+	seen := make(map[string]bool)
+	var walk func(desc ocispec.Descriptor) (int64, error)
+	walk = func(desc ocispec.Descriptor) (int64, error) {
+		key := desc.Digest.String()
+		if seen[key] {
+			return 0, nil
+		}
+		seen[key] = true
+		total := desc.Size
+		succ, err := content.Successors(ctx, fetcher, desc)
+		if err != nil {
+			return 0, err
+		}
+		for _, s := range succ {
+			n, err := walk(s)
+			if err != nil {
+				return 0, err
+			}
+			total += n
+		}
+		return total, nil
+	}
+	return walk(root)
+}
+
+// settledCounter is the shared running total of bytes a push has settled,
+// incremented from the oras copy callbacks (which oras fires concurrently, up
+// to CopyGraphOptions.Concurrency) and pushed into the Indicator's determinate
+// display. The Indicator.Update itself is concurrency-safe; the counter is
+// guarded so concurrent adds do not lose an increment.
+type settledCounter struct {
+	ind   *progress.Indicator
+	total int64
+	n     int64
+}
+
+// add advances the settled counter by delta and refreshes the determinate
+// display. It is safe for concurrent use.
+func (c *settledCounter) add(delta int64) {
+	settled := atomic.AddInt64(&c.n, delta)
+	c.ind.Update(settled, c.total)
+}
+
+// pushProgress builds the CopyGraphOptions that drive a determinate push
+// against ind, settling `total` bytes. It starts from oras.DefaultCopyGraphOptions
+// (preserving the default Concurrency of 3) and sets only the settled-byte hooks:
+//
+//   - PostCopy(desc) adds desc.Size once, for each freshly-copied node.
+//   - OnCopySkipped(desc) adds the WHOLE sub-DAG weight of desc once, because
+//     oras fires OnCopySkipped a single time per already-present sub-DAG ROOT
+//     and does not descend into its successors. Summing the skipped root's
+//     sub-DAG here is what keeps a fully-already-present push settling at
+//     exactly total (100%) rather than stalling at the root blob's size.
+//
+// A fetcher over the SOURCE store is needed to walk a skipped sub-DAG's weight;
+// the sizes come from the source descriptors, which are byte-identical to what
+// would have been copied. The returned options carry the shared counter's hooks;
+// the caller holds ind and resolves it (Done/Fail) around the copy.
+func pushProgress(fetcher content.Fetcher, ind *progress.Indicator, total int64) oras.CopyGraphOptions {
+	opts := oras.DefaultCopyGraphOptions
+	counter := &settledCounter{ind: ind, total: total}
+	// seen guards against adding a skipped digest's weight more than once. oras
+	// commits each descriptor exactly once before firing OnCopySkipped, so a
+	// second firing for the same digest should not occur; this set makes the
+	// once-only accounting explicit and robust regardless, so a repeated skip
+	// (or a shared child skipped under two parents) never double-settles. The
+	// mutex guards the set against the concurrent callbacks and reserves the key
+	// BEFORE the sumSubDAGSize walk so a concurrent duplicate observes it taken.
+	var seenMu sync.Mutex
+	seen := make(map[string]bool)
+	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
+		counter.add(desc.Size)
+		return nil
+	}
+	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
+		key := desc.Digest.String()
+		seenMu.Lock()
+		if seen[key] {
+			seenMu.Unlock()
+			return nil
+		}
+		seen[key] = true
+		seenMu.Unlock()
+
+		weight, err := sumSubDAGSize(ctx, fetcher, desc)
+		if err != nil {
+			// A weight walk failure must not fail the push (the copy itself
+			// succeeded); fall back to the root's own size so progress still
+			// advances rather than stalling, and never returns an error that
+			// oras would treat as a copy failure.
+			weight = desc.Size
+		}
+		counter.add(weight)
+		return nil
+	}
+	return opts
+}

--- a/internal/flightplan/publish/progress_test.go
+++ b/internal/flightplan/publish/progress_test.go
@@ -1,0 +1,319 @@
+package publish
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cli/progress"
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+// lastPercentLine returns the last plain "<n>%" progress line the non-TTY path
+// emitted into out, or -1 if none was emitted. The determinate Indicator writes
+// bare "<percent>%\n" lines on the non-TTY path (a captured buffer), so this
+// reads back the final settled percentage without coupling to the bar glyphs.
+func lastPercentLine(out string) int {
+	last := -1
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasSuffix(line, "%") {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.TrimSuffix(line, "%")); err == nil {
+			last = n
+		}
+	}
+	return last
+}
+
+// seedFullGraph copies the entire composed sub-DAG (index + every child +
+// blobs) from the layout store into target, so a subsequent publish takes the
+// oras OnCopySkipped(root) path for the whole image push. This is the
+// P0-regression precondition: an already-present sub-DAG must still settle the
+// bar at 100%.
+func seedFullGraph(t *testing.T, target *memory.Store, layout composedLayout) {
+	t.Helper()
+	if err := oras.CopyGraph(context.Background(), layout.store, target, layout.index, oras.DefaultCopyGraphOptions); err != nil {
+		t.Fatalf("seed full graph into target: %v", err)
+	}
+}
+
+// TestPublishProgressAlreadyPresentSettlesAt100 is the residual #2082 P0 bar
+// regression: when the whole composed sub-DAG is already present in the target,
+// oras fires OnCopySkipped once on the ROOT and never descends, so a naive
+// PostCopy-only accounting would settle the bar far below 100%. The corrected
+// settled-byte model adds the skipped root's whole sub-DAG weight, so the last
+// emitted percentage is exactly 100.
+func TestPublishProgressAlreadyPresentSettlesAt100(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	layout := twoArch(t)
+	seedFullGraph(t, target, layout)
+
+	var out bytes.Buffer
+	opts := composedOptions(target, layout)
+	opts.Stdout = &out
+	if _, err := Run(ctx, opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := lastPercentLine(out.String()); got != 100 {
+		t.Fatalf("last progress percentage = %d, want 100 (already-present sub-DAG must settle the bar at 100%%); output:\n%s", got, out.String())
+	}
+}
+
+// TestPublishProgressFreshPushSettlesAt100 proves a fully-fresh composed push
+// (nothing pre-seeded in the target) settles the determinate bar at 100 via the
+// PostCopy hook path.
+func TestPublishProgressFreshPushSettlesAt100(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	layout := twoArch(t)
+
+	var out bytes.Buffer
+	opts := composedOptions(target, layout)
+	opts.Stdout = &out
+	if _, err := Run(ctx, opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := lastPercentLine(out.String()); got != 100 {
+		t.Fatalf("last progress percentage = %d, want 100 (fresh push must advance to 100%%); output:\n%s", got, out.String())
+	}
+}
+
+// TestPublishProgressNonTTYIsPlain proves that when Stdout is a captured buffer
+// (non-TTY), the progress output carries no carriage returns and no ANSI escape
+// sequences, and the unconditional summary and install hint still print.
+func TestPublishProgressNonTTYIsPlain(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	layout := twoArch(t)
+
+	var out bytes.Buffer
+	opts := composedOptions(target, layout)
+	opts.Stdout = &out
+	if _, err := Run(ctx, opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	s := out.String()
+	if strings.Contains(s, "\r") {
+		t.Errorf("non-TTY output contains a carriage return; output:\n%q", s)
+	}
+	if strings.Contains(s, "\x1b[") {
+		t.Errorf("non-TTY output contains an ANSI escape sequence; output:\n%q", s)
+	}
+	if !strings.Contains(s, "published demo") {
+		t.Errorf("missing publish summary; output:\n%s", s)
+	}
+	if !strings.Contains(s, "Install with:") {
+		t.Errorf("missing install hint; output:\n%s", s)
+	}
+}
+
+// TestPublishProgressQuietSuppressesFeedback proves Quiet suppresses all
+// spinner/percentage output while the unconditional summary and install hint
+// still print (they are the result, not progress feedback).
+func TestPublishProgressQuietSuppressesFeedback(t *testing.T) {
+	ctx := context.Background()
+	target := memory.New()
+	layout := twoArch(t)
+
+	var out bytes.Buffer
+	opts := composedOptions(target, layout)
+	opts.Stdout = &out
+	opts.Quiet = true
+	if _, err := Run(ctx, opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	s := out.String()
+	if got := lastPercentLine(s); got != -1 {
+		t.Errorf("quiet run still emitted a percentage line (%d); output:\n%s", got, s)
+	}
+	if strings.Contains(s, "Pushing") || strings.Contains(s, "Pushed") {
+		t.Errorf("quiet run emitted a progress label; output:\n%s", s)
+	}
+	if !strings.Contains(s, "published demo") {
+		t.Errorf("quiet run dropped the publish summary; output:\n%s", s)
+	}
+	if !strings.Contains(s, "Install with:") {
+		t.Errorf("quiet run dropped the install hint; output:\n%s", s)
+	}
+}
+
+// TestPublishProgressForeignBaseDeterminate proves a foreign-base push whose
+// source Resolve returns a real Size-bearing manifest drives a determinate bar
+// that reaches 100%.
+func TestPublishProgressForeignBaseDeterminate(t *testing.T) {
+	ctx := context.Background()
+	src := memory.New()
+	manifest := seedImage(t, src, ociConfigBody(t, "linux", "amd64", "base"))
+	if err := src.Tag(ctx, manifest, manifest.Digest.String()); err != nil {
+		t.Fatalf("tag source: %v", err)
+	}
+	target := memory.New()
+
+	var out bytes.Buffer
+	pin := freeze.ImagePin{Ref: "docker.io/library/python", Digest: manifest.Digest.String()}
+	_, err := Run(ctx, Options{
+		Name: "demo", VersionID: "v1", Registry: "example.com/demo",
+		Frozen: testFrozen(),
+		Lock:   freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}},
+		Target: target,
+		Stdout: &out,
+		SourceRepo: func(context.Context, string) (oras.ReadOnlyTarget, error) {
+			return src, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := lastPercentLine(out.String()); got != 100 {
+		t.Fatalf("foreign-base determinate bar last percentage = %d, want 100; output:\n%s", got, out.String())
+	}
+}
+
+// resolveFailSource wraps a memory store but errors on the precompute Resolve of
+// failOn while still serving Fetch/Exists/Push, standing in for a source registry
+// whose HEAD-style Resolve fails even though the blob GET succeeds. The
+// foreign-base precompute Resolve then errors, so the determinate branch is
+// skipped and the indeterminate liveness spinner drives the push instead. The
+// underlying store still copies the bytes, so the push succeeds. Only the FIRST
+// Resolve (the publish precompute) fails; oras.Copy's internal resolveRoot then
+// succeeds, isolating the fallback trigger to the precompute path.
+type resolveFailSource struct {
+	*memory.Store
+	failOn string
+	failed bool
+}
+
+func (r *resolveFailSource) Resolve(ctx context.Context, ref string) (ocispec.Descriptor, error) {
+	if ref == r.failOn && !r.failed {
+		r.failed = true
+		return ocispec.Descriptor{}, errors.New("registry resolve unavailable")
+	}
+	return r.Store.Resolve(ctx, ref)
+}
+
+// TestPublishProgressForeignBaseIndeterminateFallback proves that a foreign-base
+// push whose precompute Resolve fails falls back to the indeterminate liveness
+// path: no percentage line is emitted, no divide-by-zero occurs, the liveness
+// label prints, and the push still succeeds (oras.Copy's own resolve works).
+func TestPublishProgressForeignBaseIndeterminateFallback(t *testing.T) {
+	ctx := context.Background()
+	src := memory.New()
+	manifest := seedImage(t, src, ociConfigBody(t, "linux", "amd64", "base"))
+	if err := src.Tag(ctx, manifest, manifest.Digest.String()); err != nil {
+		t.Fatalf("tag source: %v", err)
+	}
+	target := memory.New()
+
+	var out bytes.Buffer
+	pin := freeze.ImagePin{Ref: "docker.io/library/python", Digest: manifest.Digest.String()}
+	res, err := Run(ctx, Options{
+		Name: "demo", VersionID: "v1", Registry: "example.com/demo",
+		Frozen: testFrozen(),
+		Lock:   freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}},
+		Target: target,
+		Stdout: &out,
+		SourceRepo: func(context.Context, string) (oras.ReadOnlyTarget, error) {
+			return &resolveFailSource{Store: src, failOn: manifest.Digest.String()}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BindingKind != freeze.BindingManifestDigest {
+		t.Errorf("binding = %q, want %q", res.BindingKind, freeze.BindingManifestDigest)
+	}
+	s := out.String()
+	if got := lastPercentLine(s); got != -1 {
+		t.Errorf("indeterminate fallback still emitted a percentage line (%d); output:\n%s", got, s)
+	}
+	if !strings.Contains(s, "Pushing image to registry") {
+		t.Errorf("indeterminate fallback did not emit the liveness label; output:\n%s", s)
+	}
+}
+
+// TestSumSubDAGSizeDedupesSharedChildren proves sumSubDAGSize counts each
+// distinct digest once: a DAG where two manifests share a config/layer blob must
+// not double-count the shared child. It exercises the helper directly against
+// the in-memory seam.
+func TestSumSubDAGSizeDedupesSharedChildren(t *testing.T) {
+	ctx := context.Background()
+	layout := twoArch(t)
+	// The full sub-DAG weight walked from the index equals the sum of every
+	// DISTINCT descriptor's Size. A fresh CopyGraph into an empty target settles
+	// exactly that many bytes via PostCopy, so total must be positive and finite.
+	total, err := sumSubDAGSize(ctx, layout.store, layout.index)
+	if err != nil {
+		t.Fatalf("sumSubDAGSize: %v", err)
+	}
+	if total <= 0 {
+		t.Fatalf("sub-DAG total = %d, want a positive byte weight", total)
+	}
+	// Re-walking is deterministic (no mutation), so a second call matches.
+	again, err := sumSubDAGSize(ctx, layout.store, layout.index)
+	if err != nil {
+		t.Fatalf("sumSubDAGSize (again): %v", err)
+	}
+	if again != total {
+		t.Errorf("sub-DAG total not deterministic: %d then %d", total, again)
+	}
+}
+
+// TestPushProgressSkipAddsOncePerDigest proves the OnCopySkipped hook settles a
+// skipped digest's weight exactly once even if it fires twice for the same
+// descriptor (a shared child skipped under two parents), so the counter never
+// over-settles past total.
+func TestPushProgressSkipAddsOncePerDigest(t *testing.T) {
+	ctx := context.Background()
+	layout := twoArch(t)
+	total, err := sumSubDAGSize(ctx, layout.store, layout.index)
+	if err != nil {
+		t.Fatalf("sumSubDAGSize: %v", err)
+	}
+	var out bytes.Buffer
+	ind := progress.New(&out) // a *bytes.Buffer is non-TTY, so plain percentage lines
+	opts := pushProgress(layout.store, ind, total)
+
+	// Fire OnCopySkipped for the same root twice; the second must be a no-op.
+	if err := opts.OnCopySkipped(ctx, layout.index); err != nil {
+		t.Fatalf("OnCopySkipped (first): %v", err)
+	}
+	if err := opts.OnCopySkipped(ctx, layout.index); err != nil {
+		t.Fatalf("OnCopySkipped (second): %v", err)
+	}
+	ind.Done("done")
+	// The last emitted percentage must be exactly 100 (settled once at total),
+	// not >100 from a double add (which the Indicator would clamp to 100 anyway,
+	// so also assert the raw counter did not exceed total).
+	if got := lastPercentLine(out.String()); got != 100 {
+		t.Fatalf("last percentage = %d, want 100 after a duplicate skip; output:\n%s", got, out.String())
+	}
+}
+
+// TestPublishProgressImagePushErrorFails proves an image-push failure still
+// surfaces the annotated error (no swallow by the Fail path). The composed push
+// rejects the index write; the run must return a push-composed-image error.
+func TestPublishProgressImagePushErrorFails(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	layout := twoArch(t)
+	var out bytes.Buffer
+	opts := composedOptions(pushFailTarget{Store: inner, failMediaType: ocispec.MediaTypeImageIndex}, layout)
+	opts.Stdout = &out
+	if _, err := Run(ctx, opts); err == nil || !strings.Contains(err.Error(), "push composed image") {
+		t.Fatalf("err = %v, want a push-composed-image error even with progress wired", err)
+	}
+	// The Fail path must not have written a false success line.
+	if strings.Contains(out.String(), "Pushed image to registry") {
+		t.Errorf("failed push emitted a success completion line; output:\n%s", out.String())
+	}
+}

--- a/internal/flightplan/publish/publish.go
+++ b/internal/flightplan/publish/publish.go
@@ -45,6 +45,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ALRubinger/aileron/internal/cli/progress"
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
 	"github.com/ALRubinger/aileron/internal/flightplan/ociremote"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
@@ -98,6 +99,27 @@ type Options struct {
 
 	Stdout io.Writer
 	Stderr io.Writer
+
+	// Quiet suppresses the live push-progress feedback (spinner/percentage) on
+	// both the TTY and non-TTY paths. The `published ...` summary and its
+	// install hint still print: they are the result, not progress output.
+	Quiet bool
+}
+
+// newIndicator mints a fresh single-shot progress.Indicator over opts.Stdout
+// for one bracketed push step. Each step needs its own indicator because an
+// Indicator is single-shot (its first Done/Fail makes it inert), mirroring the
+// freeze factory pattern. TTY autodetection fires only when Stdout is an
+// *os.File attached to a terminal; a captured *bytes.Buffer degrades to plain,
+// control-character-free lines. opts.Quiet suppresses output on both paths. A
+// nil Stdout (never in practice: run defaults it) yields an io.Discard-backed
+// indicator that emits nothing.
+func (o Options) newIndicator() *progress.Indicator {
+	w := o.Stdout
+	if w == nil {
+		w = io.Discard
+	}
+	return progress.New(w, progress.WithQuiet(o.Quiet))
 }
 
 // Result reports what a publish run pushed.
@@ -177,7 +199,14 @@ func run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	// 2. Push the four signed-artifact blobs as layers.
+	// 2. Push the four signed-artifact blobs as layers. Bracket the whole
+	//    artifact region (blob loop + pack + tags) with a liveness indicator: the
+	//    blob/pack/tag sizes are small and fixed, so a labeled spinner reads
+	//    better than a bar that would jump straight to 100%. artifactInd resolves
+	//    exactly once, so Fail must guard every error return in the region and
+	//    Done fires after the last tag but before the summary.
+	artifactInd := opts.newIndicator()
+	artifactInd.Start("Pushing signed artifact")
 	layers := make([]ocispec.Descriptor, 0, 4)
 	for _, blob := range []struct {
 		mediaType string
@@ -190,6 +219,7 @@ func run(ctx context.Context, opts Options) (Result, error) {
 	} {
 		desc, err := pushBlob(ctx, target, blob.mediaType, blob.data)
 		if err != nil {
+			artifactInd.Fail("Pushing signed artifact")
 			return Result{}, fmt.Errorf("publish: push artifact blob %s: %w", blob.mediaType, err)
 		}
 		layers = append(layers, desc)
@@ -208,6 +238,7 @@ func run(ctx context.Context, opts Options) (Result, error) {
 		},
 	})
 	if err != nil {
+		artifactInd.Fail("Pushing signed artifact")
 		return Result{}, fmt.Errorf("publish: pack signed artifact: %w", err)
 	}
 
@@ -221,24 +252,31 @@ func run(ctx context.Context, opts Options) (Result, error) {
 	//    resolved slug rather than the mutable tag (which would break launch's
 	//    `<versionTag>-image` resolution and the no-op re-install).
 	if err := target.Tag(ctx, artifactDesc, opts.VersionID); err != nil {
+		artifactInd.Fail("Pushing signed artifact")
 		return Result{}, fmt.Errorf("publish: tag artifact %s: %w", opts.VersionID, err)
 	}
 	if err := target.Tag(ctx, artifactDesc, "latest"); err != nil {
+		artifactInd.Fail("Pushing signed artifact")
 		return Result{}, fmt.Errorf("publish: tag artifact latest: %w", err)
 	}
 	if label := opts.Lock.Version; label != "" {
 		// A semver `+build` metadata suffix (or any other character outside the
 		// OCI tag grammar) is not a legal tag. Skip the semver tag with a warning
 		// rather than hard-failing an otherwise-valid publish; the content-hash
-		// and latest tags still land.
+		// and latest tags still land. This warning branch is a non-error continue,
+		// so it must NOT resolve the indicator as failed.
 		if isValidOCITag(label) {
 			if err := target.Tag(ctx, artifactDesc, label); err != nil {
+				artifactInd.Fail("Pushing signed artifact")
 				return Result{}, fmt.Errorf("publish: tag artifact %s: %w", label, err)
 			}
 		} else {
 			fmt.Fprintf(opts.Stderr, "warning: version label %q is not a valid OCI tag; skipping the semver tag (content-hash and latest tags still published)\n", label)
 		}
 	}
+	// Resolve the artifact indicator after the last tag lands but before the
+	// summary prints, so the summary is the final output line.
+	artifactInd.Done("Pushed signed artifact")
 
 	res := Result{
 		ImageRef:       opts.Registry + "@" + imageDesc.Digest.String(),
@@ -303,18 +341,38 @@ func publishComposed(ctx context.Context, opts Options, pin freeze.ImagePin, tar
 		return ocispec.Descriptor{}, "", err
 	}
 
+	// Bracket the image push with a determinate progress indicator: precompute the
+	// whole source sub-DAG's byte weight and settle against it via the oras copy
+	// hooks. A fully-fresh push settles via PostCopy, a fully-already-present push
+	// via OnCopySkipped, and both reach exactly total (100%). ind resolves once, so
+	// every error return below fails it; Done fires only after the push, tag, and
+	// post-push re-verify all succeed.
+	ind := opts.newIndicator()
+	ind.Start("Pushing image to registry")
+	copyOpts := oras.DefaultCopyGraphOptions
+	if total, terr := sumSubDAGSize(ctx, store, root); terr == nil && total > 0 {
+		// Determinate: drive the bar off the settled-byte hooks over the source store.
+		copyOpts = pushProgress(store, ind, total)
+	}
+	// else: leave the indeterminate Start spinner running (a zero-weight or
+	// unwalkable graph, which the composed layout should never be) with the
+	// default hook-free copy options.
+
 	// Copy the full manifest-list graph (index + both platform children + any
 	// buildkit attestation manifests) into the destination, then tag it. oras
 	// copies the bytes exactly, so the manifest digest is preserved.
 	imageTag := freeze.ComposedImageTag(opts.VersionID)
-	if err := oras.CopyGraph(ctx, store, target, root, oras.DefaultCopyGraphOptions); err != nil {
+	if err := oras.CopyGraph(ctx, store, target, root, copyOpts); err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: push composed image: %w", err)
 	}
 	if err := target.Tag(ctx, root, imageTag); err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: tag composed image %s: %w", imageTag, err)
 	}
 	desc, err := target.Resolve(ctx, imageTag)
 	if err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: resolve pushed composed image: %w", err)
 	}
 
@@ -325,11 +383,14 @@ func publishComposed(ctx context.Context, opts Options, pin freeze.ImagePin, tar
 	// substitution fails closed.
 	pushedDigests, err := ociremote.AllPlatformConfigContentDigests(ctx, target, desc)
 	if err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: read pushed image config: %w", err)
 	}
 	if err := verifyPerArch(pin, pushedDigests, "pushed"); err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", err
 	}
+	ind.Done("Pushed image to registry")
 	return desc, freeze.BindingConfigContentDigest, nil
 }
 
@@ -381,16 +442,37 @@ func publishForeignBase(ctx context.Context, opts Options, pin freeze.ImagePin, 
 		}
 		src = repo
 	}
+	// Bracket the copy with a progress indicator. Precompute the source sub-DAG's
+	// byte weight for a determinate bar: resolve the pin digest against the source
+	// and sum its sub-DAG. It is determinate only when Resolve succeeds AND the
+	// resolved root carries a real Size (>0); a failed Resolve or a zero-Size root
+	// falls back to the indeterminate liveness spinner. A single-manifest image
+	// with no children but a real size stays determinate. oras.Copy re-resolves
+	// internally, so this extra Resolve is purely for the precompute (cheap against
+	// the fake, acceptable against a real registry).
+	copyGraphOpts := oras.DefaultCopyGraphOptions
+	ind := opts.newIndicator()
+	ind.Start("Pushing image to registry")
+	if resolved, rerr := src.Resolve(ctx, pin.Digest); rerr == nil && resolved.Size > 0 {
+		if total, terr := sumSubDAGSize(ctx, src, resolved); terr == nil && total > 0 {
+			copyGraphOpts = pushProgress(src, ind, total)
+		}
+	}
+	// else: leave the indeterminate Start spinner running with hook-free options.
+
 	// Copy by the attested manifest digest; oras.Copy preserves it byte-for-byte.
-	root, err := oras.Copy(ctx, src, pin.Digest, target, "", oras.DefaultCopyOptions)
+	root, err := oras.Copy(ctx, src, pin.Digest, target, "", oras.CopyOptions{CopyGraphOptions: copyGraphOpts})
 	if err != nil {
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: copy base image %s@%s: %w", pin.Ref, pin.Digest, err)
 	}
 	if root.Digest.String() != pin.Digest {
 		// oras.Copy resolved the digest reference, so this should hold; assert
 		// to fail closed if a registry ever returns a divergent manifest.
+		ind.Fail("Pushing image to registry")
 		return ocispec.Descriptor{}, "", fmt.Errorf("publish: copied manifest digest %s != lock attested %s", root.Digest, pin.Digest)
 	}
+	ind.Done("Pushed image to registry")
 	return root, freeze.BindingManifestDigest, nil
 }
 


### PR DESCRIPTION
## Summary

Wires the `internal/cli/progress` helper (shipped in #2080) into `aileron skill publish` so the image push and the signed-artifact push narrate live progress instead of sitting silent. Carries the corrected push-accounting model from residual #2082.

Today all silence stems from `run` defaulting `opts.Stdout`/`opts.Stderr` to `io.Discard` and the oras copies using the default (hook-free) options. This change:

- **Determinate image push (settled-byte model).** Precompute the total byte weight of the source sub-DAG (root + all transitive successors, deduped by digest via `sumSubDAGSize`). Settle against it through oras copy hooks in a new `pushProgress` builder (cloned from `oras.DefaultCopyGraphOptions`, preserving the default concurrency of 3):
  - `PostCopy(desc)` adds `desc.Size` once per freshly copied node.
  - `OnCopySkipped(desc)` adds the skipped sub-DAG **root's** whole recursively-summed weight once (oras fires it once per already-present sub-DAG root and does not descend), guarded by a `seen` set so a repeated skip never double-settles.
  - A fully-fresh push and a fully-already-present push both settle at exactly `total` (100%). This is the residual #2082 P0-correct model; a root-only accounting would leave an already-present push far below 100%.
- **Indeterminate fallback.** Falls back to the liveness spinner when the total is unknown: on the foreign-base path this triggers on a failed precompute `Resolve` or a zero-`Size` root. A single-manifest image with no children but a real size stays determinate.
- **Artifact region narration.** Brackets the blob-loop + pack + three-tag region with a liveness indicator: `Fail` before every error return, `Done` after the last tag but before the unconditional summary. The invalid-semver warning branch is a non-error continue and does not `Fail`.
- **`--quiet` flag.** Added to `skill_publish.go` and plumbed into a new `Options.Quiet` field, threaded into every `progress.New(..., WithQuiet(...))`. The `published ...` summary and `Install with:` hint stay unconditional (they are the result, not progress output).

No new dependencies, no backwards-compat shims, no changes to `internal/cli/progress` (the sub-DAG-sum + hook wiring lives in the publish package). Binding-verify logic, tag semantics, `annotateRegistryAuthError`, and the summary/install text are untouched.

## Test plan

New `internal/flightplan/publish/progress_test.go` (contract-level, via the existing in-memory fakes):

- **P0 bar regression** (`TestPublishProgressAlreadyPresentSettlesAt100`): pre-seed the full composed graph into the target so oras takes the `OnCopySkipped(root)` path; assert the last emitted percentage is 100. Verified this test **fails before** the fix (root-only accounting undershoots) and **passes after**.
- Fresh push advances to 100 via `PostCopy`.
- Non-TTY plainness: captured `*bytes.Buffer` output has no `\r` and no `\x1b[`, and still carries the summary + install hint.
- Foreign-base determinate reaches 100; foreign-base indeterminate fallback (failed precompute Resolve) emits no percentage, no divide-by-zero, still succeeds.
- Duplicate-skip-adds-once regression; `sumSubDAGSize` dedup/determinism.
- Image-push error still surfaces the annotated error with no false success line.
- `cmd/aileron/skill_publish_test.go`: `--quiet` plumbs into `Options.Quiet` (true when passed, false when omitted).

`go test -cover ./internal/flightplan/publish/...` → 89.3%; `go test ./cmd/aileron/...` green. CodeRabbit review clean (0 findings).

Closes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1DcnDZFwjCxxB4dQuR5p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quieter publish output with a new option to suppress live progress feedback while still showing the final publish summary and install hint.
  * Improved publish progress reporting so large image uploads now show clearer, more consistent progress and still finish at 100% when complete.
  * Added support for plain, non-TTY-friendly publish output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->