### PR TITLE
test(progress): assert redraw goroutine exits after Done and Fail

### DIFF
--- a/internal/cli/progress/progress_test.go
+++ b/internal/cli/progress/progress_test.go
@@ -136,6 +136,53 @@ func TestStartThenUpdateStopsSpinner(t *testing.T) {
 	}
 }
 
+func TestStartThenDoneStopsSpinner(t *testing.T) {
+	// Done on a running spinner must join the redraw goroutine before it
+	// returns, so the goroutine cannot keep consuming ticks (a leak) or draw a
+	// spinner frame after the resolved "✓" line. Drive one tick, resolve with
+	// Done, then prove nothing is listening on the tick channel.
+	var buf syncBuffer
+	tick := make(chan time.Time)
+	ind := New(&buf, WithForceTTY(true), WithTicker(tick))
+
+	ind.Start("copy")
+	tick <- time.Now() // one spinner frame
+	ind.Done("copy")
+
+	// resolve() joins the redraw goroutine synchronously, so after Done the
+	// goroutine has exited and a non-blocking send must hit the default branch.
+	select {
+	case tick <- time.Now():
+		t.Fatal("redraw goroutine still consuming ticks after Done")
+	default:
+	}
+	if !strings.HasSuffix(buf.String(), "✓ copy\n") {
+		t.Errorf("expected resolved done line after Start->Done, got %q", buf.String())
+	}
+}
+
+func TestStartThenFailStopsSpinner(t *testing.T) {
+	// Fail has the same stop-and-join semantics as Done: it must terminate the
+	// redraw goroutine before returning so no tick is consumed and no spinner
+	// frame is drawn after the resolved "✗" line.
+	var buf syncBuffer
+	tick := make(chan time.Time)
+	ind := New(&buf, WithForceTTY(true), WithTicker(tick))
+
+	ind.Start("deploy")
+	tick <- time.Now() // one spinner frame
+	ind.Fail("deploy")
+
+	select {
+	case tick <- time.Now():
+		t.Fatal("redraw goroutine still consuming ticks after Fail")
+	default:
+	}
+	if !strings.HasSuffix(buf.String(), "✗ deploy\n") {
+		t.Errorf("expected resolved fail line after Start->Fail, got %q", buf.String())
+	}
+}
+
 func TestUpdateLargeByteCountsNoOverflow(t *testing.T) {
 	var buf bytes.Buffer
 	ind := New(&buf, WithForceTTY(true))


### PR DESCRIPTION
## Summary

Closes the last actionable finding for cw-review-residual #2079 (sub-issue #2076): a goroutine-leak assertion that was not part of the concurrency test scenario.

`TestStartThenUpdateStopsSpinner` proves the redraw goroutine stops after a determinate `Update`, but no test asserted the goroutine terminates after `Done` or `Fail`. This adds two tests mirroring that scenario:

- `TestStartThenDoneStopsSpinner`
- `TestStartThenFailStopsSpinner`

Each constructs an indicator with `WithForceTTY(true)` + `WithTicker(tick)`, `Start`s, drives one tick, resolves (`Done` / `Fail`), then performs a non-blocking send on the injected tick channel (`select { case tick <- ...: t.Fatal(...); default: }`) to prove no goroutine is still consuming ticks. `resolve()` joins the redraw goroutine synchronously via `stopSpinnerLocked()`, so the assertion is deterministic.

No production code changed; this is a test-only, single-file addition.

## Test plan

- `go test -race -run 'TestStartThenDoneStopsSpinner|TestStartThenFailStopsSpinner|TestStartThenUpdateStopsSpinner' ./internal/cli/progress/ -v` — all pass
- `go test -race -cover ./internal/cli/progress/` — pass, coverage 97.1%
- `gofmt -l` clean, `go vet` clean

Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1DcnDZFwjCxxB4dQuR5p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for progress indicator shutdown in terminal environments.
  * Verified the spinner stops cleanly after success or failure and the final status line is shown correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->