### PR TITLE
fix(launch): make publisher-trust divergence diagnostic reassuring and actionable

### DIFF
--- a/cmd/aileron/skill_launch_publisher.go
+++ b/cmd/aileron/skill_launch_publisher.go
@@ -91,13 +91,51 @@ func (v keyringPublisherVerifier) VerifyPublisher(publisher string, signingKey e
 	}
 	if v.diag != nil {
 		if res.Conflict {
-			fmt.Fprintf(v.diag, "publisher %s trusted (key %s); note: owner-level and per-repo grants disagree on trusted keys for this publisher\n",
-				publisher, fingerprint(signingKey))
+			writeConflictDiag(v.diag, publisher, signingKey, res)
 		} else {
 			fmt.Fprintf(v.diag, "publisher %s trusted (key %s)\n", publisher, fingerprint(signingKey))
 		}
 	}
 	return nil
+}
+
+// writeConflictDiag emits the owner-vs-per-repo publisher-trust divergence
+// note. The launch is already permitted (the plan's signing key is a member of
+// the union and res.Conflict was set only after Trusted passed), so the message
+// leads with that decision and states plainly that it is informational, never
+// alarming. It then lists both diverging scopes' fingerprints, marks which
+// scope carries this plan's signing key, and offers a concrete reconcile step:
+// `aileron keyring revoke --key <fp>` to drop whichever key material the
+// operator decides is stale. signingKey is the plan's verified key so the "(this
+// plan)" marker can be placed on the exact fingerprint the launch resolved to.
+func writeConflictDiag(w io.Writer, publisher string, signingKey ed25519.PublicKey, res cstore.PublisherTrustResult) {
+	planFP := fingerprint(signingKey)
+	fmt.Fprintf(w, "publisher %s trusted (key %s); launch proceeding.\n", publisher, planFP)
+	fmt.Fprintln(w, "note (informational, no action required): this publisher's owner-level and per-repo trust grants list different keys.")
+	fmt.Fprintln(w, "  owner-level grant:")
+	writeScopeKeys(w, res.OwnerKeys, planFP)
+	fmt.Fprintln(w, "  per-repo grant:")
+	writeScopeKeys(w, res.PerRepoKeys, planFP)
+	fmt.Fprintf(w, "  to reconcile, revoke the key you no longer trust: aileron keyring revoke --key <fp>\n")
+}
+
+// writeScopeKeys prints one indented line per trusted key in a scope, marking
+// the fingerprint that matches the plan's signing key with "(this plan)" so the
+// operator can see at a glance which scope authorized the running launch. An
+// empty scope prints "(none)".
+func writeScopeKeys(w io.Writer, keys []ed25519.PublicKey, planFP string) {
+	if len(keys) == 0 {
+		fmt.Fprintln(w, "    (none)")
+		return
+	}
+	for _, k := range keys {
+		fp := fingerprint(k)
+		if fp == planFP {
+			fmt.Fprintf(w, "    %s (this plan)\n", fp)
+		} else {
+			fmt.Fprintf(w, "    %s\n", fp)
+		}
+	}
 }
 
 // newLaunchPublisherVerifier builds the keyring-backed publisher-trust gate

--- a/cmd/aileron/skill_launch_publisher_test.go
+++ b/cmd/aileron/skill_launch_publisher_test.go
@@ -158,6 +158,9 @@ func TestKeyringPublisherVerifier_RevokedFailsClosed(t *testing.T) {
 // TestKeyringPublisherVerifier_ConflictNoteOnStderr proves the P2 conflict
 // diagnostic lands on the held diag (stderr) writer when the owner and per-repo
 // scopes disagree while membership passes, and the launch is still permitted.
+// The rewritten message (#2139) must lead with the permit decision, mark itself
+// informational rather than alarming, list both diverging scopes' fingerprints,
+// and offer the concrete `keyring revoke --key` reconcile step.
 func TestKeyringPublisherVerifier_ConflictNoteOnStderr(t *testing.T) {
 	shared, _ := genKeyPair(t)
 	ownerExtra, _ := genKeyPair(t)
@@ -176,8 +179,64 @@ func TestKeyringPublisherVerifier_ConflictNoteOnStderr(t *testing.T) {
 	if err := v.VerifyPublisher("github://acme/plans", shared); err != nil {
 		t.Fatalf("a conflict must not block a member key: %v", err)
 	}
-	if !strings.Contains(diag.String(), "disagree") {
-		t.Errorf("diag = %q, want a conflict note", diag.String())
+	out := diag.String()
+	// Leads with the permit decision, not an alarm.
+	if !strings.Contains(out, "trusted") || !strings.Contains(out, "launch proceeding") {
+		t.Errorf("diag = %q, want it to lead with the trusted/launch-proceeding decision", out)
+	}
+	// Framed as informational, no action required.
+	if !strings.Contains(out, "informational") || !strings.Contains(out, "no action required") {
+		t.Errorf("diag = %q, want it framed as informational with no action required", out)
+	}
+	// Names both diverging scopes.
+	if !strings.Contains(out, "owner-level grant") || !strings.Contains(out, "per-repo grant") {
+		t.Errorf("diag = %q, want both owner-level and per-repo scopes named", out)
+	}
+	// Lists each scope's actual fingerprints (owner has the extra key too).
+	if !strings.Contains(out, fingerprint(shared)) || !strings.Contains(out, fingerprint(ownerExtra)) {
+		t.Errorf("diag = %q, want both diverging fingerprints listed", out)
+	}
+	// Offers the concrete reconcile step.
+	if !strings.Contains(out, "aileron keyring revoke --key") {
+		t.Errorf("diag = %q, want the keyring revoke --key reconcile step", out)
+	}
+}
+
+// TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope proves that when the
+// plan's signing key lives only in the owner-level grant (not the per-repo
+// grant), the conflict note marks the owner-scope fingerprint "(this plan)" so
+// the operator sees which scope authorized the running launch. This is the
+// mirror of the per-repo case and guards that the marker follows the key, not a
+// fixed scope.
+func TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope(t *testing.T) {
+	ownerKey, _ := genKeyPair(t)   // the plan's signing key, owner-scope only
+	perRepoKey, _ := genKeyPair(t) // a different key trusted per-repo
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+	ring := cstore.NewEd25519Keyring()
+	ring.AddOwner("github://acme", ownerKey)
+	ring.Add("github://acme/plans", perRepoKey)
+	if err := ring.SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+
+	var diag bytes.Buffer
+	v := keyringPublisherVerifier{path: path, diag: &diag}
+	// The plan signs with the owner-scope key: it is a union member (owner
+	// grant), so trust passes, and the two scopes diverge, so Conflict fires.
+	if err := v.VerifyPublisher("github://acme/plans", ownerKey); err != nil {
+		t.Fatalf("an owner-scope member key must verify: %v", err)
+	}
+	out := diag.String()
+	ownerFP := fingerprint(ownerKey)
+	perRepoFP := fingerprint(perRepoKey)
+	// The owner-scope key carries the plan's key and must be marked.
+	if !strings.Contains(out, ownerFP+" (this plan)") {
+		t.Errorf("diag = %q, want the owner-scope fingerprint %s marked (this plan)", out, ownerFP)
+	}
+	// The per-repo key is a different key and must NOT be marked.
+	if strings.Contains(out, perRepoFP+" (this plan)") {
+		t.Errorf("diag = %q, per-repo fingerprint %s must not be marked (this plan)", out, perRepoFP)
 	}
 }
 

--- a/internal/cstore/publisher_trust_test.go
+++ b/internal/cstore/publisher_trust_test.go
@@ -186,3 +186,80 @@ func TestPublisherTrust_MalformedAuthorityStaysFailClosed(t *testing.T) {
 		t.Error("a malformed authority must not widen trust to an unregistered key")
 	}
 }
+
+// keysContain reports whether the fingerprint-equal key is present in the
+// snapshot slice, comparing by ed25519 value equality (not slice identity), so
+// the scope-exposure assertions do not depend on the keyring's internal order.
+func keysContain(keys []ed25519.PublicKey, target ed25519.PublicKey) bool {
+	for _, k := range keys {
+		if k.Equal(target) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPublisherTrust_ExposesScopeKeys proves the result carries defensive-copy
+// snapshots of both scopes' trusted keys (#2139) so the CLI can name the exact
+// diverging material in the conflict note. It checks membership per scope, that
+// the copies are independent of the keyring's internal slices (mutating the
+// returned slice does not affect a subsequent resolution), and that an empty
+// scope is a non-nil empty slice callers can range over unconditionally.
+func TestPublisherTrust_ExposesScopeKeys(t *testing.T) {
+	ownerKey := mustGenKey(t)
+	perRepoKey := mustGenKey(t)
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://acme", ownerKey)
+	ring.Add("github://acme/plans", perRepoKey)
+
+	res, err := ring.PublisherTrust("github://acme/plans", perRepoKey)
+	if err != nil {
+		t.Fatalf("PublisherTrust: %v", err)
+	}
+	if !res.Trusted || !res.Conflict {
+		t.Fatalf("expected trusted+conflict (both scopes non-empty and divergent); got %+v", res)
+	}
+	if !keysContain(res.OwnerKeys, ownerKey) {
+		t.Errorf("OwnerKeys = %v, want it to contain the owner-scope key", res.OwnerKeys)
+	}
+	if keysContain(res.OwnerKeys, perRepoKey) {
+		t.Errorf("OwnerKeys must not contain the per-repo-only key")
+	}
+	if !keysContain(res.PerRepoKeys, perRepoKey) {
+		t.Errorf("PerRepoKeys = %v, want it to contain the per-repo-scope key", res.PerRepoKeys)
+	}
+	if keysContain(res.PerRepoKeys, ownerKey) {
+		t.Errorf("PerRepoKeys must not contain the owner-only key")
+	}
+
+	// The snapshots are defensive copies: overwriting a returned slice element
+	// must not corrupt the keyring, so a subsequent resolution is unaffected.
+	if len(res.OwnerKeys) > 0 {
+		res.OwnerKeys[0] = nil
+	}
+	res2, err := ring.PublisherTrust("github://acme/plans", ownerKey)
+	if err != nil {
+		t.Fatalf("second PublisherTrust: %v", err)
+	}
+	if !res2.Trusted {
+		t.Error("mutating the first result's OwnerKeys copy must not alter keyring trust")
+	}
+	if !keysContain(res2.OwnerKeys, ownerKey) {
+		t.Errorf("OwnerKeys corrupted across calls: %v", res2.OwnerKeys)
+	}
+
+	// An empty scope is a non-nil empty slice, not nil, so callers may range
+	// over it without a guard. A per-repo-only grant leaves OwnerKeys empty.
+	perRepoOnly := NewEd25519Keyring()
+	perRepoOnly.Add("github://acme/plans", perRepoKey)
+	res3, err := perRepoOnly.PublisherTrust("github://acme/plans", perRepoKey)
+	if err != nil {
+		t.Fatalf("per-repo-only PublisherTrust: %v", err)
+	}
+	if res3.OwnerKeys == nil {
+		t.Error("OwnerKeys must be a non-nil empty slice for an empty owner scope")
+	}
+	if len(res3.OwnerKeys) != 0 {
+		t.Errorf("OwnerKeys = %v, want empty for a per-repo-only grant", res3.OwnerKeys)
+	}
+}

--- a/internal/cstore/verify.go
+++ b/internal/cstore/verify.go
@@ -159,6 +159,17 @@ type PublisherTrustResult struct {
 	// divergence observed at the launch gate, where a fetched-key-not-in-union
 	// is simply "refuse" (Trusted=false), not a conflict.
 	Conflict bool
+	// OwnerKeys is a defensive-copy snapshot of the owner-level grant's trusted
+	// keys (`<scheme>://<owner>`) at resolution time, and PerRepoKeys is the
+	// same for the per-repo grant (`authority`). Both are populated on every
+	// call (empty slice when the scope trusts nothing) so a caller can name the
+	// exact diverging key material — e.g. the launch-gate conflict diagnostic
+	// lists each scope's fingerprints and marks which one carries the plan's
+	// signing key. They are copies, not aliases of the keyring's internal
+	// slices, so a caller may hold or sort them without racing a concurrent
+	// keyring mutation.
+	OwnerKeys   []ed25519.PublicKey
+	PerRepoKeys []ed25519.PublicKey
 }
 
 // PublisherTrust resolves the Flight-Plan publisher's signing key against the
@@ -202,7 +213,23 @@ func (k *Ed25519Keyring) PublisherTrust(authority string, signingKey ed25519.Pub
 	if trusted && len(owner) > 0 && len(perRepo) > 0 && !keySetsEqual(owner, perRepo) {
 		conflict = true
 	}
-	return PublisherTrustResult{Trusted: trusted, Conflict: conflict}, nil
+	// owner and perRepo are already defensive copies of the keyring's internal
+	// slices (taken under the RLock above), so handing them to the caller does
+	// not alias keyring state. Normalize a nil owner (malformed or missing
+	// owner authority) to a non-nil empty slice so callers can range over it
+	// unconditionally.
+	if owner == nil {
+		owner = []ed25519.PublicKey{}
+	}
+	if perRepo == nil {
+		perRepo = []ed25519.PublicKey{}
+	}
+	return PublisherTrustResult{
+		Trusted:     trusted,
+		Conflict:    conflict,
+		OwnerKeys:   owner,
+		PerRepoKeys: perRepo,
+	}, nil
 }
 
 // keySetContains reports whether target is present in keys.


### PR DESCRIPTION
## Summary

The owner-vs-per-repo publisher-trust divergence note on `aileron skill launch` read as a terse alarm — `publisher X trusted (key …); note: owner-level and per-repo grants disagree on trusted keys for this publisher` — without telling the operator that the launch was permitted or how to reconcile the divergence. This rewrites it to:

- **Lead with the permit decision**: `publisher X trusted (key …); launch proceeding.`
- **State it is informational**: `note (informational, no action required): …`
- **List both diverging scopes' fingerprints**, marking which scope carries this plan's key with `(this plan)`.
- **Offer a concrete reconcile step**: `aileron keyring revoke --key <fp>` (a command that already exists).

To name the exact diverging material, `PublisherTrustResult` (`internal/cstore/verify.go`) gains defensive-copy `OwnerKeys` / `PerRepoKeys` snapshots. The existing resolution already made per-scope copies under the read lock, so this exposes them (normalized to non-nil empty slices) without changing the trust model — union / fail-closed / `Conflict` semantics are untouched, so no ADR change.

Example new output when the scopes diverge:

```
publisher github://acme/plans trusted (key sha256:AAAA…); launch proceeding.
note (informational, no action required): this publisher's owner-level and per-repo trust grants list different keys.
  owner-level grant:
    sha256:AAAA… (this plan)
    sha256:BBBB…
  per-repo grant:
    sha256:AAAA… (this plan)
  to reconcile, revoke the key you no longer trust: aileron keyring revoke --key <fp>
```

## Test plan

- Rewrote `TestKeyringPublisherVerifier_ConflictNoteOnStderr` to assert the new message shape (leads with trusted/launch-proceeding, framed informational/no-action-required, names both scopes with their real fingerprints, offers the `keyring revoke --key` step).
- Added `TestKeyringPublisherVerifier_ConflictNoteMarksOwnerScope` — the `(this plan)` marker follows the plan's key into the owner scope, not a fixed scope, and does not mark the other scope's differing key.
- Added `TestPublisherTrust_ExposesScopeKeys` (cstore) — both scope snapshots are populated, are defensive copies (mutating a returned slice does not corrupt keyring trust across calls), and an empty scope is a non-nil empty slice.
- `go build`, `go vet`, and full `./cmd/aileron/... ./internal/cstore/...` suites all green.

Closes #2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nvjpg39gw66j5yofA7iWvi