### PR TITLE
fix(launch): stop surfacing raw input regex in launch prompt

### DIFF
--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -227,18 +227,19 @@ func (p linePrompter) PromptInput(in runtime.Input) (string, error) {
 }
 
 // inputConstraintHint renders a short, parenthesized hint for a declared input
-// constraint so the interactive prompt tells the operator the accepted shape:
-// the allowed enum values or the required pattern. An unconstrained input
-// returns "".
+// constraint so the interactive prompt tells the operator the accepted shape.
+// Only the enum branch is surfaced: "[one of: a, b, c]" is human-readable and
+// helps the operator answer. A raw regexp Pattern is deliberately NOT rendered
+// because the raw expression (e.g. `^[a-z]{2}-[a-z]+-\d$`) is meaningless noise
+// to an operator answering a prompt (#2130); the pattern is still enforced on
+// submit by the validator, this only governs display. An unconstrained input,
+// or one constrained solely by a pattern, returns "".
 func inputConstraintHint(c *runtime.Constraint) string {
 	if c == nil {
 		return ""
 	}
 	if len(c.Enum) > 0 {
 		return "[one of: " + strings.Join(c.Enum, ", ") + "]"
-	}
-	if c.Pattern != nil {
-		return "[matching " + c.Pattern.String() + "]"
 	}
 	return ""
 }

--- a/cmd/aileron/skill_launch_prompt_test.go
+++ b/cmd/aileron/skill_launch_prompt_test.go
@@ -28,14 +28,15 @@ func TestNewLaunchInputPrompter_TTYGate(t *testing.T) {
 }
 
 // linePrompter reads one line for the missing input and echoes the name,
-// description, and constraint hint so the operator knows what to type.
+// description, and the human-readable enum hint so the operator knows what to
+// type.
 func TestLinePrompter_PromptInput(t *testing.T) {
 	var out bytes.Buffer
 	p := linePrompter{stdin: strings.NewReader("us-east-1\n"), stdout: &out}
 	in := runtime.Input{
 		Name:        "region",
 		Description: "target AWS region",
-		Constraint:  &runtime.Constraint{Pattern: regexp.MustCompile("^us-[a-z]+-[0-9]$")},
+		Constraint:  &runtime.Constraint{Enum: []string{"us-east-1", "us-west-2"}},
 	}
 	got, err := p.PromptInput(in)
 	if err != nil {
@@ -45,10 +46,30 @@ func TestLinePrompter_PromptInput(t *testing.T) {
 		t.Errorf("prompted value = %q, want %q", got, "us-east-1")
 	}
 	prompt := out.String()
-	for _, want := range []string{"region", "target AWS region", "^us-[a-z]+-[0-9]$"} {
+	for _, want := range []string{"region", "target AWS region", "[one of: us-east-1, us-west-2]"} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("prompt %q missing %q", prompt, want)
 		}
+	}
+}
+
+// A pattern-constrained input must NOT echo the raw regex into the prompt: it is
+// meaningless noise to an operator (#2130). The pattern is still enforced on
+// submit by the runtime validator; the prompt just no longer prints it.
+func TestLinePrompter_PatternHidden(t *testing.T) {
+	var out bytes.Buffer
+	p := linePrompter{stdin: strings.NewReader("us-east-1\n"), stdout: &out}
+	in := runtime.Input{
+		Name:        "region",
+		Description: "target AWS region",
+		Constraint:  &runtime.Constraint{Pattern: regexp.MustCompile("^us-[a-z]+-[0-9]$")},
+	}
+	if _, err := p.PromptInput(in); err != nil {
+		t.Fatalf("PromptInput: %v", err)
+	}
+	prompt := out.String()
+	if strings.Contains(prompt, "^us-[a-z]+-[0-9]$") || strings.Contains(prompt, "[matching") {
+		t.Errorf("prompt %q must not surface the raw pattern", prompt)
 	}
 }
 
@@ -73,7 +94,12 @@ func TestInputConstraintHint(t *testing.T) {
 	}{
 		{"nil", nil, ""},
 		{"enum", &runtime.Constraint{Enum: []string{"prod", "staging"}}, "[one of: prod, staging]"},
-		{"pattern", &runtime.Constraint{Pattern: regexp.MustCompile("^x$")}, "[matching ^x$]"},
+		// A pattern-only constraint renders no hint: the raw regex is meaningless
+		// noise to an operator (#2130). The pattern is still enforced on submit;
+		// this only suppresses its display.
+		{"pattern-suppressed", &runtime.Constraint{Pattern: regexp.MustCompile("^x$")}, ""},
+		// Enum takes precedence and is still shown even when a pattern coexists.
+		{"enum-wins-over-pattern", &runtime.Constraint{Enum: []string{"a", "b"}, Pattern: regexp.MustCompile("^x$")}, "[one of: a, b]"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/aileron/skill_launch_walk.go
+++ b/cmd/aileron/skill_launch_walk.go
@@ -23,7 +23,7 @@ var newLaunchInputWalker = func(stdin *bufio.Reader, stdout io.Writer) runtime.I
 // launchInputWalker is the guided interactive input walk: it walks every
 // declared input in declaration order, prompting once per literal input
 // (name+description, required/optional marker, current default with
-// Enter-to-accept, enum/pattern hint), re-prompting on an invalid entry. It
+// Enter-to-accept, enum hint), re-prompting on an invalid entry. It
 // runs host-side, before container boot, so it feeds inputs into the sealed
 // (frozen-plan) mainline where the in-container prompter is never consulted.
 //
@@ -145,7 +145,7 @@ func (w launchInputWalker) walkLiteral(in runtime.Input) (any, bool, error) {
 // name ([name]), the declared description rendered bare after a leading space,
 // the required marker (with a "has default" note when the input carries one),
 // the current default with an Enter-to-accept note (defaulted inputs only), and
-// any enum/pattern hint.
+// any enum hint.
 func (w launchInputWalker) literalPrompt(in runtime.Input) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "[%s]", in.Name)

--- a/cmd/aileron/skill_launch_walk_test.go
+++ b/cmd/aileron/skill_launch_walk_test.go
@@ -216,8 +216,26 @@ func TestWalk_EmptyRequiredReprompts(t *testing.T) {
 	}
 }
 
-// A pattern-constrained input shows its hint in the prompt.
+// An enum-constrained input shows its human-readable hint in the prompt.
 func TestWalk_ConstraintHintShown(t *testing.T) {
+	w, out := newWalker("us-east-1\n")
+	inputs := []runtime.Input{{
+		Name:       "region",
+		Resolution: runtime.Resolution{Rule: runtime.ResolutionLiteral},
+		Constraint: &runtime.Constraint{Enum: []string{"us-east-1", "us-west-2"}},
+	}}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !strings.Contains(out.String(), "[one of: us-east-1, us-west-2]") {
+		t.Errorf("prompt must carry the enum hint:\n%s", out.String())
+	}
+}
+
+// A pattern-constrained input must NOT leak the raw regex into the walk prompt:
+// it is meaningless noise to an operator (#2130). The pattern is still enforced
+// on submit; the prompt just no longer prints it.
+func TestWalk_PatternHintHidden(t *testing.T) {
 	w, out := newWalker("us-east-1\n")
 	inputs := []runtime.Input{{
 		Name:       "region",
@@ -227,8 +245,8 @@ func TestWalk_ConstraintHintShown(t *testing.T) {
 	if _, err := w.Walk(inputs, nil); err != nil {
 		t.Fatalf("Walk: %v", err)
 	}
-	if !strings.Contains(out.String(), "^us-[a-z]+-[0-9]$") {
-		t.Errorf("prompt must carry the pattern hint:\n%s", out.String())
+	if strings.Contains(out.String(), "^us-[a-z]+-[0-9]$") || strings.Contains(out.String(), "[matching") {
+		t.Errorf("prompt must not surface the raw pattern:\n%s", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

The interactive `aileron skill launch` walk appended the raw input `Pattern` regex to constrained prompts, e.g.:

> aws_region (...) [optional] (default: us-east-1, Enter to accept) **[matching ^[a-z]{2}-[a-z]+-\d$]**

A raw regular expression is meaningless noise to an operator answering a prompt. This drops the pattern branch from `inputConstraintHint` (`cmd/aileron/skill_launch.go`) so a pattern-only constraint renders no hint.

- The **enum** branch is unchanged: `[one of: a, b, c]` is human-readable and stays.
- Enum still takes precedence when a pattern coexists.
- The pattern is **still enforced on submit** by the runtime validator; this change only governs prompt display.

Closes #2130

## Test plan

- Updated `TestInputConstraintHint`: pattern-only constraint now expects `""`; added an enum-wins-over-pattern case.
- Rewrote `TestLinePrompter_PromptInput` to assert the human-readable enum hint is echoed.
- Added `TestLinePrompter_PatternHidden`: a pattern-constrained input must not surface the raw regex or `[matching` in the prompt.
- `go build`, `go vet`, and the prompt test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ry97yqVynQ11zLzmwuFyGj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated interactive prompts to display available choices for enum-based inputs.
  * Removed regex pattern hints from prompts, keeping validation behavior unchanged.
  * When both enum and pattern constraints exist, prompts now show the available choices only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->