### PR TITLE
fix(keyring): enrich publisher-key 404 guidance for private repos

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -337,7 +337,17 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 		url.PathEscape(fqn.Repo),
 		publisherKeyPath,
 	)
-	return fetchKeyFromURL(keyURL)
+	pub, err := fetchKeyFromURL(keyURL)
+	if err != nil {
+		// raw.githubusercontent.com does not accept bearer tokens, so a
+		// private repo 404s here even with a valid token. Enrich the
+		// anonymous-path failure with the private-repo remediation, which is
+		// specific to the convention-path publisher key (not the Hub key_url
+		// path, which fetchKeyFromURL also serves).
+		return nil, fmt.Errorf("%w\n  A private-repo 404 means no/insufficient access, not that %s is missing.\n  Fix: export GH_TOKEN=$(gh auth token) to fetch it over the GitHub Contents API (GH_TOKEN wins over GITHUB_TOKEN).\n  The token needs \"Contents: Read-only\" for a fine-grained PAT, or the \"repo\" scope for a classic PAT.\n  Or bypass the fetch entirely: aileron keyring trust --key-file <path> %s",
+			err, publisherKeyPath, fqn.OwnerAuthority())
+	}
+	return pub, nil
 }
 
 // githubToken returns the GitHub token from the environment, preferring
@@ -380,8 +390,8 @@ func fetchPublisherKeyViaAPI(fqn cstore.FQN, token string) (ed25519.PublicKey, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch; check the token has read access to this repo)",
-			endpoint, resp.StatusCode, publisherKeyPath)
+		return nil, fmt.Errorf("GET %s: HTTP %d (a private-repo 404 here means the token lacks access, not that %s is missing; grant the token \"Contents: Read-only\" for a fine-grained PAT or the \"repo\" scope for a classic PAT; export GH_TOKEN=$(gh auth token) reuses your gh login (GH_TOKEN wins over GITHUB_TOKEN); or bypass the fetch entirely with `aileron keyring trust --key-file <path> %s`)",
+			endpoint, resp.StatusCode, publisherKeyPath, fqn.OwnerAuthority())
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
@@ -399,9 +409,10 @@ func fetchPublisherKeyViaAPI(fqn cstore.FQN, token string) (ed25519.PublicKey, e
 // decodes it (PEM or base64). Shared by fetchPublisherKey (the
 // convention-path fetch) and the Hub `key_url` resolution
 // (resolveOwnerKeyFromHub), so both honor the same timeout, size cap,
-// and decode rules. The 404 message names the convention path because
-// that is the most common cause for the per-repo fetch; the Hub path
-// fetches a fully-qualified `key_url` and surfaces the same status.
+// and decode rules. The status-code error stays scope-agnostic here
+// because the two callers differ: fetchPublisherKey wraps this with the
+// convention-path private-repo remediation (GH_TOKEN over the Contents
+// API), which does not apply to the Hub's fully-qualified `key_url`.
 func fetchKeyFromURL(keyURL string) (ed25519.PublicKey, error) {
 	client := &http.Client{Timeout: publisherKeyFetchTimeout}
 	resp, err := client.Get(keyURL)
@@ -411,8 +422,7 @@ func fetchKeyFromURL(keyURL string) (ed25519.PublicKey, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch; a private repo 404s here — set GH_TOKEN or GITHUB_TOKEN to fetch it over the GitHub API)",
-			keyURL, resp.StatusCode, publisherKeyPath)
+		return nil, fmt.Errorf("GET %s: HTTP %d", keyURL, resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -437,11 +437,26 @@ func TestKeyringTrust_PrivateRepoAPI404GivesGuidance(t *testing.T) {
 	if rc == 0 {
 		t.Fatal("expected non-zero exit when the API path is absent")
 	}
-	if !strings.Contains(stderr.String(), "keys/publisher.pub") {
-		t.Errorf("expected error to name the convention path; got: %s", stderr.String())
+	got := stderr.String()
+	if !strings.Contains(got, "keys/publisher.pub") {
+		t.Errorf("expected error to name the convention path; got: %s", got)
 	}
-	if !strings.Contains(stderr.String(), "read access") {
-		t.Errorf("expected token-access hint; got: %s", stderr.String())
+	// A private-repo 404 on the authenticated path means the token lacks
+	// access, not that the file is missing.
+	if !strings.Contains(got, "access") {
+		t.Errorf("expected token-access hint; got: %s", got)
+	}
+	// Name the exact token scopes for both PAT kinds.
+	if !strings.Contains(got, "Contents: Read-only") || !strings.Contains(got, "\"repo\"") {
+		t.Errorf("expected fine-grained and classic PAT scope guidance; got: %s", got)
+	}
+	// GH_TOKEN-over-GITHUB_TOKEN precedence, so the operator knows which wins.
+	if !strings.Contains(got, "GH_TOKEN") {
+		t.Errorf("expected GH_TOKEN guidance; got: %s", got)
+	}
+	// Point at the --key-file escape hatch.
+	if !strings.Contains(got, "--key-file") {
+		t.Errorf("expected --key-file escape hatch; got: %s", got)
 	}
 }
 
@@ -455,8 +470,25 @@ func TestKeyringTrust_Anonymous404MentionsToken(t *testing.T) {
 	if rc := runKeyring([]string{"trust", "github://acme/private"}, stdout, stderr); rc == 0 {
 		t.Fatal("expected non-zero exit on 404")
 	}
-	if !strings.Contains(stderr.String(), "GH_TOKEN") || !strings.Contains(stderr.String(), "GITHUB_TOKEN") {
-		t.Errorf("expected 404 to mention GH_TOKEN/GITHUB_TOKEN; got: %s", stderr.String())
+	got := stderr.String()
+	if !strings.Contains(got, "GH_TOKEN") || !strings.Contains(got, "GITHUB_TOKEN") {
+		t.Errorf("expected 404 to mention GH_TOKEN/GITHUB_TOKEN; got: %s", got)
+	}
+	// The 404 means no/insufficient access, not a missing file.
+	if !strings.Contains(got, "access") {
+		t.Errorf("expected access-not-missing framing; got: %s", got)
+	}
+	// The one-liner fix with GH_TOKEN-over-GITHUB_TOKEN precedence.
+	if !strings.Contains(got, "gh auth token") {
+		t.Errorf("expected `gh auth token` one-liner; got: %s", got)
+	}
+	// Name the exact token scopes for both PAT kinds.
+	if !strings.Contains(got, "Contents: Read-only") || !strings.Contains(got, "\"repo\"") {
+		t.Errorf("expected fine-grained and classic PAT scope guidance; got: %s", got)
+	}
+	// Point at the --key-file escape hatch.
+	if !strings.Contains(got, "--key-file") {
+		t.Errorf("expected --key-file escape hatch; got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`aileron keyring trust` failed opaquely when a publisher's `keys/publisher.pub` lived in a private repo: the 404 read like a missing file, with no hint that the real cause was token access. This enriches both 404 sites with actionable guidance.

Both the anonymous convention-path fetch (`fetchPublisherKey`) and the authenticated Contents-API path (`fetchPublisherKeyViaAPI`) now:

- State that a private-repo 404 means **no/insufficient access**, not a missing file.
- Name the exact token scope: fine-grained PAT **"Contents: Read-only"** or classic PAT **"repo"**.
- Give the one-liner fix `export GH_TOKEN=$(gh auth token)` and note **GH_TOKEN wins over GITHUB_TOKEN**.
- Point at the `--key-file <path>` escape hatch for air-gapped / private-repo operators.

The shared `fetchKeyFromURL` status-code error is left scope-agnostic; `fetchPublisherKey` wraps it with the convention-path remediation. This keeps the GH_TOKEN-over-Contents-API advice off the Hub `key_url` path (`resolveOwnerKeyFromHub`), where it does not apply. All owner/repo text is interpolated from the FQN (`fqn.OwnerAuthority()`, `publisherKeyPath`); no hardcoded values.

## Test plan

- Extended `TestKeyringTrust_Anonymous404MentionsToken` and `TestKeyringTrust_PrivateRepoAPI404GivesGuidance` to assert on the new scope guidance (`Contents: Read-only`, `"repo"`), the `gh auth token` one-liner + GH_TOKEN precedence, the access-not-missing framing, and the `--key-file` hatch.
- `TestKeyringTrust_MissingConventionPath` still passes (wrapper preserves the `404` + convention-path substrings).
- `go build ./cmd/aileron/` clean; `go vet` clean.
- `go test ./cmd/aileron/ -cover` → pass, 87.1% coverage.

Closes #2126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n9Rane4synTJJ7QQQnZDX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when key lookup fails for private repositories, making it clearer when the issue is access-related rather than a missing file.
  * Added more actionable guidance for resolving key fetch problems, including token setup and an option to use a local key file instead of fetching from the network.
  * Simplified HTTP failure messages so they are easier to read and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->