### PR TITLE
fix(launch): make publisher-trust divergence note self-explanatory

### DIFF
--- a/cmd/aileron/skill_launch_publisher.go
+++ b/cmd/aileron/skill_launch_publisher.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
@@ -91,13 +92,93 @@ func (v keyringPublisherVerifier) VerifyPublisher(publisher string, signingKey e
 	}
 	if v.diag != nil {
 		if res.Conflict {
-			fmt.Fprintf(v.diag, "publisher %s trusted (key %s); note: owner-level and per-repo grants disagree on trusted keys for this publisher\n",
-				publisher, fingerprint(signingKey))
+			v.writeConflictDiag(publisher, signingKey, res)
 		} else {
 			fmt.Fprintf(v.diag, "publisher %s trusted (key %s)\n", publisher, fingerprint(signingKey))
 		}
 	}
 	return nil
+}
+
+// writeConflictDiag renders the owner-vs-per-repo trust-divergence note for a
+// launch that was PERMITTED. The prior one-liner ("... grants disagree ...")
+// read like a warning and gave the operator nothing to act on: it never said
+// the launch proceeded, never showed which fingerprints diverged, and offered
+// no reconcile path (#2139). This message leads with the permit decision, names
+// the diverging owner-level vs per-repo fingerprints (marking which set the
+// plan's signing key came from), and offers a concrete `keyring revoke` next
+// step for an operator who wants the two scopes to agree. It is purely
+// informational — nothing is broken and there is nothing to fix for
+// correctness (ADR-0013, ADR-0027).
+func (v keyringPublisherVerifier) writeConflictDiag(publisher string, signingKey ed25519.PublicKey, res cstore.PublisherTrustResult) {
+	signingFP := fingerprint(signingKey)
+	inPerRepo := containsKey(res.PerRepoKeys, signingKey)
+	scope := "owner-level"
+	if inPerRepo {
+		scope = "per-repo"
+	}
+
+	fmt.Fprintf(v.diag, "publisher %s trusted (key %s); %s proceeding\n",
+		publisher, signingFP, v.opLabel())
+	fmt.Fprintf(v.diag, "  note: the owner-level and per-repo trust scopes for this publisher list different keys, but the plan's signing key is trusted in the %s scope, so the %s was permitted. This is informational; nothing is wrong.\n",
+		scope, v.opLabel())
+	fmt.Fprintf(v.diag, "  owner-level (%s://%s): %s\n",
+		schemeOf(publisher), ownerOf(publisher), fingerprintList(res.OwnerKeys, signingKey))
+	fmt.Fprintf(v.diag, "  per-repo   (%s): %s\n",
+		publisher, fingerprintList(res.PerRepoKeys, signingKey))
+	fmt.Fprintf(v.diag, "  to reconcile so the scopes agree, revoke a stale key by fingerprint, e.g. `aileron keyring revoke --key <sha256:...>`\n")
+}
+
+// fingerprintList renders a keyset as a comma-separated list of fingerprints,
+// marking the plan's signing key with a trailing " (this plan)" so the operator
+// can see, at a glance, which side of the divergence authorized the launch.
+// Returns "(none)" for an empty scope.
+func fingerprintList(keys []ed25519.PublicKey, signingKey ed25519.PublicKey) string {
+	if len(keys) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		fp := fingerprint(k)
+		if k.Equal(signingKey) {
+			fp += " (this plan)"
+		}
+		parts = append(parts, fp)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// containsKey reports whether target is present in keys.
+func containsKey(keys []ed25519.PublicKey, target ed25519.PublicKey) bool {
+	for _, k := range keys {
+		if k.Equal(target) {
+			return true
+		}
+	}
+	return false
+}
+
+// schemeOf and ownerOf split a `<scheme>://<owner>/<repo>` publisher authority
+// into the parts of its owner-level authority (`<scheme>://<owner>`) for
+// display. They are best-effort: a string that doesn't match the expected shape
+// falls back to the whole input so the diagnostic never panics or drops
+// context on a malformed authority.
+func schemeOf(publisher string) string {
+	if i := strings.Index(publisher, "://"); i >= 0 {
+		return publisher[:i]
+	}
+	return publisher
+}
+
+func ownerOf(publisher string) string {
+	rest := publisher
+	if i := strings.Index(rest, "://"); i >= 0 {
+		rest = rest[i+3:]
+	}
+	if i := strings.Index(rest, "/"); i >= 0 {
+		return rest[:i]
+	}
+	return rest
 }
 
 // newLaunchPublisherVerifier builds the keyring-backed publisher-trust gate

--- a/cmd/aileron/skill_launch_publisher_test.go
+++ b/cmd/aileron/skill_launch_publisher_test.go
@@ -158,26 +158,80 @@ func TestKeyringPublisherVerifier_RevokedFailsClosed(t *testing.T) {
 // TestKeyringPublisherVerifier_ConflictNoteOnStderr proves the P2 conflict
 // diagnostic lands on the held diag (stderr) writer when the owner and per-repo
 // scopes disagree while membership passes, and the launch is still permitted.
+// It also proves the note is self-explanatory (#2139): it leads with the permit
+// decision, names both diverging fingerprint sets (marking which scope carried
+// the plan's key), and offers a reconcile path — none of which the prior terse
+// "grants disagree" one-liner did.
 func TestKeyringPublisherVerifier_ConflictNoteOnStderr(t *testing.T) {
-	shared, _ := genKeyPair(t)
-	ownerExtra, _ := genKeyPair(t)
+	planKey, _ := genKeyPair(t)   // per-repo scope; the plan's signing key
+	ownerKey, _ := genKeyPair(t)  // owner-level scope; the stale divergent key
 	dir := t.TempDir()
 	path := filepath.Join(dir, "keyring.json")
 	ring := cstore.NewEd25519Keyring()
-	ring.AddOwner("github://acme", shared)
-	ring.AddOwner("github://acme", ownerExtra)
-	ring.Add("github://acme/plans", shared)
+	ring.AddOwner("github://acme", ownerKey)
+	ring.Add("github://acme/plans", planKey)
 	if err := ring.SaveKeyring(path); err != nil {
 		t.Fatalf("SaveKeyring: %v", err)
 	}
 
 	var diag bytes.Buffer
 	v := keyringPublisherVerifier{path: path, diag: &diag}
-	if err := v.VerifyPublisher("github://acme/plans", shared); err != nil {
+	if err := v.VerifyPublisher("github://acme/plans", planKey); err != nil {
 		t.Fatalf("a conflict must not block a member key: %v", err)
 	}
-	if !strings.Contains(diag.String(), "disagree") {
-		t.Errorf("diag = %q, want a conflict note", diag.String())
+	out := diag.String()
+
+	// Leads with the permit decision, not an alarming "disagree".
+	if !strings.Contains(out, "trusted") || !strings.Contains(out, "proceeding") {
+		t.Errorf("diag = %q, want it to lead with the permit decision", out)
+	}
+	// Both diverging fingerprints appear so the operator can see what differs.
+	if !strings.Contains(out, fingerprint(ownerKey)) {
+		t.Errorf("diag = %q, want the owner-level fingerprint %s", out, fingerprint(ownerKey))
+	}
+	if !strings.Contains(out, fingerprint(planKey)) {
+		t.Errorf("diag = %q, want the per-repo fingerprint %s", out, fingerprint(planKey))
+	}
+	// The plan's key is marked so the operator sees which scope authorized it.
+	if !strings.Contains(out, "(this plan)") {
+		t.Errorf("diag = %q, want the plan's key marked", out)
+	}
+	// A reconcile path is offered.
+	if !strings.Contains(out, "keyring revoke") {
+		t.Errorf("diag = %q, want a reconcile hint", out)
+	}
+	// It states the note is benign.
+	if !strings.Contains(out, "informational") {
+		t.Errorf("diag = %q, want it to state the note is informational", out)
+	}
+}
+
+// TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope proves that when the
+// plan's signing key lives in the OWNER-level scope (and the per-repo scope
+// carries a different key), the note reports the owner scope as the authorizing
+// one — the mirror of the per-repo case — and still lists both sides.
+func TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope(t *testing.T) {
+	planKey, _ := genKeyPair(t)  // owner-level scope; the plan's signing key
+	repoKey, _ := genKeyPair(t)  // per-repo scope; a different key
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	ring := cstore.NewEd25519Keyring()
+	ring.AddOwner("github://acme", planKey)
+	ring.Add("github://acme/plans", repoKey)
+	if err := ring.SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+
+	var diag bytes.Buffer
+	v := keyringPublisherVerifier{path: path, diag: &diag}
+	if err := v.VerifyPublisher("github://acme/plans", planKey); err != nil {
+		t.Fatalf("a conflict must not block a member key: %v", err)
+	}
+	out := diag.String()
+	if !strings.Contains(out, "owner-level scope") {
+		t.Errorf("diag = %q, want the owner-level scope named as the authorizing one", out)
+	}
+	if !strings.Contains(out, fingerprint(repoKey)) {
+		t.Errorf("diag = %q, want the divergent per-repo fingerprint %s", out, fingerprint(repoKey))
 	}
 }
 

--- a/internal/cstore/publisher_trust_test.go
+++ b/internal/cstore/publisher_trust_test.go
@@ -111,6 +111,36 @@ func TestPublisherTrust_ConflictWhenScopesDiffer(t *testing.T) {
 	}
 }
 
+// TestPublisherTrust_ExposesScopeKeys proves the result carries a snapshot of
+// each scope's trusted keys (#2139) so a caller rendering the conflict
+// diagnostic can name the diverging fingerprints. OwnerKeys and PerRepoKeys are
+// copies, so a later keyring mutation must not alter an already-returned result.
+func TestPublisherTrust_ExposesScopeKeys(t *testing.T) {
+	planKey := mustGenKey(t)
+	ownerKey := mustGenKey(t)
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://acme", ownerKey)
+	ring.Add("github://acme/plans", planKey)
+
+	res, err := ring.PublisherTrust("github://acme/plans", planKey)
+	if err != nil {
+		t.Fatalf("PublisherTrust: %v", err)
+	}
+	if len(res.OwnerKeys) != 1 || !res.OwnerKeys[0].Equal(ownerKey) {
+		t.Errorf("OwnerKeys = %v, want the single owner-level key", res.OwnerKeys)
+	}
+	if len(res.PerRepoKeys) != 1 || !res.PerRepoKeys[0].Equal(planKey) {
+		t.Errorf("PerRepoKeys = %v, want the single per-repo key", res.PerRepoKeys)
+	}
+
+	// The snapshot must not alias the keyring's internal storage: adding a key
+	// after resolution must not grow the already-returned slice.
+	ring.AddOwner("github://acme", mustGenKey(t))
+	if len(res.OwnerKeys) != 1 {
+		t.Errorf("OwnerKeys grew to %d after a post-resolution keyring write; want a defensive copy", len(res.OwnerKeys))
+	}
+}
+
 // TestPublisherTrust_NoConflictWhenScopesAgree proves identical key sets in
 // both scopes trust the key with no conflict.
 func TestPublisherTrust_NoConflictWhenScopesAgree(t *testing.T) {

--- a/internal/cstore/verify.go
+++ b/internal/cstore/verify.go
@@ -159,6 +159,18 @@ type PublisherTrustResult struct {
 	// divergence observed at the launch gate, where a fetched-key-not-in-union
 	// is simply "refuse" (Trusted=false), not a conflict.
 	Conflict bool
+	// OwnerKeys is the snapshot of the owner-level grant's trusted keys
+	// (`<scheme>://<owner>`) at resolution time. Populated on every call so a
+	// caller rendering the Conflict diagnostic can name exactly which
+	// owner-level fingerprint(s) diverge from the per-repo scope, rather than
+	// only reporting that *something* differs. Empty when the owner scope has
+	// no grant (or the authority was malformed and owner derivation was
+	// skipped). A copy, not an alias into the keyring's internal map.
+	OwnerKeys []ed25519.PublicKey
+	// PerRepoKeys is the snapshot of the per-repo grant's trusted keys
+	// (`authority`) at resolution time, the per-repo counterpart to OwnerKeys.
+	// A copy, not an alias into the keyring's internal map.
+	PerRepoKeys []ed25519.PublicKey
 }
 
 // PublisherTrust resolves the Flight-Plan publisher's signing key against the
@@ -202,7 +214,12 @@ func (k *Ed25519Keyring) PublisherTrust(authority string, signingKey ed25519.Pub
 	if trusted && len(owner) > 0 && len(perRepo) > 0 && !keySetsEqual(owner, perRepo) {
 		conflict = true
 	}
-	return PublisherTrustResult{Trusted: trusted, Conflict: conflict}, nil
+	return PublisherTrustResult{
+		Trusted:     trusted,
+		Conflict:    conflict,
+		OwnerKeys:   owner,
+		PerRepoKeys: perRepo,
+	}, nil
 }
 
 // keySetContains reports whether target is present in keys.


### PR DESCRIPTION
## Summary

Closes #2139.

On `aileron skill launch`, when the operator's keyring trusts a plan's publisher at both the owner-level and per-repo scopes with **different** key sets (and the plan's signing key is a member of the union), launch is permitted and a divergence diagnostic is printed. The behavior is correct per ADR-0013's union rule; the **message** was the problem. The old one-liner:

```
publisher github://ALRubinger/aileron-octane trusted (key sha256:WWmZ…); note: owner-level and per-repo grants disagree on trusted keys for this publisher
```

read like a warning, never said the launch proceeded (or why), never showed which fingerprints diverged, and offered no remediation.

The new note:

```
publisher github://ALRubinger/aileron-octane trusted (key sha256:yq4iFDXsporEYx2hqft7Tk); launch proceeding
  note: the owner-level and per-repo trust scopes for this publisher list different keys, but the plan's signing key is trusted in the per-repo scope, so the launch was permitted. This is informational; nothing is wrong.
  owner-level (github://ALRubinger): sha256:fWBujuxnlVclq9wPVHX93O
  per-repo   (github://ALRubinger/aileron-octane): sha256:yq4iFDXsporEYx2hqft7Tk (this plan)
  to reconcile so the scopes agree, revoke a stale key by fingerprint, e.g. `aileron keyring revoke --key <sha256:...>`
```

It leads with the permit decision, states it is informational, lists both diverging fingerprint sets marking which scope authorized the launch, and offers a concrete `aileron keyring revoke --key` reconcile step.

### Changes

- `internal/cstore/verify.go`: `PublisherTrustResult` gains `OwnerKeys` / `PerRepoKeys` — defensive-copy snapshots of each scope's trusted keys, populated on every `PublisherTrust` call, so the CLI can name the exact diverging fingerprints.
- `cmd/aileron/skill_launch_publisher.go`: `writeConflictDiag` renders the new multi-line note; `op`-aware so it reads "launch proceeding" / "install proceeding". Best-effort `schemeOf`/`ownerOf` split the owner-level authority for display without panicking on a malformed authority.

### Scope

Only the wording/legibility of the existing diagnostic changed. The trust model (owner∪per-repo union, fail-closed-on-empty, `Conflict` computation) is untouched. No ADR change: ADR-0013/0027 describe the divergence as "surfaced as a diagnostic on stderr" without quoting the exact wording. Unrelated to #2138.

## Test plan

- `TestKeyringPublisherVerifier_ConflictNoteOnStderr` — rewritten to assert the note leads with the permit decision, names **both** diverging fingerprints, marks the plan's key `(this plan)`, states it is informational, and offers the `keyring revoke` hint.
- `TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope` — new; mirror case where the plan's key lives in the owner-level scope, asserting the note reports the owner scope as the authorizing one and still lists the divergent per-repo fingerprint.
- `TestPublisherTrust_ExposesScopeKeys` — new; asserts `OwnerKeys`/`PerRepoKeys` carry the correct snapshots and are defensive copies (a post-resolution keyring write must not grow an already-returned slice).
- `go test ./internal/cstore/ ./cmd/aileron/` green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nvjpg39gw66j5yofA7iWvi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved publisher trust conflict diagnostics with clearer scope details and key fingerprints.
  * Identifies the key authorizing the current plan.
  * Provides an actionable `keyring revoke` command for resolving conflicting trust settings.
  * Clarifies that conflict notices are informational while preserving fail-closed verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->