### PR TITLE
fix(flightplan): record install-origin on skill publish so launch boots from registry

### DIFF
--- a/cmd/aileron/skill_publish.go
+++ b/cmd/aileron/skill_publish.go
@@ -84,5 +84,27 @@ func runSkillPublish(args []string, stdout, stderr io.Writer) int {
 		}
 		return 1
 	}
+
+	// Record the install origin sidecar so a later `skill launch` of this
+	// just-published version takes the registry pull-and-verify boot path
+	// (internal/flightplan/runtime/image.go), not the mutable local-tag path.
+	// The composed local tag `aileron/sandbox-tools:<hex>` is content-derived
+	// purely from base+featureRefs and is a SHARED daemon tag any later freeze of
+	// any plan with the same environment rebuilds/repoints, which would leave this
+	// plan's signed lock attesting a stale digest and trip the #1863
+	// config-content-digest guard. The published image is content-addressed and
+	// verified against the same signed lock pin, so pointing launch at the
+	// registry resolves the dead-end. This mirrors the OCI-install path
+	// (cmd/aileron/skill_install_oci.go): the sidecar is non-signed provenance
+	// (where to fetch), never a trust anchor; every fetched byte is still verified
+	// against the signed lock. A sidecar write failure fails the publish rather
+	// than leaving a version whose launch silently stays on the local-tag path.
+	if err := s.WriteOrigin(name, id, store.Origin{
+		Registry:   *registryRef,
+		VersionTag: id,
+	}); err != nil {
+		fmt.Fprintf(stderr, "error: record publish origin for %q: %v\n", id, err)
+		return 1
+	}
 	return 0
 }

--- a/cmd/aileron/skill_publish_test.go
+++ b/cmd/aileron/skill_publish_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -106,6 +107,115 @@ func TestRunSkillPublishQuietPlumbed(t *testing.T) {
 	}
 	if got.Quiet {
 		t.Errorf("Quiet = true, want false when --quiet is omitted")
+	}
+}
+
+// TestRunSkillPublishRecordsOrigin is the #2127 regression: a successful publish
+// MUST write the install-origin sidecar so a later `skill launch` of the
+// just-published version takes the registry pull-and-verify boot path instead of
+// the mutable, shared local composed tag (which a later freeze of any plan with
+// the same environment repoints, stranding this plan's signed lock on a stale
+// digest and tripping the #1863 config-content-digest guard). Before the fix
+// publish never wrote the sidecar, so ReadOrigin returned ok=false and launch
+// stayed on the local-tag dead-end. Registry+VersionTag must be exactly what
+// launch feeds pull.PullImage (origin.Registry, ComposedImageTag(origin.VersionTag)).
+func TestRunSkillPublishRecordsOrigin(t *testing.T) {
+	dir := t.TempDir()
+	skillStoreDir = dir
+	t.Cleanup(func() { skillStoreDir = "" })
+	pin := freeze.ImagePin{Ref: "docker.io/library/python", Digest: "sha256:abc"}
+	writeFrozenFixture(t, dir, "demo", "v1", freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}})
+
+	withStubPublish(t, func(_ context.Context, o publish.Options) (publish.Result, error) {
+		return publish.Result{ArtifactRef: o.Registry + ":" + o.VersionID}, nil
+	})
+
+	var out, errBuf bytes.Buffer
+	if code := runSkillPublish([]string{"demo", "--registry", "ghcr.io/acme/demo"}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%s)", code, errBuf.String())
+	}
+
+	s := store.New(dir)
+	origin, ok, err := s.ReadOrigin("demo", "v1")
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if !ok {
+		t.Fatal("origin sidecar absent after publish; launch would stay on the mutable local-tag boot path (#2127)")
+	}
+	if origin.Registry != "ghcr.io/acme/demo" {
+		t.Errorf("origin.Registry = %q, want ghcr.io/acme/demo (the --registry value launch pulls from)", origin.Registry)
+	}
+	if origin.VersionTag != "v1" {
+		t.Errorf("origin.VersionTag = %q, want v1 (the resolved version id launch derives ComposedImageTag from)", origin.VersionTag)
+	}
+}
+
+// TestRunSkillPublishOriginRecordsResolvedNewest proves the sidecar records the
+// RESOLVED newest version id (not a literal --version), so launching the newest
+// after an unpinned publish takes the registry path against the version that was
+// actually pushed.
+func TestRunSkillPublishOriginRecordsResolvedNewest(t *testing.T) {
+	dir := t.TempDir()
+	skillStoreDir = dir
+	t.Cleanup(func() { skillStoreDir = "" })
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:abc"}
+	writeFrozenFixture(t, dir, "demo", "v1", freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}})
+	writeFrozenFixture(t, dir, "demo", "v2", freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}})
+
+	var published string
+	withStubPublish(t, func(_ context.Context, o publish.Options) (publish.Result, error) {
+		published = o.VersionID
+		return publish.Result{}, nil
+	})
+
+	var out, errBuf bytes.Buffer
+	if code := runSkillPublish([]string{"demo", "--registry", "ghcr.io/acme/demo"}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr=%s)", code, errBuf.String())
+	}
+	if published != "v2" {
+		t.Fatalf("published = %q, want v2 (the newest frozen version)", published)
+	}
+	origin, ok, err := store.New(dir).ReadOrigin("demo", published)
+	if err != nil {
+		t.Fatalf("ReadOrigin: %v", err)
+	}
+	if !ok {
+		t.Fatalf("origin sidecar absent for the published version %q", published)
+	}
+	if origin.VersionTag != published {
+		t.Errorf("origin.VersionTag = %q, want the resolved published version %q", origin.VersionTag, published)
+	}
+}
+
+// TestRunSkillPublishOriginWriteFailureFailsPublish proves a sidecar write
+// failure fails the publish (mirroring the OCI-install path), rather than
+// reporting success for a version whose launch would silently stay on the
+// local-tag dead-end. The frozen version dir is removed after publishRun so
+// WriteOrigin's missing-version-dir guard fires.
+func TestRunSkillPublishOriginWriteFailureFailsPublish(t *testing.T) {
+	dir := t.TempDir()
+	skillStoreDir = dir
+	t.Cleanup(func() { skillStoreDir = "" })
+	pin := freeze.ImagePin{Ref: "r", Digest: "sha256:abc"}
+	writeFrozenFixture(t, dir, "demo", "v1", freeze.Lockfile{ResolvedImages: []freeze.ImagePin{pin}})
+
+	s := store.New(dir)
+	withStubPublish(t, func(_ context.Context, _ publish.Options) (publish.Result, error) {
+		// Remove the version directory so the subsequent WriteOrigin fails its
+		// "cannot write origin for missing frozen version" guard.
+		if err := os.RemoveAll(s.FrozenDir("demo", "v1")); err != nil {
+			t.Fatalf("remove frozen dir: %v", err)
+		}
+		return publish.Result{}, nil
+	})
+
+	var out, errBuf bytes.Buffer
+	if code := runSkillPublish([]string{"demo", "--registry", "ghcr.io/acme/demo"}, &out, &errBuf); code != 1 {
+		t.Fatalf("exit = %d, want 1 (a sidecar write failure must fail the publish)", code)
+	}
+	if !strings.Contains(errBuf.String(), "record publish origin") {
+		t.Errorf("stderr = %q, want a 'record publish origin' failure", errBuf.String())
 	}
 }
 

--- a/docs/src/content/docs/guides/publishing-a-flight-plan.md
+++ b/docs/src/content/docs/guides/publishing-a-flight-plan.md
@@ -45,6 +45,12 @@ Install with:
 
 If the semver label carries build metadata (a `+build` suffix) or any other character outside the OCI tag grammar, publish skips the semver tag with a warning and still publishes the content-hash and `latest` tags.
 
+## Publish makes this version launch from the registry
+
+Publishing also records where the version now lives, so `aileron skill launch <name>` boots the copy you just pushed rather than a local build. On success publish writes a small install-origin note next to the frozen version pointing launch at `<registry>` and the version tag. Launch then pulls the published, content-addressed image and verifies it against the signed lock, exactly as it does on a machine that installed the plan by OCI reference.
+
+This matters because a composed-tools plan's local image tag is a shared, content-derived daemon tag. A later freeze of any plan with the same base and tools rebuilds and repoints that tag, which would strand this version's signed lock on a now-stale local digest. Booting from the published registry image keeps launch pinned to the immutable copy you published. You do not need to install the plan locally after publishing it: the machine that published a version can launch it straight from the registry.
+
 ## Two binding kinds
 
 The digest that lets launch verify the pulled image against the signed lock depends on the plan's pin type. Publish branches automatically.


### PR DESCRIPTION
## Summary

`aileron skill publish` pushed the composed image and signed artifact to the registry but never recorded the install-origin sidecar (`store.WriteOrigin`), which only the OCI-install path wrote. A subsequent `skill launch` of the just-published local version therefore found no `ImageOrigin.Present`, stayed on the mutable local-tag boot path (`internal/flightplan/runtime/image.go`), and hit the #1863 config-content-digest guard.

That guard fails because the composed local tag `aileron/sandbox-tools:<hex>` is content-derived purely from base+featureRefs (`internal/sandbox/composition/tools.go`): it is a **shared, mutable daemon tag** that any later freeze of any plan with the same environment rebuilds/repoints, leaving the first plan's signed lock attesting a now-stale digest. The registry pull-and-verify branch (`image.go:52-71`) already existed and boots the published, content-addressed image verified against the same signed-lock pin; publish just never activated it.

**Fix:** after a successful `publishRun(...)`, write the origin sidecar `store.Origin{Registry: --registry, VersionTag: <resolved version id>}`, mirroring `cmd/aileron/skill_install_oci.go`. This is exactly consistent with the pull side: launch derives the composed image tag via `freeze.ComposedImageTag(origin.VersionTag)` and pulls from `origin.Registry`; publish tags the composed image under `freeze.ComposedImageTag(opts.VersionID)` in `opts.Registry`. With the sidecar written, freeze → publish → launch takes the registry path, pulls+verifies the published image, boots by content-addressed manifest digest, and the mutable-local-tag guard is never entered. A sidecar write failure fails the publish (mirroring install), rather than reporting success for a version launch cannot boot on this machine.

No spec/OpenAPI change (CLI-only).

## Test plan

- `TestRunSkillPublishRecordsOrigin` — a successful publish writes the sidecar with `Registry = --registry` and `VersionTag = resolved id`. Fails before the fix (sidecar absent), passes after.
- `TestRunSkillPublishOriginRecordsResolvedNewest` — an unpinned publish records the **resolved newest** version id (v2), so launching the newest takes the registry path against the version actually pushed.
- `TestRunSkillPublishOriginWriteFailureFailsPublish` — a sidecar write failure fails the publish (exit 1, `record publish origin` error), not a false success.
- All three fail before the fix and pass after (verified via `git stash`).
- `go test ./cmd/aileron/ ./internal/flightplan/...` green; `go vet` clean; `runSkillPublish` coverage 92.7% (new path fully covered).
- Docs: added a "Publish makes this version launch from the registry" section to `docs/src/content/docs/guides/publishing-a-flight-plan.md`.
- CodeRabbit review pass: one minor finding (assert resolved-newest is v2), applied.

Closes #2127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n9Rane4synTJJ7QQQnZDX
