### PR TITLE
feat(flightplan): emit flightplan.launch.seam audit record on seam suspend

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -671,6 +671,18 @@ func (s daemonAuditSink) Record(ctx context.Context, rec runtime.AuditRecord) st
 			// empty record posts an object payload rather than a JSON null.
 			payload = map[string]any{}
 		}
+	case runtime.RecordKindSeam:
+		// A seam record (#2119) carries the same flat `aileron.*` payload
+		// treatment as an output/reach/launch record: the seam step id, the
+		// recorded model hint, the seam's non-source bindings, and the plan
+		// provenance surface as top-level keys. It is constructed daemon-side (the
+		// runtime never emits this kind); this branch only keeps the CLI/daemon
+		// translation byte-equivalent for the shared record shape.
+		eventType = string(model.EventTypeFlightPlanLaunchSeam)
+		payload = rec.Fields
+		if payload == nil {
+			payload = map[string]any{}
+		}
 	case runtime.RecordKindLaunch:
 		// A launch record (#1928) carries the same flat `aileron.*` payload
 		// treatment as an output/reach record: the per-launch summary fields

--- a/internal/app/flightplan_runs.go
+++ b/internal/app/flightplan_runs.go
@@ -59,6 +59,14 @@ type flightPlanRunRecord struct {
 	// recorded decision (approved → replay the action; denied → fail closed)
 	// without re-registering. Nil until the run first suspends on an approval.
 	Approvals map[string]string
+	// AuditedSeams records the seam step ids already written to the
+	// flightplan.launch.seam audit trail in THIS run (#2119). The daemon emits
+	// one seam record per distinct seam step at the suspend point and stamps the
+	// step id here, so an empty-body re-suspend of the same still-unfulfilled seam
+	// (which re-walks and re-suspends the same step) does not double-audit. A
+	// fulfilled seam is memoized and never re-suspends. Nil until the run first
+	// suspends on a seam.
+	AuditedSeams map[string]bool
 	// touched is the last time the record was created/updated/read, driving lazy
 	// TTL expiry so an abandoned suspended run is eventually reaped.
 	touched time.Time
@@ -111,6 +119,9 @@ func (r *flightPlanRunRegistry) Put(runID string, rec *flightPlanRunRecord) {
 	}
 	if rec.Approvals == nil {
 		rec.Approvals = map[string]string{}
+	}
+	if rec.AuditedSeams == nil {
+		rec.AuditedSeams = map[string]bool{}
 	}
 	nowT := r.clock()
 	rec.touched = nowT

--- a/internal/app/handlers_flightplans.go
+++ b/internal/app/handlers_flightplans.go
@@ -439,7 +439,7 @@ func (s *apiServer) runOrResume(w http.ResponseWriter, r *http.Request, rec flig
 	}
 
 	if res.Pending != nil {
-		s.writeFlightPlanPending(w, rec, res)
+		s.writeFlightPlanPending(w, r, rec, res)
 		return
 	}
 
@@ -453,7 +453,7 @@ func (s *apiServer) runOrResume(w http.ResponseWriter, r *http.Request, rec flig
 // writeFlightPlanPending stores/updates the run record with the suspend's
 // accumulated memo and writes the matching pending envelope: 200 seam_pending
 // for a seam suspend, 202 pending_approval for an approval suspend.
-func (s *apiServer) writeFlightPlanPending(w http.ResponseWriter, rec flightPlanRunRecord, res runtime.RunResult) {
+func (s *apiServer) writeFlightPlanPending(w http.ResponseWriter, r *http.Request, rec flightPlanRunRecord, res runtime.RunResult) {
 	pending := res.Pending
 	runID := pending.RunID
 
@@ -462,16 +462,25 @@ func (s *apiServer) writeFlightPlanPending(w http.ResponseWriter, rec flightPlan
 	// The approver may already have recorded an approval linkage on rec.Approvals
 	// during this call (a first-reach gated action), so carry it forward.
 	stored := &flightPlanRunRecord{
-		Name:      rec.Name,
-		Version:   rec.Version,
-		Inputs:    rec.Inputs,
-		Outputs:   pending.StepOutputs,
-		Approvals: rec.Approvals,
+		Name:         rec.Name,
+		Version:      rec.Version,
+		Inputs:       rec.Inputs,
+		Outputs:      pending.StepOutputs,
+		Approvals:    rec.Approvals,
+		AuditedSeams: rec.AuditedSeams,
 	}
 	s.flightPlanRuns.Put(runID, stored)
 
 	switch pending.Kind {
 	case runtime.SuspendKindSeam:
+		// Emit the flightplan.launch.seam audit record (#2119) exactly once per
+		// distinct seam step. The daemon owns the run record, so it is the only
+		// layer that can dedupe across suspend/resume calls: an empty-body resume
+		// while still seam-suspended re-walks and re-suspends the same step, and
+		// the AuditedSeams stamp guards against re-emitting for it. This is
+		// best-effort (a record/verify error must not fail the launch), matching
+		// the audit sink's own best-effort discipline (ADR-0010).
+		s.recordSeamAudit(r, stored, pending.Seam)
 		writeJSON(w, http.StatusOK, flightPlanSeamPendingResponse(runID, pending.Seam))
 	case runtime.SuspendKindApproval:
 		// The approval id was recorded on the run record by the approver during
@@ -525,6 +534,67 @@ func flightPlanSeamPendingResponse(runID string, seam *runtime.SeamRequest) api.
 		out.Seam = sr
 	}
 	return out
+}
+
+// recordSeamAudit writes the flightplan.launch.seam audit record for a seam
+// suspend, once per distinct seam step id in this run (#2119). It is a no-op
+// when the seam is absent, the recorder is unwired, or the step was already
+// recorded (an empty-body re-suspend of the same still-unfulfilled seam). It
+// loads and verifies the plan to filter the seam's bindings to the non-source
+// subset (the source-input inline dataset is excluded per the ADR-0027 audit
+// boundary) and to derive the plan provenance. It is best-effort: a load,
+// build, or record failure must not fail the launch, so it returns without
+// stamping the seam so a later suspend may retry, matching the audit sink's own
+// best-effort discipline (ADR-0010).
+func (s *apiServer) recordSeamAudit(r *http.Request, stored *flightPlanRunRecord, seam *runtime.SeamRequest) {
+	if seam == nil || s.auditRecorder == nil {
+		return
+	}
+	if stored.AuditedSeams != nil && stored.AuditedSeams[seam.StepID] {
+		return
+	}
+	loaded, err := runtime.LoadVerified(s.flightPlanStore, stored.Name, stored.Version)
+	if err != nil {
+		// Best-effort: a verify failure here does not fail the suspended launch.
+		// Leave the seam unstamped so a subsequent suspend may retry the emit.
+		return
+	}
+	payload := flightplanSeamAuditPayload(loaded, seam)
+	rec := runtime.AuditRecord{Kind: runtime.RecordKindSeam, Fields: payload}
+	eventType, evPayload := flightplanAuditEvent(rec)
+	actor := model.ActorRef{Type: model.ActorTypeService, ID: flightPlanLaunchActor}
+	if _, err := s.auditRecorder.RecordEvent(r.Context(), eventType, actor, evPayload); err != nil {
+		// Best-effort append: leave the seam unstamped so a later suspend retries.
+		return
+	}
+	if stored.AuditedSeams == nil {
+		stored.AuditedSeams = map[string]bool{}
+	}
+	stored.AuditedSeams[seam.StepID] = true
+}
+
+// flightplanSeamAuditPayload builds the flat `aileron.*` payload for a
+// flightplan.launch.seam record (#2119): the seam step id, the recorded model
+// hint (omitted when empty, mirroring the omit-rather-than-guess discipline),
+// the seam's non-source resolved bindings (the ADR-0027 audit boundary drops a
+// source-input's inline dataset), and the plan provenance the daemon derives
+// truthfully from the verified plan (skill name + content hash, each omitted
+// when empty).
+func flightplanSeamAuditPayload(loaded runtime.LoadedPlan, seam *runtime.SeamRequest) map[string]any {
+	payload := map[string]any{
+		"aileron.seam.step_id":  seam.StepID,
+		"aileron.seam.bindings": runtime.NonSourceSeamBindings(loaded.Plan, seam.StepID, seam.Bindings),
+	}
+	if seam.Model != "" {
+		payload["aileron.seam.model"] = seam.Model
+	}
+	if loaded.Plan != nil && loaded.Plan.Name != "" {
+		payload["aileron.plan.skill"] = loaded.Plan.Name
+	}
+	if loaded.ContentHash != "" {
+		payload["aileron.plan.content_hash"] = loaded.ContentHash
+	}
+	return payload
 }
 
 // writeFlightPlanLaunchError maps a runtime.Run error onto an ADR-0010
@@ -833,6 +903,7 @@ func (s *flightplanAuditSink) Record(ctx context.Context, rec runtime.AuditRecor
 //   - RecordKindLaunch  → flightplan.launch, flat aileron.* fields
 //   - RecordKindOutput  → output.materialized, flat aileron.* fields
 //   - RecordKindReach   → flightplan.launch.reach, flat aileron.* fields
+//   - RecordKindSeam    → flightplan.launch.seam, flat aileron.* fields
 //
 // The flat-vs-nested split matches #1928: output/reach/launch records surface
 // their aileron.* map as the top-level payload so the invocation filter and the
@@ -844,6 +915,8 @@ func flightplanAuditEvent(rec runtime.AuditRecord) (model.EventType, map[string]
 		return model.EventTypeOutputMaterialized, flatOrEmpty(rec.Fields)
 	case runtime.RecordKindReach:
 		return model.EventTypeFlightPlanLaunchReach, flatOrEmpty(rec.Fields)
+	case runtime.RecordKindSeam:
+		return model.EventTypeFlightPlanLaunchSeam, flatOrEmpty(rec.Fields)
 	case runtime.RecordKindLaunch:
 		return model.EventTypeFlightPlanLaunch, flatOrEmpty(rec.Fields)
 	default: // runtime.RecordKindAction

--- a/internal/app/handlers_flightplans_resume_test.go
+++ b/internal/app/handlers_flightplans_resume_test.go
@@ -143,6 +143,85 @@ aileron:
 # Two Seam Fixture
 `
 
+// seamSourceBindingPlanMD is a one-seam plan whose seam binds BOTH a non-source
+// step output (steps.read.series) AND a source-rule input (inputs.dataset,
+// resolved from an action-call read). The seam sends the whole bindings map to
+// the agent, but the flightplan.launch.seam audit record must exclude the
+// source binding's inline dataset per the ADR-0027 audit boundary (#2119).
+const seamSourceBindingPlanMD = `---
+name: seam-source-fixture
+description: A one-seam plan whose seam binds a source input plus a step output.
+license: Apache-2.0
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+            idempotencyKey: false
+          audit:
+            fields:
+              - operation-effect
+              - result
+            sink: audit/reads
+      - ref: aileron:metrics.load_dataset
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+            idempotencyKey: false
+          audit:
+            fields:
+              - operation-effect
+              - result
+            sink: audit/reads
+  inputs:
+    - name: dataset
+      type: object
+      description: A source-resolved dataset the seam binds.
+      resolution:
+        rule: source
+        source:
+          actionRef: aileron:metrics.load_dataset
+          select: rows
+  outputs:
+    - name: summary.json
+      mimeType: application/json
+      encoding: utf-8
+      publish:
+        target: file
+        path: summary.json
+  steps:
+    - id: read
+      kind: action-call
+      actionRef: aileron:metrics.query_series
+      outputs:
+        - series
+    - id: summarize
+      kind: llm-seam
+      model: anthropic:claude-haiku-4-5
+      bindings:
+        series: steps.read.series
+        dataset: inputs.dataset
+      outputs:
+        - summary
+      materializesOutput: summary.json
+---
+
+# Seam Source Fixture
+`
+
 // mixedPlanMD chains a gated write action → a read action → an llm-seam, so a
 // launch suspends first at the gate (202), then at the seam (seam_pending), then
 // completes. The write is topologically before the read + seam, so a naive
@@ -601,9 +680,11 @@ func TestResumeFlightPlan_DeniedApprovalFailsClosed(t *testing.T) {
 }
 
 // TestLaunchFlightPlan_SeamAuditRecordsModelAndBindings (R8): a completed seam
-// run's audit trail carries the seam step's outputs, and each real step is
-// recorded exactly once across the suspend/resume sequence (no double-audit).
-func TestLaunchFlightPlan_SeamAuditNoDoubleRecord(t *testing.T) {
+// run's audit trail carries exactly one flightplan.launch.seam record for the
+// seam step, stamped with the seam's model hint and its non-source bindings, and
+// each real step is recorded exactly once across the suspend/resume sequence (no
+// double-audit).
+func TestLaunchFlightPlan_SeamAuditRecordsModelAndBindings(t *testing.T) {
 	fv := freezeFixture(t, oneSeamPlanMD)
 	exec := &flightplanRecordingExecutor{results: map[string]string{"query_series": `{"series":[1,2,3]}`}}
 	srv, auditStore := newFlightPlanTestServer(t, "one-seam-fixture", fv, exec)
@@ -625,12 +706,15 @@ func TestLaunchFlightPlan_SeamAuditNoDoubleRecord(t *testing.T) {
 	}
 	actionRecords := 0
 	launchSummaries := 0
+	var seamRecords []audit.Event
 	for _, ev := range events {
 		switch ev.EventType {
 		case model.EventTypeFlightPlanLaunchAction:
 			actionRecords++
 		case model.EventTypeFlightPlanLaunch:
 			launchSummaries++
+		case model.EventTypeFlightPlanLaunchSeam:
+			seamRecords = append(seamRecords, ev)
 		}
 	}
 	if actionRecords != 1 {
@@ -639,6 +723,184 @@ func TestLaunchFlightPlan_SeamAuditNoDoubleRecord(t *testing.T) {
 	// Exactly one per-launch summary, emitted by the terminal (completing) resume.
 	if launchSummaries != 1 {
 		t.Errorf("per-launch summary records = %d, want exactly 1", launchSummaries)
+	}
+	// Exactly one flightplan.launch.seam record, carrying the model + bindings.
+	if len(seamRecords) != 1 {
+		t.Fatalf("seam audit records = %d, want exactly 1", len(seamRecords))
+	}
+	ev := seamRecords[0]
+	if ev.Actor.Type != model.ActorTypeService || ev.Actor.ID != flightPlanLaunchActor {
+		t.Errorf("seam record actor = %+v, want service/%s", ev.Actor, flightPlanLaunchActor)
+	}
+	if ev.Payload["aileron.seam.step_id"] != "summarize" {
+		t.Errorf("seam step_id = %v, want summarize", ev.Payload["aileron.seam.step_id"])
+	}
+	if ev.Payload["aileron.seam.model"] != "anthropic:claude-haiku-4-5" {
+		t.Errorf("seam model = %v, want anthropic:claude-haiku-4-5", ev.Payload["aileron.seam.model"])
+	}
+	binds, ok := ev.Payload["aileron.seam.bindings"].(map[string]any)
+	if !ok {
+		t.Fatalf("seam bindings = %v (%T), want map", ev.Payload["aileron.seam.bindings"], ev.Payload["aileron.seam.bindings"])
+	}
+	if _, present := binds["series"]; !present {
+		t.Errorf("seam bindings missing the non-source BindStep binding %q; got %v", "series", binds)
+	}
+}
+
+// countSeamAuditEvents returns the flightplan.launch.seam records grouped by
+// their seam step id, so a test can assert one record per distinct seam step.
+func countSeamAuditEvents(t *testing.T, store *audit.MemStore) map[string]int {
+	t.Helper()
+	events, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	byStep := map[string]int{}
+	for _, ev := range events {
+		if ev.EventType != model.EventTypeFlightPlanLaunchSeam {
+			continue
+		}
+		stepID, _ := ev.Payload["aileron.seam.step_id"].(string)
+		byStep[stepID]++
+	}
+	return byStep
+}
+
+// TestLaunchFlightPlan_SeamAuditNoDoubleOnEmptyResume: an empty-body resume while
+// the same seam is still unfulfilled re-walks and re-suspends the same step, but
+// the daemon's AuditedSeams stamp keeps exactly one flightplan.launch.seam record
+// for that step (#2119).
+func TestLaunchFlightPlan_SeamAuditNoDoubleOnEmptyResume(t *testing.T) {
+	fv := freezeFixture(t, oneSeamPlanMD)
+	exec := &flightplanRecordingExecutor{results: map[string]string{"query_series": `{"series":[1,2,3]}`}}
+	srv, auditStore := newFlightPlanTestServer(t, "one-seam-fixture", fv, exec)
+
+	seam := decodeSeam(t, launch(t, srv, "one-seam-fixture", nil))
+	if got := countSeamAuditEvents(t, auditStore)["summarize"]; got != 1 {
+		t.Fatalf("seam records after launch = %d, want 1", got)
+	}
+
+	// Resume with an empty body: the seam is still unfulfilled, so the run
+	// re-suspends at the same step. No new seam record must be emitted.
+	rec := resume(t, srv, seam.RunId, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty-body resume status = %d, want 200 seam_pending; body=%s", rec.Code, rec.Body.String())
+	}
+	reSeam := decodeSeam(t, rec)
+	if reSeam.Seam.StepId != "summarize" {
+		t.Fatalf("re-suspend step = %q, want summarize", reSeam.Seam.StepId)
+	}
+	if got := countSeamAuditEvents(t, auditStore)["summarize"]; got != 1 {
+		t.Errorf("seam records after empty re-suspend = %d, want exactly 1 (no double-audit)", got)
+	}
+}
+
+// TestLaunchFlightPlan_TwoSeamsAuditOnePerStep: a two-seam plan emits exactly one
+// flightplan.launch.seam record per distinct seam step across the
+// suspend→resume→suspend→resume sequence — both present, neither duplicated.
+func TestLaunchFlightPlan_TwoSeamsAuditOnePerStep(t *testing.T) {
+	fv := freezeFixture(t, twoSeamPlanMD)
+	exec := &flightplanRecordingExecutor{results: map[string]string{"query_series": `{"series":[1,2,3]}`}}
+	srv, auditStore := newFlightPlanTestServer(t, "two-seam-fixture", fv, exec)
+
+	seam := decodeSeam(t, launch(t, srv, "two-seam-fixture", nil))
+	runID := seam.RunId
+	if seam.Seam.StepId != "seam_a" {
+		t.Fatalf("first suspend step = %q, want seam_a", seam.Seam.StepId)
+	}
+
+	rec := resume(t, srv, runID, api.FlightPlanResumeRequest{
+		Outputs: &map[string]map[string]interface{}{"seam_a": {"summary": "S"}},
+	})
+	seam = decodeSeam(t, rec)
+	if seam.Seam.StepId != "seam_b" {
+		t.Fatalf("second suspend step = %q, want seam_b", seam.Seam.StepId)
+	}
+
+	bodyFileMap := `{"path":"body.json","mimeType":"application/json","encoding":"utf-8","content":"{\"body\":\"done\"}"}`
+	rec = resume(t, srv, runID, api.FlightPlanResumeRequest{
+		Outputs: &map[string]map[string]interface{}{"seam_b": {"body": bodyFileMap}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("final resume status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	byStep := countSeamAuditEvents(t, auditStore)
+	if byStep["seam_a"] != 1 {
+		t.Errorf("seam_a records = %d, want exactly 1", byStep["seam_a"])
+	}
+	if byStep["seam_b"] != 1 {
+		t.Errorf("seam_b records = %d, want exactly 1", byStep["seam_b"])
+	}
+	if len(byStep) != 2 {
+		t.Errorf("distinct seam steps recorded = %d, want 2 (seam_a, seam_b); got %v", len(byStep), byStep)
+	}
+}
+
+// TestLaunchFlightPlan_SeamAuditExcludesSourceBinding: a seam that binds a
+// source-rule input inline-carries that dataset to the agent, but the
+// flightplan.launch.seam record excludes the source binding (ADR-0027 audit
+// boundary) while keeping the non-source step-output binding (#2119).
+func TestLaunchFlightPlan_SeamAuditExcludesSourceBinding(t *testing.T) {
+	fv := freezeFixture(t, seamSourceBindingPlanMD)
+	exec := &flightplanRecordingExecutor{results: map[string]string{
+		"query_series": `{"series":[1,2,3]}`,
+		"load_dataset": `{"rows":[{"secret":"do-not-audit"}]}`,
+	}}
+	srv, auditStore := newFlightPlanTestServer(t, "seam-source-fixture", fv, exec)
+
+	seam := decodeSeam(t, launch(t, srv, "seam-source-fixture", nil))
+	if seam.Seam.StepId != "summarize" {
+		t.Fatalf("suspend step = %q, want summarize", seam.Seam.StepId)
+	}
+	// The agent still receives the full bindings, source dataset included.
+	if seam.Seam.Bindings == nil {
+		t.Fatal("seam_pending must carry the full bindings to the agent")
+	}
+	if _, present := (*seam.Seam.Bindings)["dataset"]; !present {
+		t.Errorf("agent bindings must include the source binding %q; got %v", "dataset", *seam.Seam.Bindings)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	var seamRecords []audit.Event
+	for _, ev := range events {
+		if ev.EventType == model.EventTypeFlightPlanLaunchSeam {
+			seamRecords = append(seamRecords, ev)
+		}
+	}
+	if len(seamRecords) != 1 {
+		t.Fatalf("seam audit records = %d, want exactly 1", len(seamRecords))
+	}
+	binds, ok := seamRecords[0].Payload["aileron.seam.bindings"].(map[string]any)
+	if !ok {
+		t.Fatalf("seam bindings = %v (%T), want map", seamRecords[0].Payload["aileron.seam.bindings"], seamRecords[0].Payload["aileron.seam.bindings"])
+	}
+	if _, present := binds["dataset"]; present {
+		t.Errorf("seam audit bindings must EXCLUDE the source binding %q; got %v", "dataset", binds)
+	}
+	if _, present := binds["series"]; !present {
+		t.Errorf("seam audit bindings must include the non-source binding %q; got %v", "series", binds)
+	}
+}
+
+// TestLaunchFlightPlan_SeamAuditNilRecorder: a daemon with no configured audit
+// recorder still suspends the seam cleanly and simply emits no seam record (the
+// best-effort discipline: audit is a companion, never a hard dependency).
+func TestLaunchFlightPlan_SeamAuditNilRecorder(t *testing.T) {
+	fv := freezeFixture(t, oneSeamPlanMD)
+	exec := &flightplanRecordingExecutor{results: map[string]string{"query_series": `{"series":[1,2,3]}`}}
+	srv, auditStore := newFlightPlanTestServer(t, "one-seam-fixture", fv, exec)
+	srv.auditRecorder = nil
+
+	seam := decodeSeam(t, launch(t, srv, "one-seam-fixture", nil))
+	if seam.Seam.StepId != "summarize" {
+		t.Fatalf("suspend step = %q, want summarize", seam.Seam.StepId)
+	}
+	if got := countSeamAuditEvents(t, auditStore); len(got) != 0 {
+		t.Errorf("seam records with nil recorder = %v, want none", got)
 	}
 }
 

--- a/internal/flightplan/runtime/seam_audit.go
+++ b/internal/flightplan/runtime/seam_audit.go
@@ -1,0 +1,57 @@
+package runtime
+
+// NonSourceSeamBindings returns the subset of a seam step's resolved bindings
+// that is safe to persist in the flightplan.launch.seam audit record (#2119),
+// honoring the ADR-0027 audit boundary. The full bindings map is deliberately
+// sent whole to the agent on the seam_pending envelope (the agent needs it),
+// but a binding of BindInput kind that references a `source`-rule input carries
+// the source dataset inline in that map. Such an inline dataset must never land
+// in the persisted audit trail, so this helper drops any binding whose
+// BindInput name resolves to a source input; every BindStep binding and every
+// non-source BindInput binding passes through verbatim.
+//
+// It single-sources the ADR-0027 boundary rule in the runtime (mirroring
+// launchConfigInputs) so the daemon-side emission stays free of binding/input
+// knowledge. Deterministic and nil-safe: a nil plan, an unknown step id, or nil
+// bindings all yield an empty (non-nil) map.
+func NonSourceSeamBindings(plan *Plan, stepID string, bindings map[string]any) map[string]any {
+	out := map[string]any{}
+	if plan == nil || len(bindings) == 0 {
+		return out
+	}
+	// Build the set of source-rule input names once.
+	sourceInputs := map[string]bool{}
+	for _, in := range plan.Inputs {
+		if in.Resolution.Rule == ResolutionSource {
+			sourceInputs[in.Name] = true
+		}
+	}
+	// Locate the seam step so its declared binding kinds can be read.
+	var stepBinds map[string]Binding
+	for _, st := range plan.Steps {
+		if st.ID == stepID {
+			stepBinds = st.binds()
+			break
+		}
+	}
+	if stepBinds == nil {
+		// Unknown step id: no binding knowledge, so nothing is provably
+		// non-source. Fail closed to an empty map rather than leaking an
+		// unclassified value.
+		return out
+	}
+	for name, v := range bindings {
+		b, ok := stepBinds[name]
+		if !ok {
+			// A resolved binding value with no declared binding entry cannot be
+			// classified against the source rule; exclude it to stay on the safe
+			// side of the audit boundary.
+			continue
+		}
+		if b.Kind == BindInput && sourceInputs[b.Name] {
+			continue
+		}
+		out[name] = v
+	}
+	return out
+}

--- a/internal/flightplan/runtime/seam_audit_test.go
+++ b/internal/flightplan/runtime/seam_audit_test.go
@@ -1,0 +1,120 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+// seamAuditPlan builds a minimal plan with one llm-seam step ("summarize") whose
+// bindings and the plan's inputs are supplied by the caller, so each scenario can
+// exercise the NonSourceSeamBindings source/non-source classification directly.
+func seamAuditPlan(inputs []Input, seamBindings map[string]Binding) *Plan {
+	return &Plan{
+		Name:   "seam-audit-fixture",
+		Inputs: inputs,
+		Steps: []Step{
+			{ID: "read", Kind: KindActionCall, Outputs: []string{"series"}},
+			{ID: "summarize", Kind: KindLLMSeam, Bindings: seamBindings, Outputs: []string{"summary"}},
+		},
+	}
+}
+
+func TestNonSourceSeamBindings(t *testing.T) {
+	sourceInput := Input{
+		Name:       "dataset",
+		Type:       "object",
+		Resolution: Resolution{Rule: ResolutionSource, SourceActionRef: "aileron:metrics.load_dataset", SourceSelect: "rows"},
+	}
+	literalInput := Input{
+		Name:       "window",
+		Type:       "number",
+		Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: float64(7)},
+	}
+
+	tests := []struct {
+		name     string
+		inputs   []Input
+		binds    map[string]Binding
+		bindings map[string]any
+		want     map[string]any
+	}{
+		{
+			name:     "BindStep binding passes through",
+			inputs:   nil,
+			binds:    map[string]Binding{"series": {Kind: BindStep, StepID: "read", Output: "series"}},
+			bindings: map[string]any{"series": []any{1, 2, 3}},
+			want:     map[string]any{"series": []any{1, 2, 3}},
+		},
+		{
+			name:     "BindInput to a literal input passes through",
+			inputs:   []Input{literalInput},
+			binds:    map[string]Binding{"window": {Kind: BindInput, Name: "window"}},
+			bindings: map[string]any{"window": float64(7)},
+			want:     map[string]any{"window": float64(7)},
+		},
+		{
+			name:     "BindInput to a source input is excluded",
+			inputs:   []Input{sourceInput},
+			binds:    map[string]Binding{"dataset": {Kind: BindInput, Name: "dataset"}},
+			bindings: map[string]any{"dataset": []any{map[string]any{"secret": "x"}}},
+			want:     map[string]any{},
+		},
+		{
+			name:   "mixed: source excluded, step + literal kept",
+			inputs: []Input{sourceInput, literalInput},
+			binds: map[string]Binding{
+				"dataset": {Kind: BindInput, Name: "dataset"},
+				"series":  {Kind: BindStep, StepID: "read", Output: "series"},
+				"window":  {Kind: BindInput, Name: "window"},
+			},
+			bindings: map[string]any{
+				"dataset": []any{map[string]any{"secret": "x"}},
+				"series":  []any{1, 2, 3},
+				"window":  float64(7),
+			},
+			want: map[string]any{
+				"series": []any{1, 2, 3},
+				"window": float64(7),
+			},
+		},
+		{
+			name:     "empty bindings yield empty map",
+			inputs:   []Input{sourceInput},
+			binds:    map[string]Binding{"dataset": {Kind: BindInput, Name: "dataset"}},
+			bindings: map[string]any{},
+			want:     map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := seamAuditPlan(tt.inputs, tt.binds)
+			got := NonSourceSeamBindings(plan, "summarize", tt.bindings)
+			if got == nil {
+				t.Fatal("NonSourceSeamBindings returned nil, want a non-nil map")
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NonSourceSeamBindings = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNonSourceSeamBindings_UnknownStep: an unknown step id cannot classify any
+// binding against the source rule, so the helper fails closed to an empty map
+// rather than leaking unclassified values.
+func TestNonSourceSeamBindings_UnknownStep(t *testing.T) {
+	plan := seamAuditPlan(nil, map[string]Binding{"series": {Kind: BindStep, StepID: "read", Output: "series"}})
+	got := NonSourceSeamBindings(plan, "does-not-exist", map[string]any{"series": []any{1}})
+	if len(got) != 0 {
+		t.Errorf("unknown step id yielded %v, want empty map", got)
+	}
+}
+
+// TestNonSourceSeamBindings_NilPlan: a nil plan yields an empty, non-nil map.
+func TestNonSourceSeamBindings_NilPlan(t *testing.T) {
+	got := NonSourceSeamBindings(nil, "summarize", map[string]any{"series": []any{1}})
+	if got == nil || len(got) != 0 {
+		t.Errorf("nil plan yielded %v, want empty non-nil map", got)
+	}
+}

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -120,6 +120,16 @@ const (
 	// step declared a contract but no sealed reach existed (a
 	// directly-constructed plan outside the verified load path).
 	RecordKindReach
+	// RecordKindSeam is one per-distinct-seam-step record (#2119). It is
+	// constructed daemon-side (not emitted by the runtime's emitStepAudit) when a
+	// launch/resume suspends at a marked llm-seam step: the runtime is stateless
+	// across suspend/resume calls, so only the daemon (which owns the run record)
+	// can dedupe a re-suspend. This kind exists so both audit sinks translate the
+	// daemon-constructed record onto model.EventTypeFlightPlanLaunchSeam
+	// uniformly. Its flat `aileron.*` payload carries the seam step id, the
+	// recorded model hint, and the seam's non-source bindings (the source-input
+	// inline dataset is excluded per the ADR-0027 audit boundary).
+	RecordKindSeam
 )
 
 // AuditRecord is one customer-owned audit entry. Fields holds exactly the
@@ -129,7 +139,8 @@ type AuditRecord struct {
 	// Kind is the record's kind, the explicit discriminator the CLI sink maps
 	// to a model.EventType (RecordKindAction → flightplan.launch.action,
 	// RecordKindLaunch → flightplan.launch, RecordKindOutput →
-	// output.materialized, RecordKindReach → flightplan.launch.reach).
+	// output.materialized, RecordKindReach → flightplan.launch.reach,
+	// RecordKindSeam → flightplan.launch.seam).
 	Kind AuditRecordKind
 	// ActionRef is the action the record describes, or "" for a per-launch
 	// summary or per-output record.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -424,6 +424,24 @@ const (
 	// "<user>@<host>"}, the operator who ran the launch (#1875).
 	EventTypeFlightPlanLaunchReach EventType = "flightplan.launch.reach"
 
+	// EventTypeFlightPlanLaunchSeam is one per-distinct-seam-step record
+	// emitted daemon-side when a launch/resume SUSPENDS at a marked llm-seam
+	// step (#2119). The daemon owns the run record and is the only layer that
+	// can dedupe across suspend/resume calls, so it (not the stateless runtime)
+	// writes this record and stamps the seam step id to guard against a
+	// double-audit on an empty-body re-suspend. The flat `aileron.*` payload
+	// carries the seam step id (`aileron.seam.step_id`), the recorded model
+	// target hint when the seam declares one (`aileron.seam.model`, omitted
+	// when empty), and the seam's NON-SOURCE resolved bindings
+	// (`aileron.seam.bindings`) — a source-input binding's inline dataset is
+	// excluded per the ADR-0027 audit boundary even though the full bindings
+	// still ride the seam_pending envelope to the agent. It also stamps the
+	// plan provenance the daemon derives from the verified plan
+	// (`aileron.plan.skill`, `aileron.plan.content_hash`). Actor is {type:
+	// service, id: "flightplan-launch"}, the daemon service that suspended the
+	// run.
+	EventTypeFlightPlanLaunchSeam EventType = "flightplan.launch.seam"
+
 	// EventTypeOutputMaterialized is one per-output-per-step provenance event
 	// (#1752). The in-process launch runtime emits exactly one such record for
 	// each materialized artifact, whether the materializing step is an


### PR DESCRIPTION
## Summary

A marked llm-seam step reaches the agent only through the daemon's suspend envelope (`seam_pending`), and nothing wrote the seam's `model` + resolved bindings to the **persisted** audit trail. This adds a `flightplan.launch.seam` audit record emitted daemon-side at the seam suspend point, closing umbrella acceptance #8.

Key decisions:
- **Emit daemon-side, not from the runtime.** An unfulfilled seam has no memo entry, so the stateless runtime cannot distinguish a first suspend from a re-suspend. The daemon owns the run record and is the only layer that can dedupe.
- **New kind `flightplan.launch.seam`** (`model.EventTypeFlightPlanLaunchSeam`), mirrored as `runtime.RecordKindSeam` so both audit sinks (in-process `flightplanAuditSink` and the CLI `daemonAuditSink`) translate the daemon-constructed record uniformly through the one existing `flightplanAuditEvent` switch.
- **ADR-0027 audit boundary.** A seam binding of `BindInput` kind to a `source`-rule input carries the source dataset inline in the bindings map (which is deliberately sent whole to the agent). The new exported `runtime.NonSourceSeamBindings` single-sources the boundary rule and drops those source bindings from the persisted record; `BindStep` and non-source `BindInput` bindings pass through verbatim.
- **Exactly-once.** `AuditedSeams map[string]bool` on the run record stamps each distinct seam step id, so an empty-body resume while still seam-suspended (which re-walks and re-suspends the same step) does not double-audit. A fulfilled seam is memoized and never re-suspends. Emission is best-effort: a load/record error never fails the launch.
- **Payload:** `aileron.seam.step_id`, `aileron.seam.model` (omitted when empty), `aileron.seam.bindings` (non-source subset), plus the daemon-derived `aileron.plan.skill` / `aileron.plan.content_hash`.

No OpenAPI change: audit event kinds are internal (`model.EventType`), and the `seam_pending` envelope is unchanged (the agent still gets full bindings).

## Test plan

- `go build ./...` across the `internal` and `cmd/aileron` modules — clean.
- `go test ./internal/app/... ./internal/flightplan/runtime/... ./cmd/aileron/... -cover` — green (app 83.8%, runtime 92.4%).
- New runtime helper test `TestNonSourceSeamBindings` (+ nil-plan/unknown-step) covers: BindStep passes through, BindInput→literal passes through, BindInput→source excluded, mixed, empty, unknown step → empty, nil plan → empty.
- Renamed/expanded R8 test `TestLaunchFlightPlan_SeamAuditRecordsModelAndBindings`: exactly one `flightplan.launch.seam` event whose payload carries `aileron.seam.model == "anthropic:claude-haiku-4-5"` and `aileron.seam.bindings` includes the non-source `series` binding; kept the no-double action==1 / launch-summary==1 assertions.
- New daemon-side tests: no-double on empty-body re-suspend, two-seam plan → one record per distinct seam step, source-binding exclusion at the daemon layer (agent still receives the source binding; audit record excludes it), and nil-recorder best-effort path.

Uncovered lines are limited to the two best-effort error `return`s in `recordSeamAudit` (LoadVerified error, RecordEvent error) — defensive nil-safety paths that would need a fault-injection store/recorder to hit honestly; not padded.

Closes #2119
