### PR TITLE
fix(launch): bracket input name and bare description in literal prompt

### DIFF
--- a/cmd/aileron/skill_launch_walk.go
+++ b/cmd/aileron/skill_launch_walk.go
@@ -141,15 +141,16 @@ func (w launchInputWalker) walkLiteral(in runtime.Input) (any, bool, error) {
 	}
 }
 
-// literalPrompt renders the one-line prompt for a literal input: its name, the
-// declared description, the required marker (with a "has default" note when the
-// input carries one), the current default with an Enter-to-accept note
-// (defaulted inputs only), and any enum/pattern hint.
+// literalPrompt renders the one-line prompt for a literal input: its bracketed
+// name ([name]), the declared description rendered bare after a leading space,
+// the required marker (with a "has default" note when the input carries one),
+// the current default with an Enter-to-accept note (defaulted inputs only), and
+// any enum/pattern hint.
 func (w launchInputWalker) literalPrompt(in runtime.Input) string {
 	var b strings.Builder
-	b.WriteString(in.Name)
+	fmt.Fprintf(&b, "[%s]", in.Name)
 	if in.Description != "" {
-		fmt.Fprintf(&b, " (%s)", in.Description)
+		fmt.Fprintf(&b, " %s", in.Description)
 	}
 	if in.Resolution.HasDefault {
 		b.WriteString(" [required · has default]")

--- a/cmd/aileron/skill_launch_walk_test.go
+++ b/cmd/aileron/skill_launch_walk_test.go
@@ -326,3 +326,25 @@ func TestWalk_NoPromptStillOverridable(t *testing.T) {
 		t.Errorf("an overridden input must not also render the advanced skip line:\n%s", s)
 	}
 }
+
+// The literal prompt brackets the input name ([name]) and renders the
+// declared description bare after a leading space, with no parentheses around
+// it. The trailing "(default: X, Enter to accept)" note keeps its parenthetical
+// form. This guards the interactive-launch prompt format specifically.
+func TestWalk_LiteralPromptBracketsNameBareDescription(t *testing.T) {
+	w, out := newWalker("\n") // accept the default
+	inputs := []runtime.Input{litDefault("aws_region", "The AWS region to target", "us-east-1")}
+	if _, err := w.Walk(inputs, nil); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "[aws_region] The AWS region to target") {
+		t.Errorf("prompt must bracket the name and render the description bare:\n%s", s)
+	}
+	if strings.Contains(s, "(The AWS region to target)") {
+		t.Errorf("the description must not be wrapped in parentheses:\n%s", s)
+	}
+	if !strings.Contains(s, "(default: us-east-1, Enter to accept)") {
+		t.Errorf("the default-note parenthetical must be preserved:\n%s", s)
+	}
+}


### PR DESCRIPTION
## Summary

The interactive launch walk (`aileron launch`) rendered a literal input's one-line prompt as `name (description)`. This changes `literalPrompt` in `cmd/aileron/skill_launch_walk.go` to:

- bracket the input name as `[name]`
- render the declared description bare after a leading space (no surrounding parentheses)

The trailing `(default: X, Enter to accept)` note is untouched and keeps its parenthetical form. Example rendering:

```
[aws_region] The AWS region to target [optional] (default: us-east-1, Enter to accept):
```

Scope is kept to `literalPrompt` per the issue's explicit intent. The sibling `advancedLine` / `readOnlyLine` informational lines are intentionally left in their existing `(desc)` form since the issue targets only the interactive launch prompt.

## Test plan

- Added regression test `TestWalk_LiteralPromptBracketsNameBareDescription` asserting the prompt contains `[aws_region] The AWS region to target`, does not wrap the description in parentheses, and preserves the `(default: us-east-1, Enter to accept)` parenthetical. Verified it fails on the pre-fix code and passes after.
- `go build ./cmd/aileron/`, `go vet ./cmd/aileron/`, and `go test ./cmd/aileron/` all pass.

Closes #2132
