### PR TITLE
feat(freeze): determinate buildkit build-stage progress via rawjson

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -372,9 +372,12 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		Stdout:  io.Discard,
 		Stderr:  io.Discard,
 	}
-	// setBuildSinks points the Builder's stdout/stderr at the liveness sink for
-	// the given indicator (falling back to io.Discard when no indicator is
-	// active). The stderr sink stays the OUTER argument of runBuildStep's
+	// setBuildSinks points the Builder's stdout/stderr at the buildkit-progress
+	// sink for the given indicator (falling back to io.Discard when no indicator
+	// is active). The sink parses the BUILDKIT_PROGRESS=rawjson stream buildx emits
+	// on stderr into a determinate percentage, and degrades to indeterminate
+	// liveness on any non-rawjson output, so it never regresses today's behavior.
+	// The stderr sink stays the OUTER argument of runBuildStep's
 	// io.MultiWriter(stderr, &buf) tee, so the daemon-unreachable capture buffer
 	// still sees every byte and the sink never consumes the stream. It emits no
 	// bytes itself, so the non-TTY/quiet plain-line contract holds.
@@ -384,8 +387,8 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 			b.Stderr = io.Discard
 			return
 		}
-		b.Stdout = progress.NewLivenessWriter(ind)
-		b.Stderr = progress.NewLivenessWriter(ind)
+		b.Stdout = progress.NewBuildkitProgressWriter(ind)
+		b.Stderr = progress.NewBuildkitProgressWriter(ind)
 	}
 	// Wire the managed provisioner only on the managed branch; the host-npx
 	// opt-out must never carry a provisioner (its no-network/no-provision
@@ -431,6 +434,10 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		// build below intentionally omits this so it stays on the default `docker`
 		// driver and lands the image in the local daemon (issue #2054).
 		BuildxBuilder: container.FreezeBuilderName,
+		// Request structured buildkit progress so the build sink can render a
+		// determinate percentage; it carries into loadOpts below too, so both build
+		// steps get it (issue #2084).
+		ProgressRawJSON: true,
 	}
 	var buildInd *progress.Indicator
 	if in.newProgress != nil {
@@ -464,6 +471,10 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 	loadOpts := buildOpts
 	loadOpts.Platforms = nil
 	loadOpts.OCILayoutDest = ""
+	// loadOpts inherits ProgressRawJSON=true from buildOpts (only Platforms and
+	// OCILayoutDest are zeroed), so this single-arch daemon-load build also emits
+	// determinate buildkit progress; BuildxBuilder is inert here because Platforms
+	// is nil, so the build stays on the default `docker` driver (issue #2084).
 	var loadInd *progress.Indicator
 	if in.newProgress != nil {
 		loadInd = in.newProgress()

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -342,6 +342,118 @@ func TestRunSkillFreeze_IndicatorDrivenAcrossPullAndBuilds(t *testing.T) {
 	}
 }
 
+// rawjsonBuildRunner passes the buildx preflight and, for each build command,
+// writes a BUILDKIT_PROGRESS=rawjson vertex stream to the build's stderr sink
+// (where buildx emits rawjson) so the freeze build sink parses it into a
+// determinate percentage. It also records the env each build carried so a test
+// can assert BUILDKIT_PROGRESS=rawjson reached both build subprocesses. It
+// overrides both Run and RunWithEnv because every build now carries a
+// BUILDKIT_PROGRESS=rawjson env entry and routes through the envRunner path.
+type rawjsonBuildRunner struct {
+	*genericInspectRunner
+	mu        sync.Mutex
+	buildEnvs [][]string
+}
+
+func (r *rawjsonBuildRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdout, stderr)
+}
+
+func (r *rawjsonBuildRunner) RunWithEnv(ctx context.Context, name string, args, env []string, stdout, stderr io.Writer) error {
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "build") && (strings.Contains(joined, "--output") || strings.Contains(joined, "--image-name")) {
+		r.mu.Lock()
+		r.buildEnvs = append(r.buildEnvs, append([]string(nil), env...))
+		r.mu.Unlock()
+		// Emit a three-vertex rawjson stream that reveals then completes every
+		// vertex, exactly as buildx does on stderr under BUILDKIT_PROGRESS=rawjson.
+		for _, d := range []string{"sha256:v1", "sha256:v2", "sha256:v3"} {
+			_, _ = stderr.Write([]byte(`{"vertexes":[{"digest":"` + d + `","name":"[stage] RUN"}]}` + "\n"))
+		}
+		for _, d := range []string{"sha256:v1", "sha256:v2", "sha256:v3"} {
+			_, _ = stderr.Write([]byte(`{"vertexes":[{"digest":"` + d + `","name":"[stage] RUN","completed":"2026-07-08T00:00:00Z"}]}` + "\n"))
+		}
+		return nil
+	}
+	return r.genericInspectRunner.RunWithEnv(ctx, name, args, env, stdout, stderr)
+}
+
+func (r *rawjsonBuildRunner) recordedBuildEnvs() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][]string(nil), r.buildEnvs...)
+}
+
+// TestRunSkillFreeze_DeterminateBuildProgress proves the determinate happy path:
+// when the build subprocess emits a BUILDKIT_PROGRESS=rawjson vertex stream on
+// stderr, freeze renders a determinate percentage (100% on the non-TTY path) for
+// the two build steps while still printing the completion labels, and both build
+// invocations carried BUILDKIT_PROGRESS=rawjson in their env (issue #2084).
+func TestRunSkillFreeze_DeterminateBuildProgress(t *testing.T) {
+	t.Setenv(container.ToolchainModeEnv, container.ToolchainModeHostNPX)
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	key := writeSigningKey(t)
+
+	stubOCILayoutDigests(t, []ociremote.PlatformConfigDigest{
+		{OS: "linux", Arch: "amd64", Digest: "sha256:" + strings.Repeat("a", 64)},
+		{OS: "linux", Arch: "arm64", Digest: "sha256:" + strings.Repeat("b", 64)},
+	})
+	gr := &rawjsonBuildRunner{
+		genericInspectRunner: &genericInspectRunner{
+			fakeRunner: &fakeRunner{outputs: buildxPreflightOK()},
+			repoDigest: "sha256:" + strings.Repeat("c", 64),
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{
+			runner:  gr,
+			runtime: "docker",
+			newProgress: func() *progress.Indicator {
+				return progress.New(&stdout, progress.WithForceTTY(false))
+			},
+		}, nil
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	// The determinate signal reached 100% (all vertexes completed) on the non-TTY
+	// path, which renders a plain `100%` line, for the build steps.
+	if !strings.Contains(out, "100%") {
+		t.Errorf("determinate build progress must render a percentage reaching 100%%:\n%s", out)
+	}
+	// The completion labels still print.
+	for _, want := range []string{"Built environment image", "Loaded image into local daemon"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout must still print completion label %q:\n%s", want, out)
+		}
+	}
+	// Both build invocations carried BUILDKIT_PROGRESS=rawjson in their env,
+	// tying the freeze call site to the container-package env plumbing.
+	buildEnvs := gr.recordedBuildEnvs()
+	if len(buildEnvs) < 2 {
+		t.Fatalf("expected at least 2 build invocations (multi-arch + daemon-load), got %d", len(buildEnvs))
+	}
+	for i, env := range buildEnvs {
+		found := false
+		for _, e := range env {
+			if e == "BUILDKIT_PROGRESS=rawjson" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("build invocation %d env = %#v, want BUILDKIT_PROGRESS=rawjson", i, env)
+		}
+	}
+}
+
 // TestRunSkillFreeze_QuietSuppressesProgress proves --quiet suppresses every
 // progress label while the freeze summary still prints. It runs the same real
 // pull + build path with a quiet indicator factory.
@@ -1101,15 +1213,21 @@ func TestRuntimeDigestResolver_InspectorError(t *testing.T) {
 // failLoadBuildRunner passes the buildx preflight and the multi-arch OCI build
 // (which carries `--output`) but fails the subsequent host-arch daemon-load build
 // (which carries `--image-name` without `--output`), so the composer's daemon-load
-// error path is exercised.
+// error path is exercised. It overrides both Run and RunWithEnv because the
+// daemon-load build now carries a BUILDKIT_PROGRESS=rawjson env entry and thus
+// routes through the envRunner path (issue #2084).
 type failLoadBuildRunner struct{ *fakeRunner }
 
 func (r failLoadBuildRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	return r.RunWithEnv(ctx, name, args, nil, stdout, stderr)
+}
+
+func (r failLoadBuildRunner) RunWithEnv(ctx context.Context, name string, args, env []string, stdout, stderr io.Writer) error {
 	joined := strings.Join(args, " ")
 	if strings.Contains(joined, "--image-name") && !strings.Contains(joined, "--output") {
 		return errors.New("daemon load failed")
 	}
-	return r.fakeRunner.Run(ctx, name, args, stdout, stderr)
+	return r.fakeRunner.RunWithEnv(ctx, name, args, env, stdout, stderr)
 }
 
 // TestBuilderFeatureComposer_DaemonLoadErrorPropagates proves a failure loading

--- a/internal/cli/progress/driver.go
+++ b/internal/cli/progress/driver.go
@@ -1,6 +1,10 @@
 package progress
 
-import "io"
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
 
 // countingWriter is an io.Writer adapter that forwards bytes to an underlying
 // writer while reporting the running total written into an Indicator's
@@ -109,3 +113,163 @@ func (w livenessWriter) Write(p []byte) (int, error) {
 
 // compile-time assertion that livenessWriter satisfies io.Writer.
 var _ io.Writer = livenessWriter{}
+
+// solveStatus is the minimal subset of buildkit's client.SolveStatus record we
+// parse from a BUILDKIT_PROGRESS=rawjson stream. buildx emits one JSON object
+// per line on stderr, each carrying the build's evolving vertex (build-stage)
+// set. We intentionally do NOT import buildkit's Go types: this local struct
+// names only the fields the determinate signal needs and lets json.Unmarshal
+// drop everything else, so the parse stays tolerant of buildkit-version schema
+// drift and of the human log lines the devcontainer CLI interleaves.
+type solveStatus struct {
+	// Vertexes is the set of build-stage nodes revealed so far. Each rawjson line
+	// re-emits the vertexes it touched; a vertex with a non-nil Completed
+	// timestamp has finished. The completed-fraction of the known vertex set is
+	// the determinate signal: it is the per-stage total buildkit reliably exposes
+	// across versions, unlike the per-status byte totals (often zero).
+	Vertexes []struct {
+		Digest    string `json:"digest"`
+		Completed *any   `json:"completed"`
+	} `json:"vertexes"`
+}
+
+// buildkitProgressWriter is an io.Writer a caller passes as a build
+// subprocess's stderr (and stdout) sink in place of a livenessWriter to turn a
+// BUILDKIT_PROGRESS=rawjson stream into a determinate percentage. It line-buffers
+// its input, parses each complete line as a rawjson solveStatus, and drives
+// ind.Update(completedVertexes, knownVertexes) as build stages complete. The
+// known-vertex total grows as the stream reveals stages, and Indicator.Update
+// renders current/total against the moving total fine.
+//
+// It degrades cleanly and never regresses: a line that is not parseable rawjson,
+// or a parsed line that has not yet revealed any vertex, falls back to a
+// liveness poke so the step still animates exactly as a livenessWriter would.
+// The determinate bar supersedes the spinner the first time Update fires with a
+// non-zero total (existing Indicator.Update semantics), so when
+// BUILDKIT_PROGRESS=rawjson is unhonored (older buildx, a non-buildkit daemon,
+// or a plain docker build), the indeterminate liveness path is preserved intact.
+//
+// Like livenessWriter it emits nothing to the Indicator's destination itself:
+// all rendering goes through Indicator.Update/poke, which already honor the
+// TTY/quiet contract, so the non-TTY path stays plain and --quiet suppresses. It
+// consumes every byte, forwards nothing to any co-writer, never blocks, and never
+// errors, so it composes safely as the OUTER argument of an
+// io.MultiWriter(w, &captureBuf) tee without altering the teed bytes.
+type buildkitProgressWriter struct {
+	ind *Indicator
+	// buf retains a partial trailing line across Write calls so a rawjson object
+	// split across chunk boundaries is only parsed once fully received.
+	buf bytes.Buffer
+	// seen dedupes vertex digests across the stream (each line re-emits the
+	// vertexes it touched), so a vertex is counted toward the total exactly once.
+	seen map[string]bool
+	// completed is the running count of distinct vertexes observed with a
+	// completion timestamp.
+	completed int64
+	// completedDigests records which vertex digests have already been counted as
+	// completed, so a completion re-emitted on a later line is counted once. It
+	// is lazily allocated via completedSet.
+	completedDigests map[string]bool
+}
+
+// NewBuildkitProgressWriter returns an io.Writer that parses a
+// BUILDKIT_PROGRESS=rawjson stream into determinate progress on ind, degrading
+// to liveness pokes on any non-rawjson or not-yet-determinate input. A nil ind
+// is valid and yields a pure byte-sink (matching NewLivenessWriter's
+// nil-tolerance), so callers need no nil branching.
+func NewBuildkitProgressWriter(ind *Indicator) io.Writer {
+	return &buildkitProgressWriter{ind: ind, seen: make(map[string]bool)}
+}
+
+// Write accumulates p, splits it into complete lines on '\n', and processes each
+// line, retaining any partial trailing line for the next call. It reports every
+// byte as consumed and never errors, so it never blocks or fails the subprocess
+// writing through it, and forwards nothing to any other writer so a co-writer in
+// an io.MultiWriter sees the stream verbatim.
+func (w *buildkitProgressWriter) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+	for {
+		data := w.buf.Bytes()
+		nl := bytes.IndexByte(data, '\n')
+		if nl < 0 {
+			break
+		}
+		// Copy the line out before consuming it: bytes.Buffer may reuse the backing
+		// array on the next Write, so the slice must not be retained past the Next.
+		line := append([]byte(nil), data[:nl]...)
+		w.buf.Next(nl + 1)
+		w.processLine(line)
+	}
+	return len(p), nil
+}
+
+// processLine parses one complete line as rawjson and advances the determinate
+// count, or pokes liveness when the line yields no new determinate information.
+// A nil Indicator makes both paths no-ops, so the writer is a pure byte-sink.
+func (w *buildkitProgressWriter) processLine(line []byte) {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return
+	}
+	var status solveStatus
+	if err := json.Unmarshal(trimmed, &status); err != nil || len(status.Vertexes) == 0 {
+		// Not a rawjson status line (the devcontainer CLI interleaves its own human
+		// log lines), or a status line that revealed no vertex: fall back to
+		// liveness so the step still animates, exactly like a livenessWriter.
+		if w.ind != nil {
+			w.ind.poke()
+		}
+		return
+	}
+	newInfo := false
+	for _, v := range status.Vertexes {
+		if v.Digest == "" {
+			continue
+		}
+		if !w.seen[v.Digest] {
+			w.seen[v.Digest] = true
+			newInfo = true
+		}
+		if v.Completed != nil && !w.completedSeen(v.Digest) {
+			w.markCompleted(v.Digest)
+			newInfo = true
+		}
+	}
+	if !newInfo {
+		// The line re-stated only already-known vertexes with no new completion;
+		// keep the step alive without a redundant determinate redraw.
+		if w.ind != nil {
+			w.ind.poke()
+		}
+		return
+	}
+	if w.ind != nil {
+		w.ind.Update(w.completed, int64(len(w.seen)))
+	}
+}
+
+// completedSeen and markCompleted track which vertex digests have already been
+// counted as completed, so a vertex re-emitted with a completion timestamp on a
+// later line is counted exactly once. They lean on a dedicated set rather than
+// overloading seen, because seen also holds still-running vertexes.
+func (w *buildkitProgressWriter) completedSeen(digest string) bool {
+	return w.completedSet()[digest]
+}
+
+func (w *buildkitProgressWriter) markCompleted(digest string) {
+	w.completedSet()[digest] = true
+	w.completed++
+}
+
+// completedSet lazily allocates the completed-digest set. It is separate from
+// seen so an already-seen (running) vertex that later reports completion still
+// increments the completed count exactly once.
+func (w *buildkitProgressWriter) completedSet() map[string]bool {
+	if w.completedDigests == nil {
+		w.completedDigests = make(map[string]bool)
+	}
+	return w.completedDigests
+}
+
+// compile-time assertion that buildkitProgressWriter satisfies io.Writer.
+var _ io.Writer = (*buildkitProgressWriter)(nil)

--- a/internal/cli/progress/driver_test.go
+++ b/internal/cli/progress/driver_test.go
@@ -93,6 +93,239 @@ func TestCountingWriterComposesWithIOCopy(t *testing.T) {
 	}
 }
 
+// rawjsonLine builds one BUILDKIT_PROGRESS=rawjson status line describing a
+// single vertex, optionally with a completion timestamp, mirroring the shape
+// buildx emits (one JSON object per line on stderr).
+func rawjsonLine(digest string, completed bool) string {
+	if completed {
+		return `{"vertexes":[{"digest":"` + digest + `","name":"stage","completed":"2026-07-08T00:00:00Z"}]}` + "\n"
+	}
+	return `{"vertexes":[{"digest":"` + digest + `","name":"stage"}]}` + "\n"
+}
+
+// TestBuildkitProgressWriterDrivesDeterminatePercentage proves a rawjson stream
+// whose vertexes all complete drives the Indicator to 100%.
+func TestBuildkitProgressWriterDrivesDeterminatePercentage(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	// Reveal three vertexes, then complete all three. The final Update must be
+	// 3/3 = 100%.
+	for _, d := range []string{"sha256:v1", "sha256:v2", "sha256:v3"} {
+		if _, err := w.Write([]byte(rawjsonLine(d, false))); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for _, d := range []string{"sha256:v1", "sha256:v2", "sha256:v3"} {
+		if _, err := w.Write([]byte(rawjsonLine(d, true))); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected 100%% after all vertexes complete, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterIgnoresNonJSONLines proves interleaved human log
+// lines from the devcontainer CLI do not corrupt the vertex count: the parsed
+// rawjson still settles at 100%.
+func TestBuildkitProgressWriterIgnoresNonJSONLines(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	stream := "" +
+		"[+] Building devcontainer...\n" +
+		rawjsonLine("sha256:v1", false) +
+		"resolving provenance for metadata file\n" +
+		rawjsonLine("sha256:v1", true) +
+		"not-json {oops\n"
+	if _, err := w.Write([]byte(stream)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected 100%% with one vertex completed despite noise, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterReassemblesSplitLines proves a rawjson object split
+// across multiple Write calls (partial-line reassembly) still parses.
+func TestBuildkitProgressWriterReassemblesSplitLines(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	line := rawjsonLine("sha256:v1", true)
+	// Write the line one byte at a time; nothing renders until the trailing
+	// newline arrives, then it settles at 1/1 = 100%.
+	for i := 0; i < len(line); i++ {
+		if _, err := w.Write([]byte{line[i]}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("expected split-line reassembly to reach 100%%, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterAllNoiseEmitsNothingDeterminate proves an all-noise
+// stream (no parseable vertexes) emits no determinate output but consumes every
+// byte with no error (poke-only liveness), leaving the buffer at just Start's
+// label line.
+func TestBuildkitProgressWriterAllNoiseEmitsNothingDeterminate(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	before := display.String()
+	w := NewBuildkitProgressWriter(ind)
+
+	payload := []byte("plain docker build output line 1\nno buildkit rawjson here\n")
+	n, err := w.Write(payload)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("expected all %d bytes consumed, got %d", len(payload), n)
+	}
+	if got := display.String(); got != before {
+		t.Errorf("all-noise stream must emit no determinate output; buffer changed from %q to %q", before, got)
+	}
+	if strings.Contains(display.String(), "%") {
+		t.Errorf("all-noise stream must not render a percentage, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterNilIndicator proves the writer is safe with no
+// backing indicator: it swallows bytes (including a full rawjson line) and
+// reports them consumed with no panic.
+func TestBuildkitProgressWriterNilIndicator(t *testing.T) {
+	w := NewBuildkitProgressWriter(nil)
+	payload := []byte(rawjsonLine("sha256:v1", true) + "noise\n")
+	n, err := w.Write(payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("nil-indicator write = %d, %v", n, err)
+	}
+}
+
+// TestBuildkitProgressWriterComposesInMultiWriterUnchanged proves the writer
+// does not alter the bytes a co-writer in an io.MultiWriter receives, so a
+// stderr capture buffer teed alongside it (the freeze daemon-unreachable
+// detection) sees the stream verbatim. Mirrors
+// TestLivenessWriterComposesInMultiWriterUnchanged.
+func TestBuildkitProgressWriterComposesInMultiWriterUnchanged(t *testing.T) {
+	var display, capture bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+
+	tee := io.MultiWriter(NewBuildkitProgressWriter(ind), &capture)
+	payload := []byte(rawjsonLine("sha256:v1", true) + "cannot connect to the docker daemon\n")
+	if _, err := tee.Write(payload); err != nil {
+		t.Fatalf("tee write: %v", err)
+	}
+	if capture.String() != string(payload) {
+		t.Errorf("capture buffer must receive the stream verbatim, got %q", capture.String())
+	}
+}
+
+// TestBuildkitProgressWriterQuietEmitsNothing proves a quiet indicator's build
+// progress writer consumes a full rawjson stream without error and writes
+// nothing.
+func TestBuildkitProgressWriterQuietEmitsNothing(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false), WithQuiet(true))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	payload := []byte(rawjsonLine("sha256:v1", false) + rawjsonLine("sha256:v1", true))
+	n, err := w.Write(payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("quiet build progress write = %d, %v", n, err)
+	}
+	if display.Len() != 0 {
+		t.Errorf("quiet indicator must emit nothing, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterEmptyDigestVertexIgnored proves a vertex with no
+// digest does not count toward the total: a stream of one empty-digest vertex
+// then one real completed vertex settles at 1/1 = 100%, not 1/2.
+func TestBuildkitProgressWriterEmptyDigestVertexIgnored(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	// A rawjson line whose vertex carries an empty digest reveals no countable
+	// stage; it must be skipped rather than inflating the known-vertex total.
+	if _, err := w.Write([]byte(`{"vertexes":[{"digest":"","name":"noise"}]}` + "\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := w.Write([]byte(rawjsonLine("sha256:v1", true))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("empty-digest vertex must not inflate the total; want 100%%, got %q", display.String())
+	}
+}
+
+// TestBuildkitProgressWriterDuplicateLinesDoNotDoubleCount proves a vertex
+// re-emitted as completed on later lines is counted once: after two vertexes
+// complete (each restated multiple times), the fraction is exactly 2/2 = 100%,
+// never overshooting.
+func TestBuildkitProgressWriterDuplicateLinesDoNotDoubleCount(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	stream := "" +
+		rawjsonLine("sha256:v1", false) +
+		rawjsonLine("sha256:v2", false) +
+		rawjsonLine("sha256:v1", true) +
+		// Restate v1 as completed again (buildkit re-emits touched vertexes): this
+		// re-stated line carries no new info and must not double-count or redraw a
+		// determinate step; it only pokes liveness.
+		rawjsonLine("sha256:v1", true) +
+		rawjsonLine("sha256:v2", true)
+	if _, err := w.Write([]byte(stream)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out := display.String()
+	if !strings.Contains(out, "100%") {
+		t.Errorf("want the two-vertex build to settle at 100%%, got %q", out)
+	}
+	// The non-TTY path emits one line per changed percentage; a double-count would
+	// have driven the fraction past 2/2 and cannot, so 100% is the terminal line.
+	if strings.Contains(out, "150%") || strings.Contains(out, "200%") {
+		t.Errorf("duplicate completion lines must not overshoot 100%%, got %q", out)
+	}
+}
+
+// TestBuildkitProgressWriterBlankLinesIgnored proves blank/whitespace-only lines
+// in the stream are consumed with no error and no effect on the count.
+func TestBuildkitProgressWriterBlankLinesIgnored(t *testing.T) {
+	var display bytes.Buffer
+	ind := New(&display, WithForceTTY(false))
+	ind.Start("building")
+	w := NewBuildkitProgressWriter(ind)
+
+	stream := "\n   \n" + rawjsonLine("sha256:v1", true) + "\n"
+	n, err := w.Write([]byte(stream))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(stream) {
+		t.Errorf("expected all %d bytes consumed, got %d", len(stream), n)
+	}
+	if !strings.Contains(display.String(), "100%") {
+		t.Errorf("blank lines must not disturb the count; want 100%%, got %q", display.String())
+	}
+}
+
 func TestLivenessWriterConsumesAllBytesNoError(t *testing.T) {
 	var display bytes.Buffer
 	ind := New(&display, WithForceTTY(false))

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -354,6 +354,19 @@ type BuildOptions struct {
 	// The freeze producer sets it to the dedicated `aileron-freeze`
 	// docker-container builder (issue #2054). Ignored when Platforms is empty.
 	BuildxBuilder string
+	// ProgressRawJSON requests structured buildkit progress from the build
+	// subprocess by exporting BUILDKIT_PROGRESS=rawjson in its environment. buildx
+	// (whether invoked directly or under @devcontainers/cli, which inherits the
+	// environment and forwards it to its child buildx) then emits one JSON status
+	// object per line on stderr, which a progress parser turns into a determinate
+	// percentage. It is honored for BOTH the multi-arch build and the single-arch
+	// daemon-load build, independent of the Platforms/BuildxBuilder gating, so both
+	// build steps get determinate progress. The freeze producer sets it; every
+	// other caller leaves it false, keeping their build subprocess env byte-for-byte
+	// identical to before (issue #2084). Requesting rawjson is best-effort: an older
+	// buildx or a non-buildkit daemon that does not honor it simply emits its usual
+	// output and the parser degrades to indeterminate liveness.
+	ProgressRawJSON bool
 }
 
 // BuildResult reports the image selected or built for launch.
@@ -462,9 +475,11 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		stderr = io.Discard
 	}
 	// Per-invocation environment for the build subprocess. It carries a scoped
-	// BUILDX_BUILDER selection for a multi-arch build (issue #2054) and is nil for
-	// a single-arch build, keeping that argv+env byte-identical to before.
-	buildEnv := multiArchBuildEnv(opts)
+	// BUILDX_BUILDER selection for a multi-arch build (issue #2054) and, when
+	// ProgressRawJSON is set, BUILDKIT_PROGRESS=rawjson for determinate progress
+	// (issue #2084). It is nil for a single-arch build with neither requested,
+	// keeping that argv+env byte-identical to before.
+	buildEnv := buildStepEnv(opts)
 
 	// A multi-arch build and its OCI-layout output are one atomic request: the
 	// `--output type=oci,dest=<dir>` token is only emitted when both are set, so a
@@ -1279,21 +1294,33 @@ func multiArchLayoutDir(opts BuildOptions) string {
 	return opts.OCILayoutDest
 }
 
-// multiArchBuildEnv returns the extra environment entries a multi-arch build
-// subprocess needs to select a scoped buildx builder, or nil for a single-arch
-// build. When BuildxBuilder is set on a multi-arch build (Platforms non-empty) it
-// exports BUILDX_BUILDER=<name> so buildx — whether invoked as `docker buildx
-// build` (raw tiers) or under `@devcontainers/cli` (which inherits the
-// environment and shells out to buildx) — runs on that dedicated builder without
-// `docker buildx use` repointing the operator's default. It is gated on Platforms
-// so the single-arch daemon-load build never inherits the selection: that build
-// must stay on the default `docker` driver to land the image in the local daemon,
-// which a docker-container builder cannot do (issue #2054).
-func multiArchBuildEnv(opts BuildOptions) []string {
-	if len(opts.Platforms) == 0 || strings.TrimSpace(opts.BuildxBuilder) == "" {
-		return nil
+// buildStepEnv returns the extra environment entries a build subprocess needs
+// for this invocation, or nil when none apply (keeping that build's argv+env
+// byte-identical to before). Two independent entries are appended in a fixed
+// order so the result is deterministic for tests:
+//
+//   - BUILDX_BUILDER=<name>, ONLY for a multi-arch build (Platforms non-empty)
+//     with BuildxBuilder set, so buildx — whether invoked as `docker buildx
+//     build` (raw tiers) or under `@devcontainers/cli` (which inherits the
+//     environment and shells out to buildx) — runs on that dedicated builder
+//     without `docker buildx use` repointing the operator's default. It is gated
+//     on Platforms so the single-arch daemon-load build never inherits the
+//     selection: that build must stay on the default `docker` driver to land the
+//     image in the local daemon, which a docker-container builder cannot do
+//     (issue #2054).
+//   - BUILDKIT_PROGRESS=rawjson, whenever ProgressRawJSON is set, for BOTH the
+//     multi-arch and the single-arch daemon-load build, so both steps emit
+//     structured buildkit progress a parser turns into a determinate percentage
+//     (issue #2084). It is independent of the Platforms/BuildxBuilder gating.
+func buildStepEnv(opts BuildOptions) []string {
+	var env []string
+	if len(opts.Platforms) > 0 && strings.TrimSpace(opts.BuildxBuilder) != "" {
+		env = append(env, "BUILDX_BUILDER="+opts.BuildxBuilder)
 	}
-	return []string{"BUILDX_BUILDER=" + opts.BuildxBuilder}
+	if opts.ProgressRawJSON {
+		env = append(env, "BUILDKIT_PROGRESS=rawjson")
+	}
+	return env
 }
 
 // FreezeBuilderName is the name of the dedicated buildx builder `aileron skill

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -297,6 +297,125 @@ func TestBuildSingleArchIgnoresBuildxBuilder(t *testing.T) {
 	}
 }
 
+// hasEnv reports whether env contains want.
+func hasEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildProgressRawJSONMultiArchExportsBoth proves a multi-arch build with
+// ProgressRawJSON set carries BOTH the scoped BUILDX_BUILDER selection and
+// BUILDKIT_PROGRESS=rawjson in the build subprocess env (issue #2084).
+func TestBuildProgressRawJSONMultiArchExportsBoth(t *testing.T) {
+	dir := t.TempDir()
+	writeFeaturesDevcontainer(t, dir)
+	dest := filepath.Join(t.TempDir(), "layout")
+	runner := &envRecordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir:         dir,
+		ToolchainMode:   ToolchainModeHostNPX,
+		Platforms:       composition.MultiArchPlatforms,
+		OCILayoutDest:   dest,
+		BuildxBuilder:   FreezeBuilderName,
+		ProgressRawJSON: true,
+		Plan: composition.Plan{
+			Tier:     composition.TierDevcontainer,
+			Features: map[string]json.RawMessage{"./tool": json.RawMessage("{}")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasEnv(runner.env, "BUILDX_BUILDER="+FreezeBuilderName) {
+		t.Errorf("multi-arch build env = %#v, want BUILDX_BUILDER=%s", runner.env, FreezeBuilderName)
+	}
+	if !hasEnv(runner.env, "BUILDKIT_PROGRESS=rawjson") {
+		t.Errorf("multi-arch build env = %#v, want BUILDKIT_PROGRESS=rawjson", runner.env)
+	}
+}
+
+// TestBuildProgressRawJSONSingleArchExportsProgressOnly proves a single-arch
+// daemon-load build (Platforms nil) with ProgressRawJSON set carries
+// BUILDKIT_PROGRESS=rawjson and NO BUILDX_BUILDER, so it stays on the default
+// `docker` driver and still gets determinate progress (issue #2084).
+func TestBuildProgressRawJSONSingleArchExportsProgressOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFeaturesDevcontainer(t, dir)
+	runner := &envRecordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir:         dir,
+		ToolchainMode:   ToolchainModeHostNPX,
+		BuildxBuilder:   FreezeBuilderName, // set but no Platforms -> must be ignored
+		ProgressRawJSON: true,
+		Plan: composition.Plan{
+			Tier:     composition.TierDevcontainer,
+			Features: map[string]json.RawMessage{"./tool": json.RawMessage("{}")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasEnv(runner.env, "BUILDKIT_PROGRESS=rawjson") {
+		t.Errorf("single-arch build env = %#v, want BUILDKIT_PROGRESS=rawjson", runner.env)
+	}
+	if hasEnv(runner.env, "BUILDX_BUILDER="+FreezeBuilderName) {
+		t.Errorf("single-arch build env = %#v, must NOT carry BUILDX_BUILDER (default driver must load into the daemon)", runner.env)
+	}
+}
+
+// TestBuildProgressRawJSONFalseLeavesEnvUnchanged proves that with
+// ProgressRawJSON false the env is byte-identical to before this change: nil for
+// a single-arch build, and BUILDX_BUILDER-only for a multi-arch build.
+func TestBuildProgressRawJSONFalseLeavesEnvUnchanged(t *testing.T) {
+	t.Run("single-arch has nil env", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFeaturesDevcontainer(t, dir)
+		runner := &envRecordingRunner{}
+		_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+			WorkDir:       dir,
+			ToolchainMode: ToolchainModeHostNPX,
+			Plan: composition.Plan{
+				Tier:     composition.TierDevcontainer,
+				Features: map[string]json.RawMessage{"./tool": json.RawMessage("{}")},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		if len(runner.env) != 0 {
+			t.Errorf("single-arch build env = %#v, want empty with ProgressRawJSON=false", runner.env)
+		}
+	})
+
+	t.Run("multi-arch has BUILDX_BUILDER only", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFeaturesDevcontainer(t, dir)
+		dest := filepath.Join(t.TempDir(), "layout")
+		runner := &envRecordingRunner{}
+		_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+			WorkDir:       dir,
+			ToolchainMode: ToolchainModeHostNPX,
+			Platforms:     composition.MultiArchPlatforms,
+			OCILayoutDest: dest,
+			BuildxBuilder: FreezeBuilderName,
+			Plan: composition.Plan{
+				Tier:     composition.TierDevcontainer,
+				Features: map[string]json.RawMessage{"./tool": json.RawMessage("{}")},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		if len(runner.env) != 1 || runner.env[0] != "BUILDX_BUILDER="+FreezeBuilderName {
+			t.Errorf("multi-arch build env = %#v, want exactly [BUILDX_BUILDER=%s]", runner.env, FreezeBuilderName)
+		}
+	})
+}
+
 // TestBuild_MultiArchPairingValidated proves Build fails fast on a half-configured
 // multi-arch request rather than emitting a broken `--output type=oci,dest=` token.
 func TestBuild_MultiArchPairingValidated(t *testing.T) {


### PR DESCRIPTION
## Summary

`aileron skill freeze` showed an indeterminate liveness spinner for its two build steps (`Building environment image` multi-arch OCI build, and `Loading image into local daemon` single-arch daemon-load build). This wires structured buildkit progress so those two steps advance a **determinate percentage** where buildkit exposes per-stage/vertex totals, and **degrades cleanly** to today's indeterminate liveness where a total is unavailable (older buildx, non-buildkit daemon, plain `docker build`) — and to plain non-TTY lines / `--quiet` suppression exactly as before. It mirrors the determinate treatment the publish push already gets (#2078/#2086), reusing the same `progress.Indicator.Update(current, total)` API.

### How it works

- **Determinate signal = fraction of build vertexes completed.** `NewBuildkitProgressWriter` line-buffers the build subprocess stream, parses each line as a minimal `rawjson` `solveStatus` (only the fields we need — no dependency on buildkit's Go module), and drives `Update(completedVertexes, knownVertexes)`. The known-vertex total grows monotonically as the stream reveals stages; `Indicator.Update` renders a moving total fine.
- **Never regresses.** A non-parseable line, or a line that reveals no new determinate info, falls back to `poke()` liveness so the step still animates. The bar supersedes the spinner the first time `Update` fires with a non-zero total. When `BUILDKIT_PROGRESS=rawjson` is unhonored the indeterminate path stays intact.
- **Env-only request.** The freeze build path uses the devcontainer-CLI Features path, which does not accept a `--progress` flag. buildx (the CLI's child process) selects its renderer from the inherited `BUILDKIT_PROGRESS` env, so the request is threaded via a new `BuildOptions.ProgressRawJSON bool` → `buildStepEnv` (generalized from `multiArchBuildEnv`) appending `BUILDKIT_PROGRESS=rawjson` for both build steps. Every other Builder caller leaves it false, so their argv+env stay byte-identical.
- **Tee intact.** The new writer stays the OUTER arg of `runBuildStep`'s `io.MultiWriter(stderr, &buf)` and forwards nothing, so the daemon-unreachable capture buffer still sees every byte.

### Files changed

- `internal/cli/progress/driver.go` — new `buildkitProgressWriter` + `NewBuildkitProgressWriter`.
- `internal/sandbox/container/runtime.go` — `BuildOptions.ProgressRawJSON`; `multiArchBuildEnv` → `buildStepEnv`.
- `cmd/aileron/skill_freeze.go` — set `ProgressRawJSON: true` on both build opts; install the new writer as the build sinks.

## Test plan

- `go test -race ./cmd/aileron/...` — clean (acceptance criterion).
- `go test ./internal/cli/progress/...` — new writer tests: determinate stream reaches 100%, interleaved non-JSON ignored, split-line reassembly, all-noise poke-only, nil indicator, MultiWriter byte-identical tee, quiet suppression, empty-digest/duplicate-line/blank-line edges. Package coverage 98.3%; `processLine` 100%.
- `go test ./internal/sandbox/container/...` — env tests: multi-arch exports both `BUILDX_BUILDER` + `BUILDKIT_PROGRESS=rawjson`; single-arch exports rawjson only (no `BUILDX_BUILDER`); `ProgressRawJSON=false` leaves env byte-identical (nil single-arch, `BUILDX_BUILDER`-only multi-arch).
- Freeze integration tests: new `TestRunSkillFreeze_DeterminateBuildProgress` (fake runner emits a rawjson vertex stream on stderr → 100% rendered, both builds carry the rawjson env); existing degrade / `--quiet` / daemon-unreachable-tee tests pass unchanged (the daemon-load fake runner was updated to override `RunWithEnv`, since that build now carries env and routes through the envRunner path).
- `coderabbit review --agent`: 0 findings. `gofmt`/`go vet` clean.

Closes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1DcnDZFwjCxxB4dQuR5p
