### PR TITLE
fix(flightplan): gate llm-seam plans to agent surfaces, fail closed elsewhere

### DIFF
--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -254,6 +254,53 @@ func stripEnvironmentBlock(t *testing.T, md string) string {
 	return res
 }
 
+// stripSeamStepRewireBinding removes the worked example's `summarize` llm-seam
+// step and rewires the `file_issue` action-call's `body` binding off the
+// deleted seam output onto the surviving deterministic `render_csv.csv` output,
+// producing a fully deterministic no-seam variant. A naive seam-step delete
+// leaves a dangling `steps.summarize.issue_body` binding that freeze rejects, so
+// the rewire is required. It fails the test if either surgery does not apply.
+func stripSeamStepRewireBinding(t *testing.T, md string) string {
+	t.Helper()
+	lines := strings.Split(md, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	dropped := false
+	for _, ln := range lines {
+		if !skipping {
+			// The `summarize` step is a list item at 4-space indent
+			// (`    - id: summarize`). Drop from it until the next list item at the
+			// same-or-shallower indent.
+			if strings.TrimSpace(ln) == "- id: summarize" {
+				skipping = true
+				dropped = true
+				continue
+			}
+			out = append(out, ln)
+			continue
+		}
+		trimmed := strings.TrimLeft(ln, " ")
+		indent := len(ln) - len(trimmed)
+		if trimmed == "" || indent > 4 {
+			continue
+		}
+		skipping = false
+		out = append(out, ln)
+	}
+	if !dropped {
+		t.Fatal("stripSeamStepRewireBinding: did not find the summarize seam step")
+	}
+	res := strings.Join(out, "\n")
+	if strings.Contains(res, "kind: llm-seam") {
+		t.Fatal("stripSeamStepRewireBinding left an llm-seam step in place")
+	}
+	const dangling = "body: steps.summarize.issue_body"
+	if !strings.Contains(res, dangling) {
+		t.Fatalf("stripSeamStepRewireBinding: expected file_issue to bind %q", dangling)
+	}
+	return strings.Replace(res, dangling, "body: steps.render_csv.csv", 1)
+}
+
 // TestRunSkillLaunch_BootsPinnedEnvironmentImage proves the acceptance
 // property: the worked example declares environment tools, so its verified
 // lock pins a composed image carrying a bootable local-daemon tag (#1856).

--- a/cmd/aileron/skill_launch_walk_e2e_test.go
+++ b/cmd/aileron/skill_launch_walk_e2e_test.go
@@ -198,6 +198,13 @@ func freezeRequiredInputForLaunch(t *testing.T, storeDir string) {
 		t.Fatal(err)
 	}
 	stripped := stripEnvironmentBlock(t, string(raw))
+	// Remove the llm-seam step so this fixture isolates the input-resolution
+	// fail-fast path. The worked example carries a `summarize` llm-seam step, and
+	// the runtime's surface gate (#2102) fails a seam plan closed on a non-agent
+	// surface BEFORE input resolution runs. This test drives the required-input
+	// path, not the seam gate, so it removes the seam (and rewires the dangling
+	// binding) to keep the plan deterministic.
+	stripped = stripSeamStepRewireBinding(t, stripped)
 	// Remove the window_days default so it becomes a required-no-default literal.
 	required := strings.Replace(stripped, "\n        default: 7", "", 1)
 	if required == stripped {

--- a/docs/src/content/docs/development/launch-surfaces-spec.md
+++ b/docs/src/content/docs/development/launch-surfaces-spec.md
@@ -42,6 +42,8 @@ Three per-surface dimensions specialize this contract.
 
 Approval routing reuses the effect-driven gate. The trust contract declares an `effect` for each action, one of `read`, `write`, `delete`, `spend`, or `external-send` ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) trust contract). A `read` Launch runs unattended. A `write`, `delete`, `spend`, or `external-send` Launch raises an out-of-band approval gate and blocks on the decision ([ADR-0009](/adr/0009-user-channel)). The approval-time preview is fetched at decision time ([ADR-0016](/adr/0016-approval-preview/)). A surface routes the approval to the approver through its channel and surfaces the recorded decision in result delivery. A surface never confirms an effect inline in place of the out-of-band gate.
 
+A Flight Plan that carries a marked llm-seam step needs a surface that can fulfill that seam. An interactive agent context wires a seam provider directly. The daemon launch door suspends an unfulfilled seam so an agent fulfills it out of band and resumes the run. A surface that can do neither, such as a plain `aileron skill launch` with no agent-backed provider, fails the launch closed before any step runs. A deterministic Flight Plan with no llm-seam step runs unchanged on every surface.
+
 ## Internal surfaces
 
 The internal surfaces expose a Flight Plan to people inside the org. The four internal surfaces are the button in the org's own portal, the form, the Slack command, and integrations into the org's own tools.

--- a/internal/app/handlers_flightplans.go
+++ b/internal/app/handlers_flightplans.go
@@ -418,6 +418,15 @@ func (s *apiServer) runOrResume(w http.ResponseWriter, r *http.Request, rec flig
 		// environment image or declares tool steps errors via the runtime's own
 		// nil-guards. The LLM seam is nil so an unfulfilled seam SUSPENDS
 		// (SuspendKindSeam) rather than erroring — the agent is the provider.
+		//
+		// The runtime's llm-seam surface gate (#2102) is INERT for this caller:
+		// it fires only when the seam is unwired AND the run is not suspendable,
+		// and this endpoint sets Suspendable above. So a seam plan here suspends
+		// for the agent to fulfill via resume; it does not fail closed. That gate
+		// governs the plain non-agent surface (a bare `aileron skill launch` with
+		// no agent-backed provider), where a seam plan fails closed at the Run
+		// precondition and surfaces through writeFlightPlanLaunchError as a
+		// runtime-boundary FailureEnvelope.
 	})
 	if err != nil {
 		// A denied approval (or any other runtime error) on this call is terminal:

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -96,6 +96,99 @@ func frozenNoImage(t *testing.T) store.FrozenVersion {
 	}
 }
 
+// frozenNoSeam freezes a no-environment, no-seam variant of the worked example:
+// the `environment` block is stripped (so freeze pins no image and the run
+// stays in-process) AND the `summarize` llm-seam step is removed, with
+// `file_issue`'s dangling `body: steps.summarize.issue_body` binding rewired
+// onto the surviving deterministic `render_csv.csv` output so the frozen plan
+// still decodes (a naive seam-step delete would leave a dangling binding
+// freeze/decode rejects). The result is a fully deterministic plan that runs on
+// every surface, including a non-agent one, which is what the surface gate
+// (#2102) must leave untouched.
+func frozenNoSeam(t *testing.T) store.FrozenVersion {
+	t.Helper()
+	keyPath := writeSigningKey(t)
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	stripped := stripEnvironment(t, string(raw))
+	deSeamed := stripSeamRewireBinding(t, stripped)
+
+	res, err := freeze.Run(context.Background(), []byte(deSeamed), freeze.Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run no-seam variant: %v", err)
+	}
+	return store.FrozenVersion{
+		ID:        "test",
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}
+}
+
+// stripSeamRewireBinding removes the worked example's `summarize` llm-seam step
+// and rewires the `file_issue` action-call's `body` binding off the deleted
+// seam output onto the surviving `render_csv.csv` output. It drops the seam
+// step by the same 4-space list-item indent boundary stripEnvironment uses for
+// its block, then does a targeted string replacement on the one dangling
+// binding. It fails the test if either surgery does not apply, so a change to
+// the worked example that breaks this assumption is caught rather than silently
+// producing a seam-carrying fixture.
+func stripSeamRewireBinding(t *testing.T, md string) string {
+	t.Helper()
+	lines := strings.Split(md, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	dropped := false
+	for _, ln := range lines {
+		if !skipping {
+			// The `summarize` step header is a list item at 4-space indent
+			// (`    - id: summarize`). Drop from it until the next line at the
+			// same-or-shallower list-item indent.
+			if strings.TrimSpace(ln) == "- id: summarize" {
+				skipping = true
+				dropped = true
+				continue
+			}
+			out = append(out, ln)
+			continue
+		}
+		trimmed := strings.TrimLeft(ln, " ")
+		indent := len(ln) - len(trimmed)
+		// A blank line or a line indented deeper than the list item (4 spaces)
+		// is a child of the seam step; the next list item at 4-space indent ends
+		// it.
+		if trimmed == "" || indent > 4 {
+			continue
+		}
+		skipping = false
+		out = append(out, ln)
+	}
+	if !dropped {
+		t.Fatalf("stripSeamRewireBinding: did not find the summarize seam step to drop")
+	}
+	res := strings.Join(out, "\n")
+	// Guard on the step declaration specifically. The manifest's prose body
+	// mentions "(llm-seam)" in describing the step, so a bare "llm-seam"
+	// substring check would false-positive on the surviving narrative.
+	if strings.Contains(res, "kind: llm-seam") {
+		t.Fatalf("stripSeamRewireBinding left an llm-seam step in place")
+	}
+	// Rewire the one dangling binding onto a surviving deterministic output.
+	const dangling = "body: steps.summarize.issue_body"
+	if !strings.Contains(res, dangling) {
+		t.Fatalf("stripSeamRewireBinding: expected file_issue to bind %q", dangling)
+	}
+	res = strings.Replace(res, dangling, "body: steps.render_csv.csv", 1)
+	return res
+}
+
 // stripEnvironment removes the `environment:` mapping (and its indented
 // children) from the worked-example frontmatter, leaving a valid
 // no-environment manifest. It drops the block by 2-space indent boundary:

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -270,10 +270,13 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	//     the gate is inert there — including the in-container image-boot
 	//     re-entry, where the agent passes a real Seam and in-process IS the
 	//     certified environment).
-	//   - !opts.Suspendable: this surface cannot suspend/resume. The daemon HTTP
+	//   - not suspendable: this surface cannot suspend/resume. The daemon HTTP
 	//     handler sets Suspendable, so a seam plan there SUSPENDS (SuspendKindSeam)
 	//     for the agent, and the gate stays inert — that surface fulfills the seam
-	//     out of band, it does not fail closed.
+	//     out of band, it does not fail closed. "Suspendable" mirrors runPlan's own
+	//     definition (opts.Suspendable OR a non-nil resume memo), so a resume can
+	//     never be preempted by this gate even if a caller supplies ResumeOutputs
+	//     without the explicit Suspendable flag.
 	//
 	// Placement is deliberate: this guards only the in-process runPlan branch,
 	// AFTER the image-boot branch. An image-pinning plan (the committed worked
@@ -282,7 +285,8 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	// unaffected. The daemon caller is internal/app/handlers_flightplans.go; it
 	// is a governed runtime.Run caller, but because it runs Suspendable the gate
 	// is inert for it and a seam plan suspends rather than failing closed.
-	if planHasSeamSteps(lp.Plan) && opts.Seam == nil && !opts.Suspendable {
+	suspendable := opts.Suspendable || opts.ResumeOutputs != nil
+	if planHasSeamSteps(lp.Plan) && opts.Seam == nil && !suspendable {
 		return RunResult{}, fmt.Errorf(
 			"flightplan: plan %q contains an llm-seam step; it can only be launched from an interactive agent context (aileron launch), not this surface",
 			lp.Plan.Name)

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -253,6 +253,40 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 	if hasWholePlanImage(lp.ResolvedImages) && !opts.InPinnedImage {
 		return runInImage(ctx, lp, opts)
 	}
+	// LLM-seam surface gate (#2102). A plan carrying a marked llm-seam step can
+	// only run on a surface that can fulfill the seam: an interactive agent
+	// context (`aileron launch`) wires a non-nil Seam, and the daemon HTTP door
+	// runs suspendable so an unfulfilled seam SUSPENDS for the agent to fulfill
+	// via resume. Every other surface (a plain `aileron skill launch` with no
+	// agent-backed provider) can neither wire a provider nor suspend, so a seam
+	// plan there would reach the mid-run runSeam nil-guard only after earlier
+	// deterministic steps already ran. This precondition fails such a launch
+	// CLOSED before any step runs, with a message that names the fulfilling
+	// surface.
+	//
+	// The gate keys on three conditions together:
+	//   - planHasSeamSteps(lp.Plan): the plan actually carries a seam.
+	//   - opts.Seam == nil: no provider is wired (an agent launch wires one, so
+	//     the gate is inert there — including the in-container image-boot
+	//     re-entry, where the agent passes a real Seam and in-process IS the
+	//     certified environment).
+	//   - !opts.Suspendable: this surface cannot suspend/resume. The daemon HTTP
+	//     handler sets Suspendable, so a seam plan there SUSPENDS (SuspendKindSeam)
+	//     for the agent, and the gate stays inert — that surface fulfills the seam
+	//     out of band, it does not fail closed.
+	//
+	// Placement is deliberate: this guards only the in-process runPlan branch,
+	// AFTER the image-boot branch. An image-pinning plan (the committed worked
+	// example pins an environment AND carries a seam) still boots (or hits the
+	// image nil-guard) exactly as before, so the existing image tests are
+	// unaffected. The daemon caller is internal/app/handlers_flightplans.go; it
+	// is a governed runtime.Run caller, but because it runs Suspendable the gate
+	// is inert for it and a seam plan suspends rather than failing closed.
+	if planHasSeamSteps(lp.Plan) && opts.Seam == nil && !opts.Suspendable {
+		return RunResult{}, fmt.Errorf(
+			"flightplan: plan %q contains an llm-seam step; it can only be launched from an interactive agent context (aileron launch), not this surface",
+			lp.Plan.Name)
+	}
 	return runPlan(ctx, lp.Plan, lp.ContentHash, lp.SignerFingerprint, lp.StepTrust, opts)
 }
 
@@ -260,6 +294,18 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 func planHasToolSteps(plan *Plan) bool {
 	for _, s := range plan.Steps {
 		if s.Kind == KindTool {
+			return true
+		}
+	}
+	return false
+}
+
+// planHasSeamSteps reports whether the plan carries any `kind: llm-seam` step.
+// It mirrors planHasToolSteps and is the marker the surface gate (#2102) keys
+// on: the presence of a seam step is what makes a launch surface-sensitive.
+func planHasSeamSteps(plan *Plan) bool {
+	for _, s := range plan.Steps {
+		if s.Kind == KindLLMSeam {
 			return true
 		}
 	}

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -82,6 +82,169 @@ func TestRun_StructuralNoLLMGuarantee(t *testing.T) {
 	}
 }
 
+// TestRun_SeamPlanOnNonAgentSurfaceFailsClosed proves the surface gate (#2102):
+// a store-backed plan carrying an llm-seam step, launched through Run on a
+// non-agent surface (no wired Seam, not suspendable), fails CLOSED before any
+// step runs with the exact agent-context message. A dispatcher is wired so that
+// any accidental step execution would be observable; the gate must fire first,
+// so the dispatcher is never called.
+func TestRun_SeamPlanOnNonAgentSurfaceFailsClosed(t *testing.T) {
+	fv := frozenNoImage(t) // no-environment variant that keeps the summarize seam step
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-exec-env", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	fake := &fakeImageRunner{}
+	res, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "no-exec-env",
+		Version:     "test",
+		ImageRunner: fake,
+		Dispatcher:  disp,
+		Approver:    &fakeApprover{decision: Decision{Approved: true}},
+		// Seam intentionally nil and Suspendable unset: the non-agent surface.
+		Clock:  FixedClock{},
+		OutDir: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("a seam plan on a non-agent surface must fail closed")
+	}
+	const want = "contains an llm-seam step; it can only be launched from an interactive agent context (aileron launch), not this surface"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), want)
+	}
+	// The gate is a static precondition: no step ran, so nothing dispatched and
+	// no result was produced.
+	if len(disp.calls) != 0 {
+		t.Errorf("the gate must fire before any step runs; the dispatcher was invoked %d time(s)", len(disp.calls))
+	}
+	if fake.called {
+		t.Error("a no-environment plan must not touch the ImageRunner")
+	}
+	if res.ContentHash != "" || len(res.Artifacts) != 0 {
+		t.Errorf("a fail-closed run must produce no result: %+v", res)
+	}
+}
+
+// TestRun_NoSeamPlanRunsOnNonAgentSurface proves the gate keys on seam presence,
+// not on the absence of a wired Seam alone: a deterministic (no-seam) plan runs
+// unchanged on the same non-agent surface (no Seam, not suspendable). This is
+// the load-bearing "deterministic plans keep running everywhere" guarantee.
+func TestRun_NoSeamPlanRunsOnNonAgentSurface(t *testing.T) {
+	fv := frozenNoSeam(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-seam", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	res, err := Run(context.Background(), Options{
+		Store:      s,
+		Name:       "no-seam",
+		Version:    "test",
+		Dispatcher: disp,
+		Approver:   &fakeApprover{decision: Decision{Approved: true}},
+		// Seam nil and Suspendable unset: the same non-agent surface. A
+		// deterministic plan must run here unchanged.
+		Clock:      FixedClock{},
+		Transforms: reg,
+		OutDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("a deterministic plan must run on a non-agent surface: %v", err)
+	}
+	if !strings.HasPrefix(res.ContentHash, "sha256:") {
+		t.Errorf("RunResult.ContentHash = %q, want the verified hash", res.ContentHash)
+	}
+}
+
+// TestRun_SeamPlanWithWiredSeamRunsOnAgentSurface proves the gate is inert on an
+// agent surface: the same seam plan, launched with a non-nil Seam (the CLI
+// `aileron launch` wiring), runs to completion. The gate keys on provider
+// absence, not merely on seam presence.
+func TestRun_SeamPlanWithWiredSeamRunsOnAgentSurface(t *testing.T) {
+	fv := frozenNoImage(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-exec-env", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	res, err := Run(context.Background(), Options{
+		Store:      s,
+		Name:       "no-exec-env",
+		Version:    "test",
+		Dispatcher: disp,
+		Approver:   &fakeApprover{decision: Decision{Approved: true}},
+		Seam:       fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:      FixedClock{},
+		Transforms: reg,
+		OutDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("a seam plan with a wired Seam must run on an agent surface: %v", err)
+	}
+	if !strings.HasPrefix(res.ContentHash, "sha256:") {
+		t.Errorf("RunResult.ContentHash = %q, want the verified hash", res.ContentHash)
+	}
+}
+
+// TestRun_SeamPlanSuspendableStaysInert proves the gate does not fire on the
+// daemon's suspendable surface: a seam plan with no wired Seam but Suspendable
+// set SUSPENDS (SuspendKindSeam) for the agent to fulfill via resume, rather
+// than failing closed. This is the third gate condition (`!opts.Suspendable`).
+func TestRun_SeamPlanSuspendableStaysInert(t *testing.T) {
+	fv := frozenNoImage(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("no-exec-env", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	res, err := Run(context.Background(), Options{
+		Store:       s,
+		Name:        "no-exec-env",
+		Version:     "test",
+		Dispatcher:  disp,
+		Approver:    &fakeApprover{decision: Decision{Approved: true}},
+		Suspendable: true, // the daemon surface: unfulfilled seam suspends, not fails
+		Clock:       FixedClock{},
+		Transforms:  reg,
+		OutDir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("a suspendable seam launch must not fail closed: %v", err)
+	}
+	if res.Pending == nil {
+		t.Fatal("a suspendable seam launch with no wired Seam must SUSPEND, not complete")
+	}
+	if res.Pending.Kind != SuspendKindSeam {
+		t.Errorf("suspend kind = %v, want SuspendKindSeam", res.Pending.Kind)
+	}
+}
+
 // TestRun_DeniedApprovalAbortsAndAudits proves a denied write mid-run aborts
 // the run and the audit reflects the denial.
 func TestRun_DeniedApprovalAbortsAndAudits(t *testing.T) {


### PR DESCRIPTION
## Summary

A Flight Plan carrying a marked `llm-seam` step can only run on a surface that can fulfill the seam:

- An interactive agent context (`aileron launch`) wires a non-nil `Seam` provider.
- The daemon HTTP door runs `Suspendable: true`, so an unfulfilled seam SUSPENDS (`SuspendKindSeam`) for the agent to fulfill via resume.

A plain `aileron skill launch` with no agent-backed provider can do neither. Today such a launch reaches the mid-run `runSeam` nil-guard in `seam.go` only *after* earlier deterministic steps already ran.

This PR adds a static surface precondition in `runtime.Run` that fails such a launch **closed before any step runs**, with a message naming the fulfilling surface:

```
flightplan: plan %q contains an llm-seam step; it can only be launched from an interactive agent context (aileron launch), not this surface
```

The gate keys on `planHasSeamSteps(plan) && opts.Seam == nil && !opts.Suspendable`:

- **Agent surface** (`aileron launch`): a non-nil `Seam` is wired, gate inert.
- **Daemon HTTP door**: `Suspendable` is set, so a seam plan suspends for the agent, gate inert. (This reconciles the original plan with the suspend/resume work merged in #2114/#2117: the daemon is no longer a fail-closed surface for seam plans, it is an agent-via-resume surface.)
- **In-container image-boot re-entry**: the agent passes a real `Seam`, gate inert.
- **Plain `skill launch`** (non-agent, non-suspendable): fails closed with the clear message before any step runs.

Placement is on the in-process branch **after** the image-boot branch, so an image-pinning plan (the worked example pins an environment AND carries a seam) still boots or hits the image nil-guard exactly as before. The `seam.go` mid-run `runSeam` nil-guard stays as the structural backstop for `runPlan`-direct callers.

## Scope reconciliation vs. the original plan

The plan predated #2114/#2117 (suspend/resume). Two of its units shifted:

- **Gate condition** gained `&& !opts.Suspendable` so the daemon's now-suspendable surface stays inert (suspends rather than fails closed).
- **Unit 3 daemon integration test** (`SeamPlanFailsClosed`) was dropped: with `Suspendable: true` the daemon suspends a seam plan (200 `seam_pending`), not 500 fail-closed. The existing resume tests (`TestLaunchFlightPlan_OneSeamSuspendsThenResumes`, etc.) already prove that path. The handler comment was refined instead to document the gate as inert for that caller.

## Test plan

- `internal/flightplan/runtime` (unit): four new `Run` tests —
  - seam plan on a non-agent surface fails closed with the exact string, and no step ran (dispatcher never invoked, no result);
  - a deterministic (no-seam) plan runs unchanged on the same non-agent surface (new `frozenNoSeam` store fixture);
  - a seam plan with a wired `Seam` runs (gate inert on agent surface);
  - a seam plan with `Suspendable: true` suspends (`SuspendKindSeam`), gate inert.
  - `planHasSeamSteps` 100% covered; package coverage 92.3%.
- `internal/app` (unit + `-tags integration`): green; `TestLaunchFlightPlan_*` unchanged; coverage 83.7%.
- `cmd/aileron`: full suite green. `TestRunSkillLaunch_AcceptDefaultsFailFastOnRequired` fixture updated to strip the seam step (with binding rewire) so it isolates the input-resolution fail-fast path the gate would otherwise preempt — correct product behavior.
- Docs: added a terse cross-surface note to `launch-surfaces-spec.md` (spec voice: no em-dashes, one thought per sentence).

Closes #2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1DcnDZFwjCxxB4dQuR5p
