### PR TITLE
fix(freeze): re-attest host pin from daemon-loaded image so freeze→launch boots

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/cli/progress"
@@ -460,9 +461,10 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 	// LocalTag; buildx reuses the layer cache, so it is cheap. This host-arch daemon
 	// image is intentionally retained: local `launch` of an un-published Flight Plan
 	// resolves the composed image straight from the daemon under LocalTag, with no
-	// publish step in between. Publish itself no longer needs it: as of S4 (#2047)
-	// it consumes the OCI layout directly. Dropping this second build is a documented
-	// launch-side follow-up, not done here.
+	// publish step in between, AND freeze re-attests the host pin from this exact
+	// image below (#2138) so the boot guard's observed digest equals the recorded
+	// want by construction. Publish itself no longer needs it: as of S4 (#2047) it
+	// consumes the OCI layout directly.
 	loadOpts := buildOpts
 	loadOpts.Platforms = nil
 	loadOpts.OCILayoutDest = ""
@@ -486,12 +488,59 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, base string, fe
 		loadInd.Done("Loaded image into local daemon")
 	}
 
+	// Re-attest the host-platform entry from the daemon-loaded image itself
+	// (issue #2138). The per-arch digests above come from the multi-arch buildx
+	// OCI-layout build on the dedicated docker-container driver; the daemon-load
+	// build just run is a SECOND, independent build on the default docker driver
+	// with a separate layer cache. Composed layers are not bit-reproducible, so
+	// the host child's diff_ids (and thus its config content digest) can differ
+	// between the two builds. Local launch of an unpublished plan boots the
+	// daemon-loaded LocalTag and the #1863 boot guard resolves it through the
+	// SAME localImageContentDigest used here, so unless the recorded host pin is
+	// taken from the daemon image, `observed != want` fires on a freeze->launch
+	// with nothing rebuilt. Overwrite the host entry with the daemon image's
+	// content digest so observed == want on the host by construction; the other
+	// arch and the publish/cross-machine path keep the OCI-layout digests, and
+	// the guard stays fully fail-closed for a genuine post-freeze rebuild.
+	hostDigest, err := in.localImageContentDigest(ctx, localTag)
+	if err != nil {
+		return nil, fmt.Errorf("resolve daemon-loaded composed image digest for %q: %w", localTag, err)
+	}
 	out := make([]freeze.PlatformDigest, 0, len(perArch))
+	hostArch := hostComposedArch()
+	replaced := false
 	for _, p := range perArch {
-		out = append(out, freeze.PlatformDigest{OS: p.OS, Arch: p.Arch, Digest: p.Digest})
+		digest := p.Digest
+		if p.OS == composedImageOS && p.Arch == hostArch {
+			digest = hostDigest
+			replaced = true
+		}
+		out = append(out, freeze.PlatformDigest{OS: p.OS, Arch: p.Arch, Digest: digest})
+	}
+	// The multi-arch build always produces the host child (composition builds for
+	// both linux/amd64 and linux/arm64, one of which is the host), so a missing
+	// host entry means the OCI-layout read and the daemon build disagree on which
+	// platforms exist — a fail-closed error rather than a silent single-source pin.
+	if !replaced {
+		return nil, fmt.Errorf(
+			"compose environment tools: multi-arch layout carried no %s/%s child to re-attest from the daemon-loaded image %q",
+			composedImageOS, hostArch, localTag)
 	}
 	return out, nil
 }
+
+// composedImageOS is the operating system every composed container image is
+// built for. imgconfig.CanonicalConfig.OS for a container image is "linux"
+// regardless of the launching host GOOS, matching the platform vocabulary the
+// freeze producer and the launch boot guard key on (freeze.hostPlatform).
+const composedImageOS = "linux"
+
+// hostComposedArch returns the architecture whose composed config digest the
+// launch boot guard selects for this host: the host GOARCH. It mirrors the
+// platform key freeze/launch use to pick the host entry from a composed pin's
+// per-arch set, so the daemon-loaded image re-attested here lands on the exact
+// entry the boot guard later compares against.
+func hostComposedArch() string { return goruntime.GOARCH }
 
 // localImageContentDigest resolves a local image tag to its serialization-
 // agnostic config content digest (see internal/flightplan/imgconfig): a hash

--- a/cmd/aileron/skill_freeze_boot_integration_test.go
+++ b/cmd/aileron/skill_freeze_boot_integration_test.go
@@ -100,9 +100,11 @@ func TestFlightPlanComposedToolsBootGuard(t *testing.T) {
 	// builderFeatureComposer -> container.Builder + composition.ToolsPlan, which
 	// BUILDS a genuine multi-architecture composed image via docker buildx (both
 	// linux/amd64 and linux/arm64), reads the per-arch serialization-agnostic
-	// config content digests back from the built OCI layout, and loads the composed
-	// image into the local daemon under LocalTag. The produced pin carries the
-	// bootable LocalTag and a per-arch config-digest set. This path needs buildx +
+	// config content digests back from the built OCI layout, loads the composed
+	// image into the local daemon under LocalTag, and re-attests the host-arch pin
+	// from that daemon-loaded image (#2138) so the boot guard observes exactly what
+	// freeze recorded. The produced pin carries the bootable LocalTag and a
+	// per-arch config-digest set. This path needs buildx +
 	// the QEMU emulators + the containerd image store on the CI host; provisioning
 	// that emulated build environment is owned by the S5 CI job (#2036).
 	raw, err := os.ReadFile(exampleManifestPath(t))

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -211,7 +212,12 @@ func TestRunSkillFreeze_MultiArchRecordsBothArchesInLock(t *testing.T) {
 		{OS: "linux", Arch: "amd64", Digest: amd},
 		{OS: "linux", Arch: "arm64", Digest: arm},
 	})
-	fr := &fakeRunner{outputs: buildxPreflightOK()}
+	// The host arch's entry is re-attested from the daemon-loaded image (#2138),
+	// so its recorded digest is the content digest of this inspect body, not the
+	// OCI-layout value. The other arch keeps its OCI-layout digest.
+	inspect := dockerInspectJSON(t, "multiarch-lock-daemon-image")
+	hostDigest := wantContentDigestFromDocker(t, inspect)
+	fr := &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: inspect}
 	withFakeInspector(t, fr)
 
 	var stdout, stderr bytes.Buffer
@@ -229,7 +235,13 @@ func TestRunSkillFreeze_MultiArchRecordsBothArchesInLock(t *testing.T) {
 		t.Fatalf("ReadFrozen: %v", err)
 	}
 	lf := string(v.Lockfile)
-	for _, want := range []string{"arch: amd64", "arch: arm64", amd, arm} {
+	// Both arch keys are recorded, the host arch pins the re-attested daemon
+	// digest, and the non-host arch pins its OCI-layout digest.
+	nonHost := arm
+	if goruntime.GOARCH == "arm64" {
+		nonHost = amd
+	}
+	for _, want := range []string{"arch: amd64", "arch: arm64", hostDigest, nonHost} {
 		if !strings.Contains(lf, want) {
 			t.Errorf("lockfile must record %q for the multi-arch pin:\n%s", want, lf)
 		}
@@ -294,7 +306,7 @@ func TestRunSkillFreeze_IndicatorDrivenAcrossPullAndBuilds(t *testing.T) {
 		{OS: "linux", Arch: "arm64", Digest: "sha256:" + strings.Repeat("b", 64)},
 	})
 	gr := &genericInspectRunner{
-		fakeRunner: &fakeRunner{outputs: buildxPreflightOK()},
+		fakeRunner: &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: dockerInspectJSON(t, "indicator-daemon-image")},
 		repoDigest: "sha256:" + strings.Repeat("c", 64),
 	}
 
@@ -361,7 +373,7 @@ func TestRunSkillFreeze_QuietSuppressesProgress(t *testing.T) {
 		{OS: "linux", Arch: "arm64", Digest: "sha256:" + strings.Repeat("b", 64)},
 	})
 	gr := &genericInspectRunner{
-		fakeRunner: &fakeRunner{outputs: buildxPreflightOK()},
+		fakeRunner: &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: dockerInspectJSON(t, "quiet-daemon-image")},
 		repoDigest: "sha256:" + strings.Repeat("c", 64),
 	}
 
@@ -1028,7 +1040,12 @@ type fakeRunner struct {
 	outputs map[string]string
 	// fails maps a join of the args to an error the command returns.
 	fails map[string]error
-	calls []string
+	// inspectJSON, when non-empty, is written as the body of any
+	// `image inspect --format {{json .}} <ref>` command regardless of the ref,
+	// so a composer/launch test can answer the daemon-loaded composed image's
+	// content-digest read (#2138) without scripting the content-derived local tag.
+	inspectJSON string
+	calls       []string
 	// callEnvs is parallel to calls: the per-invocation env each command saw
 	// (nil for a plain Run), so a test can assert a scoped BUILDX_BUILDER
 	// selection reached the multi-arch build but not the daemon-load build.
@@ -1050,6 +1067,14 @@ func (f *fakeRunner) RunWithEnv(_ context.Context, _ string, args, env []string,
 	}
 	if out, ok := f.outputs[key]; ok {
 		_, _ = stdout.Write([]byte(out))
+		return nil
+	}
+	// Answer the daemon-loaded composed image's content-digest read (#2138): the
+	// re-attest inspects `image inspect --format {{json .}} <localTag>`, and the
+	// tag is content-derived, so match on the command shape rather than the exact
+	// tag when an inspectJSON body is configured.
+	if f.inspectJSON != "" && strings.Contains(key, "image inspect --format {{json .}}") {
+		_, _ = stdout.Write([]byte(f.inspectJSON))
 	}
 	return nil
 }
@@ -1230,14 +1255,17 @@ func TestBuilderFeatureComposer_ResolvesHostNPXToolchain(t *testing.T) {
 		{OS: "linux", Arch: "amd64", Digest: amd},
 		{OS: "linux", Arch: "arm64", Digest: arm},
 	})
-	fr := &fakeRunner{outputs: buildxPreflightOK()}
+	inspect := dockerInspectJSON(t, "host-npx-daemon-image")
+	hostDigest := wantContentDigestFromDocker(t, inspect)
+	fr := &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: inspect}
 	withFakeInspector(t, fr)
 
 	got, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), "base@"+fakeFreezeDigest, []string{"aws-cli"})
 	if err != nil {
 		t.Fatalf("ComposeDigest with host-npx toolchain: %v", err)
 	}
-	assertTwoArchDigests(t, got, amd, arm)
+	// The host arch's entry is re-attested from the daemon-loaded image (#2138).
+	assertTwoArchDigests(t, got, amd, arm, hostDigest)
 }
 
 // TestBuilderFeatureComposer_ScopesFreezeBuilder is the regression guard for
@@ -1254,7 +1282,8 @@ func TestBuilderFeatureComposer_ScopesFreezeBuilder(t *testing.T) {
 	})
 	// The freeze builder is absent, so the preflight must create it exactly once.
 	fr := &fakeRunner{
-		outputs: buildxPreflightOK(),
+		outputs:     buildxPreflightOK(),
+		inspectJSON: dockerInspectJSON(t, "scoped-builder-daemon-image"),
 		fails: map[string]error{
 			"buildx inspect " + container.FreezeBuilderName: errors.New("no builder named aileron-freeze"),
 		},
@@ -1332,17 +1361,94 @@ func TestBuilderFeatureComposer_ManagedToolchainWiresProvisioner(t *testing.T) {
 		{OS: "linux", Arch: "amd64", Digest: amd},
 		{OS: "linux", Arch: "arm64", Digest: arm},
 	})
-	fr := &fakeRunner{outputs: buildxPreflightOK()}
+	inspect := dockerInspectJSON(t, "managed-daemon-image")
+	hostDigest := wantContentDigestFromDocker(t, inspect)
+	fr := &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: inspect}
 	withFakeInspector(t, fr)
 
 	got, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), "base@"+fakeFreezeDigest, []string{"aws-cli"})
 	if err != nil {
 		t.Fatalf("ComposeDigest with managed toolchain + escape hatch: %v", err)
 	}
-	assertTwoArchDigests(t, got, amd, arm)
+	// The host arch's entry is re-attested from the daemon-loaded image (#2138).
+	assertTwoArchDigests(t, got, amd, arm, hostDigest)
 }
 
-func assertTwoArchDigests(t *testing.T, got []freeze.PlatformDigest, amd, arm string) {
+// TestBuilderFeatureComposer_HostPinReattestedFromDaemonImage is the #2138
+// regression guard. Freeze runs TWO independent builds: the multi-arch buildx
+// OCI-layout build (whose per-arch config digests are the OCI-layout values) and
+// a second daemon-load build on the default docker driver. Composed layers are
+// not bit-reproducible, so the daemon-loaded host image's config content digest
+// can DIFFER from the OCI-layout host digest. Local (no-publish) launch boots the
+// daemon image under LocalTag and the #1863 boot guard resolves it through the
+// SAME localImageContentDigest, so unless the recorded host pin comes from the
+// daemon image, observed != want and a fresh freeze->launch refuses to boot with
+// nothing rebuilt.
+//
+// This test wires the OCI-layout host digest to a value that DIFFERS from the
+// daemon inspect's content digest and asserts the composer records the DAEMON
+// digest for the host arch (and keeps the OCI-layout digest for the other arch).
+// Before the fix the composer recorded the OCI-layout host digest verbatim, so
+// this assertion fails; after the fix the host pin equals exactly what the boot
+// guard observes, so observed == want by construction.
+func TestBuilderFeatureComposer_HostPinReattestedFromDaemonImage(t *testing.T) {
+	t.Setenv(container.ToolchainModeEnv, container.ToolchainModeHostNPX)
+
+	// OCI-layout host digest deliberately unequal to the daemon image's digest,
+	// standing in for the non-reproducible-build diff_id divergence.
+	ociAMD := "sha256:" + strings.Repeat("1", 64)
+	ociARM := "sha256:" + strings.Repeat("2", 64)
+	stubOCILayoutDigests(t, []ociremote.PlatformConfigDigest{
+		{OS: "linux", Arch: "amd64", Digest: ociAMD},
+		{OS: "linux", Arch: "arm64", Digest: ociARM},
+	})
+	inspect := dockerInspectJSON(t, "reattest-daemon-image")
+	daemonDigest := wantContentDigestFromDocker(t, inspect)
+
+	ociHost := ociARM
+	if goruntime.GOARCH == "amd64" {
+		ociHost = ociAMD
+	}
+	if daemonDigest == ociHost {
+		t.Fatalf("test precondition: the daemon digest %q must differ from the OCI-layout host digest to exercise the divergence", daemonDigest)
+	}
+
+	fr := &fakeRunner{outputs: buildxPreflightOK(), inspectJSON: inspect}
+	withFakeInspector(t, fr)
+
+	got, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), "base@"+fakeFreezeDigest, []string{"aws-cli"})
+	if err != nil {
+		t.Fatalf("ComposeDigest: %v", err)
+	}
+
+	byArch := map[string]string{}
+	for _, p := range got {
+		byArch[p.Arch] = p.Digest
+	}
+	// The host arch pins the re-attested daemon digest (the value the boot guard
+	// will observe), NOT the OCI-layout host digest.
+	if byArch[goruntime.GOARCH] != daemonDigest {
+		t.Errorf("host arch %s pin = %q, want the daemon-loaded image digest %q (re-attested per #2138), not the OCI-layout digest %q",
+			goruntime.GOARCH, byArch[goruntime.GOARCH], daemonDigest, ociHost)
+	}
+	// The non-host arch keeps its OCI-layout digest (the daemon-load build only
+	// loads the host arch, so the other arch has no daemon image to re-attest).
+	otherArch, otherOCI := "arm64", ociARM
+	if goruntime.GOARCH == "arm64" {
+		otherArch, otherOCI = "amd64", ociAMD
+	}
+	if byArch[otherArch] != otherOCI {
+		t.Errorf("non-host arch %s pin = %q, want its OCI-layout digest %q unchanged", otherArch, byArch[otherArch], otherOCI)
+	}
+}
+
+// assertTwoArchDigests asserts the composer returned both arch entries with the
+// expected digests. The host arch's entry is re-attested from the daemon-loaded
+// image (#2138), so its expected value is hostDigest (the content digest of the
+// runner's inspectJSON) rather than the OCI-layout value amd/arm. The non-host
+// arch keeps its OCI-layout digest. A hostDigest of "" means the test did not
+// configure a daemon inspect, so the OCI-layout value is expected on both arches.
+func assertTwoArchDigests(t *testing.T, got []freeze.PlatformDigest, amd, arm, hostDigest string) {
 	t.Helper()
 	if len(got) != 2 {
 		t.Fatalf("want two per-arch digests, got %+v", got)
@@ -1351,11 +1457,20 @@ func assertTwoArchDigests(t *testing.T, got []freeze.PlatformDigest, amd, arm st
 	for _, p := range got {
 		byArch[p.Arch] = p.Digest
 	}
-	if byArch["amd64"] != amd {
-		t.Errorf("amd64 digest = %q, want %q", byArch["amd64"], amd)
+	wantAMD, wantARM := amd, arm
+	if hostDigest != "" {
+		switch goruntime.GOARCH {
+		case "amd64":
+			wantAMD = hostDigest
+		case "arm64":
+			wantARM = hostDigest
+		}
 	}
-	if byArch["arm64"] != arm {
-		t.Errorf("arm64 digest = %q, want %q", byArch["arm64"], arm)
+	if byArch["amd64"] != wantAMD {
+		t.Errorf("amd64 digest = %q, want %q", byArch["amd64"], wantAMD)
+	}
+	if byArch["arm64"] != wantARM {
+		t.Errorf("arm64 digest = %q, want %q", byArch["arm64"], wantARM)
 	}
 }
 

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -40,8 +40,12 @@ type FeatureComposer interface {
 	// serialization-agnostic config content digests (one PlatformDigest per built
 	// platform, e.g. linux/amd64 and linux/arm64). The freeze producer records the
 	// whole set as the composed pin's ConfigDigests, so a plan launches on either
-	// architecture (ADR-0027, issue #2036). Every entry's Digest MUST be a
-	// `sha256:` content digest; a tag is rejected.
+	// architecture (ADR-0027, issue #2036). The host-platform entry is attested
+	// from the image the daemon-load build actually loaded under LocalTag, which is
+	// the exact image the local (no-publish) launch boots and re-checks, so the
+	// boot guard's observed digest equals the recorded pin by construction (issue
+	// #2138). Every entry's Digest MUST be a `sha256:` content digest; a tag is
+	// rejected.
 	ComposeDigest(ctx context.Context, base string, features []string) ([]PlatformDigest, error)
 }
 

--- a/internal/flightplan/runtime/image.go
+++ b/internal/flightplan/runtime/image.go
@@ -83,12 +83,15 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 	// boot therefore trusts the LocalTag string; nothing else re-checks that the
 	// daemon image behind that tag STILL resolves to the attested Digest. When a
 	// resolver is wired, re-inspect the tag in the local daemon and fail closed
-	// unless it resolves to pin.Digest: a mismatch means the local tag was
-	// rebuilt or repointed since freeze, and a resolve error means the attested
-	// image is gone. Either way the boot must refuse rather than enter an
-	// unverified environment. The guard is scoped to composed pins: for an
-	// image-only / custom-base pin the boot target is content-addressed
-	// (`ref@digest`) and the daemon resolves the digest itself, so no local-Id
+	// unless it resolves to the attested host config digest: a mismatch means the
+	// local tag was rebuilt or repointed since freeze, and a resolve error means
+	// the attested image is gone. Either way the boot must refuse rather than
+	// enter an unverified environment, and the error names `aileron skill freeze`
+	// as the recovery verb. Freeze re-attests the host pin from this same
+	// daemon-loaded image (#2138), so a fresh freeze->launch always satisfies the
+	// guard; only a genuine post-freeze mutation trips it. The guard is scoped to
+	// composed pins: for an image-only / custom-base pin the boot target is
+	// content-addressed (`ref@digest`) and the daemon resolves the digest itself, so no local-Id
 	// comparison applies. A nil resolver skips the guard (backward-compatible).
 	//
 	// The boot target stays the LocalTag (imageRef's LocalTag-wins semantics,
@@ -113,12 +116,12 @@ func runInImage(ctx context.Context, lp LoadedPlan, opts Options) (RunResult, er
 		observed, err := opts.ImageDigestResolver.Resolve(ctx, pin.LocalTag)
 		if err != nil {
 			return RunResult{}, fmt.Errorf(
-				"flightplan: refusing to boot composed local tag %q: cannot resolve its digest in the local daemon (attested %s): %w",
+				"flightplan: refusing to boot composed local tag %q: cannot resolve its digest in the local daemon (attested %s); the frozen image may have been removed — re-run `aileron skill freeze` for this plan to rebuild and re-attest it: %w",
 				pin.LocalTag, want, err)
 		}
 		if observed != want {
 			return RunResult{}, fmt.Errorf(
-				"flightplan: refusing to boot composed local tag %q: it resolves to %s but the signed lock attested %s; the local image was rebuilt or repointed since freeze",
+				"flightplan: refusing to boot composed local tag %q: the local image now resolves to config digest %s but the signed lock attested %s, so the tag no longer points at the frozen environment; re-run `aileron skill freeze` for this plan to re-attest the current local image",
 				pin.LocalTag, observed, want)
 		}
 	}


### PR DESCRIPTION
## Summary

The author-side happy path — `skill install` → `skill freeze` → `skill launch`, back-to-back on one machine with no publish — refused to boot, blaming a "local image rebuilt or repointed since freeze" that the operator never touched (#2138). This is the no-publish sibling of #2127; #2129's registry-origin fix only cured the post-publish path.

Root cause: `builderFeatureComposer.ComposeDigest` runs **two independent builds** and the #1863 boot guard compares digests taken from **different** builds:

- The attested per-arch config digests (`want`) come from the multi-arch buildx **OCI-layout build** on the dedicated `docker-container` driver.
- The boot-time `observed` digest comes from a **separate** single-arch **daemon-load** build on the default `docker` driver, resolved at launch via `localImageContentDigest`.

The content-digest projection includes `rootfs.diff_ids`. The two builds use different buildkit drivers with separate layer caches, and composed layers are not bit-reproducible, so the host child's `diff_ids` (and thus its config content digest) can differ. When they do, `observed != want` and the guard refuses to boot — with nothing rebuilt.

### Fix (option A from the triage decision)

After the daemon-load build, resolve the loaded `LocalTag` through the **same** `localImageContentDigest` the boot guard uses and record that as the **host-platform** entry in `ConfigDigests`. The other arch and the publish/cross-machine path keep the OCI-layout digests, so `observed == want` on the host by construction while the #1863 guard stays fully fail-closed for a genuine post-freeze rebuild. No new origin kind, no boot-target-semantics change.

Also (Q2) reword the guard's mismatch and resolve-error messages to state what actually diverged and name `aileron skill freeze` as the recovery verb, instead of asserting the operator rebuilt the image.

## Test plan

- New regression `TestBuilderFeatureComposer_HostPinReattestedFromDaemonImage`: builds a composed plan with the OCI-layout host digest deliberately unequal to the daemon image's digest (standing in for the non-reproducible-build diff_id divergence) and asserts the recorded host pin equals the **daemon** digest and the non-host arch keeps its OCI-layout digest. Verified it **fails before** the fix (recorded the OCI-layout digest) and **passes after**.
- Existing freeze composer tests updated to answer the new daemon-image content-digest read and to expect the re-attested host digest (`assertTwoArchDigests` now takes the host digest; multi-arch-lock test asserts the re-attested host pin plus the non-host OCI-layout pin).
- Runtime boot-guard tests (`TestRunInImage_*`) unchanged and green; the reworded messages still name the tag and both digests.
- `go test ./...` green for `cmd/aileron` and all `internal/flightplan/...` packages; `gofmt`/`go vet` clean.
- The real-container freeze→boot linkage remains covered by the `integration_sandbox_multiarch` `TestFlightPlanComposedToolsBootGuard` (docker/buildx/QEMU-gated in CI), whose prose is updated to note the host-arch re-attest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nvjpg39gw66j5yofA7iWvi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-architecture image pinning by validating the host-platform digest against the image loaded locally.
  - Prevented launches from using mismatched or stale composed-image digests.
  - Added clearer error messages when local image verification fails, including guidance to rerun `aileron skill freeze`.

- **Documentation**
  - Clarified how image digests are attested, validated, and used during composed-image publishing and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->