### PR TITLE
fix(freeze): surface publisher key and warn on committed-key divergence

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -74,7 +74,7 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	raw, err := readSkillForFreeze(target)
+	raw, srcPath, err := readSkillForFreeze(target)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -130,7 +130,126 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
 	fmt.Fprintf(stdout, "  Stored at:   %s\n", s.FrozenDir(res.Name, id))
+
+	// When a publisher is attributed, the frozen plan's launch-time trust gate
+	// resolves the consumer's committed `keys/publisher.pub` (seeded by
+	// `keyring trust github://owner/repo`). Freeze has just computed and stored
+	// the matching signing-key.pub; surface it here so the committed pubkey is a
+	// byproduct of freezing rather than a manual afterthought, and warn loudly
+	// when an existing committed key in the source repo has diverged from it.
+	if *publisher != "" {
+		surfacePublisherKey(stdout, s.FrozenDir(res.Name, id), srcPath, res.PublicKey)
+	}
 	return 0
+}
+
+// publisherKeyRepoPath is the repo-relative path a consumer commits the
+// publisher public key at and that `keyring trust github://owner/repo` fetches.
+// It mirrors cmd/aileron/keyring.go's publisherKeyPath so the surfaced hint and
+// the launch-time gate agree on one location.
+const publisherKeyRepoPath = "keys/publisher.pub"
+
+// signingKeyPubFile is the file name freeze persists the derived signing-key
+// public key under inside each frozen version directory (store's
+// frozenPublicKeyFile). Surfacing it lets an author copy the exact bytes the
+// launch gate will verify into their repo's committed publisher key.
+const signingKeyPubFile = "signing-key.pub"
+
+// surfacePublisherKey prints where freeze stored the derived signing-key.pub and
+// the exact repo path a consumer seeds via `keyring trust`, plus a copy hint. It
+// then reconciles against any key already committed in the freeze source repo:
+// when the source was a filesystem path, it walks up from the SKILL.md dir to a
+// bounded repo root looking for a committed keys/publisher.pub. A committed key
+// whose ed25519 bytes differ from the freshly derived key is a STALE-key
+// divergence (the launch trust gate will fail closed for consumers), surfaced as
+// a prominent NON-FATAL warning with the fix. An absent key gets a create hint.
+// When frozen from an installed skill name (srcPath == ""), there is no repo to
+// reconcile, so only the surface + generic recommit hint prints.
+func surfacePublisherKey(stdout io.Writer, frozenDir, srcPath string, derivedPubPEM []byte) {
+	storedPub := filepath.Join(frozenDir, signingKeyPubFile)
+	fmt.Fprintf(stdout, "  Publisher key: %s\n", storedPub)
+	fmt.Fprintf(stdout, "    Consumers trust this plan by committing it to %q in your repo\n", publisherKeyRepoPath)
+
+	committed, ok := findCommittedPublisherKey(srcPath)
+	if !ok {
+		// No repo path to reconcile (installed-name source) or no committed key
+		// found on the ascent: point the author at the copy that makes the key a
+		// byproduct of freezing.
+		fmt.Fprintf(stdout, "    Commit it as %s:\n", publisherKeyRepoPath)
+		fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, publisherKeyRepoPath)
+		return
+	}
+
+	if publisherKeysEqual(committed.pem, derivedPubPEM) {
+		fmt.Fprintf(stdout, "    Committed %s matches this signing key.\n", committed.path)
+		return
+	}
+
+	// A committed key that does not match the freshly derived signing key means
+	// regenerating the signing key has orphaned the repo's publisher.pub. The
+	// launch-time publisher-trust gate is fail-closed, so every consumer that
+	// seeded the old key will refuse to launch this plan. Warn prominently and
+	// non-fatally with the exact fix.
+	fmt.Fprintf(stdout, "  WARNING: committed %s is STALE: it does not match the signing key just used.\n", committed.path)
+	fmt.Fprintln(stdout, "    Consumers who trusted the committed key will FAIL the launch publisher-trust gate.")
+	fmt.Fprintf(stdout, "    Fix: recommit the surfaced key, then refreeze and republish:\n")
+	fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, committed.path)
+}
+
+// committedPublisherKey is a committed keys/publisher.pub found on the ascent
+// from a freeze source path: its on-disk location and PEM bytes.
+type committedPublisherKey struct {
+	path string
+	pem  []byte
+}
+
+// findCommittedPublisherKey walks up from the freeze source's SKILL.md directory
+// looking for an existing committed keys/publisher.pub. The ascent is bounded: it
+// stops at the git/repo root (a directory containing a `.git` entry) or after a
+// small fixed number of levels, so it never escapes far up the filesystem. It
+// returns false when srcPath is empty (frozen from an installed skill name, no
+// repo to check) or no committed key is found.
+func findCommittedPublisherKey(srcPath string) (committedPublisherKey, bool) {
+	if srcPath == "" {
+		return committedPublisherKey{}, false
+	}
+	dir := filepath.Dir(srcPath)
+	// Bound the ascent so a stray SKILL.md deep in the filesystem never walks to
+	// the root probing every ancestor. 24 levels comfortably covers any real repo
+	// layout while staying finite.
+	for i := 0; i < 24; i++ {
+		candidate := filepath.Join(dir, publisherKeyRepoPath)
+		if b, err := os.ReadFile(candidate); err == nil {
+			return committedPublisherKey{path: candidate, pem: b}, true
+		}
+		// Stop at the repo root: a `.git` entry marks the top of the working tree,
+		// beyond which there is no repo to reconcile against.
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return committedPublisherKey{}, false
+}
+
+// publisherKeysEqual reports whether two PEM-encoded public keys represent the
+// same ed25519 key. It compares the parsed keys (not the raw PEM bytes) so
+// whitespace, trailing-newline, or line-wrapping differences between a
+// hand-committed key and freeze's emitted key never read as divergence. When
+// either input fails to parse, it falls back to a trimmed byte compare so a
+// malformed committed key that nonetheless matches byte-for-byte is not
+// mis-flagged as stale.
+func publisherKeysEqual(a, b []byte) bool {
+	ka, aerr := cstore.ParsePEMPublicKey(a)
+	kb, berr := cstore.ParsePEMPublicKey(b)
+	if aerr == nil && berr == nil {
+		return ka.Equal(kb)
+	}
+	return bytes.Equal(bytes.TrimSpace(a), bytes.TrimSpace(b))
 }
 
 // validatePublisherAuthority checks that a --publisher value is a connector-
@@ -152,8 +271,11 @@ func validatePublisherAuthority(authority string) error {
 
 // readSkillForFreeze loads the SKILL.md bytes to freeze. The target is
 // either an installed skill name (read from the store) or a filesystem path
-// to a skill directory or a SKILL.md file.
-func readSkillForFreeze(target string) ([]byte, error) {
+// to a skill directory or a SKILL.md file. The returned srcPath is the resolved
+// on-disk SKILL.md path when the source was a filesystem path, and "" when the
+// source was an installed skill name (there is no source repo to reconcile a
+// committed publisher key against in that case).
+func readSkillForFreeze(target string) (raw []byte, srcPath string, err error) {
 	// A filesystem path (directory or SKILL.md) takes precedence when it
 	// exists, so a local author can freeze before installing.
 	if info, statErr := os.Stat(target); statErr == nil {
@@ -161,22 +283,28 @@ func readSkillForFreeze(target string) ([]byte, error) {
 		if info.IsDir() {
 			path = filepath.Join(target, "SKILL.md")
 		} else if filepath.Base(target) != "SKILL.md" {
-			return nil, fmt.Errorf("freeze source %q is not a SKILL.md", target)
+			return nil, "", fmt.Errorf("freeze source %q is not a SKILL.md", target)
 		}
 		b, readErr := os.ReadFile(path)
 		if readErr != nil {
-			return nil, fmt.Errorf("read %s: %w", path, readErr)
+			return nil, "", fmt.Errorf("read %s: %w", path, readErr)
 		}
-		return b, nil
+		abs, absErr := filepath.Abs(path)
+		if absErr != nil {
+			// Fall back to the resolved (possibly relative) path: the ancestor
+			// walk still works from a relative dir, it just cannot climb above cwd.
+			abs = path
+		}
+		return b, abs, nil
 	}
 
 	// Otherwise treat it as an installed skill name.
 	s := store.New(skillStoreDir)
 	b, readErr := s.Read(target)
 	if readErr != nil {
-		return nil, fmt.Errorf("no installed skill or path %q (install it first, or pass a path to a SKILL.md): %w", target, readErr)
+		return nil, "", fmt.Errorf("no installed skill or path %q (install it first, or pass a path to a SKILL.md): %w", target, readErr)
 	}
-	return b, nil
+	return b, "", nil
 }
 
 // frozenVersionID derives the immutable store directory id from a

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -128,6 +128,83 @@ func writeSigningKey(t *testing.T) string {
 	return path
 }
 
+// writeSigningKeyWithPub writes a fresh PKCS#8 ed25519 PEM signing key to a temp
+// file and returns its path plus the PKIX PEM of the matching public key (the
+// exact bytes freeze derives and surfaces as signing-key.pub). Tests use the
+// returned PEM to seed a committed keys/publisher.pub that either matches or (by
+// generating a second key) diverges from the signing key.
+func writeSigningKeyWithPub(t *testing.T) (keyPath string, pubPEM []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path, pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+}
+
+// freshPubPEM returns a PKIX PEM public key for a freshly generated, unrelated
+// ed25519 keypair — used to seed a STALE committed publisher key that does not
+// match the signing key.
+func freshPubPEM(t *testing.T) []byte {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}
+
+// exampleSourceInRepo materializes the worked example SKILL.md inside a fake repo
+// root (a dir containing a `.git` marker) and, when committedPub is non-nil,
+// writes it as keys/publisher.pub under that root. It returns the repo root and
+// the SKILL.md dir; the SKILL.md lives at <root>/plan/SKILL.md so the ancestor
+// walk must climb one level to find the committed key, and the `.git` marker
+// bounds the ascent.
+func exampleSourceInRepo(t *testing.T, committedPub []byte) (repoRoot, skillDir string) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	repoRoot = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillDir = filepath.Join(repoRoot, "plan")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if committedPub != nil {
+		keysDir := filepath.Join(repoRoot, "keys")
+		if err := os.MkdirAll(keysDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(keysDir, "publisher.pub"), committedPub, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repoRoot, skillDir
+}
+
 // installExample copies the worked example into the temp store under its
 // name so `skill freeze <name>` can read it.
 func installExample(t *testing.T, storeDir string) {
@@ -715,6 +792,147 @@ func TestRunSkillFreeze_InvalidPublisherFails(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "invalid --publisher") {
 		t.Errorf("stderr = %q, want an invalid-publisher message", stderr.String())
+	}
+}
+
+// TestRunSkillFreeze_SurfacesPublisherKey proves that with --publisher set the
+// freeze summary surfaces the stored signing-key.pub path and the exact
+// keys/publisher.pub target with a copy hint, so the committed pubkey is a
+// byproduct of freezing (issue #2146, item 1).
+func TestRunSkillFreeze_SurfacesPublisherKey(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	src := exampleSource(t) // a bare temp dir with no repo / committed key
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", src}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, signingKeyPubFile) {
+		t.Errorf("summary must surface the stored %s path:\n%s", signingKeyPubFile, out)
+	}
+	if !strings.Contains(out, publisherKeyRepoPath) {
+		t.Errorf("summary must surface the committed %s target:\n%s", publisherKeyRepoPath, out)
+	}
+}
+
+// TestRunSkillFreeze_NoPublisherDoesNotSurfaceKey proves the key surface is gated
+// on --publisher: an omitted publisher (no launch trust gate) prints no
+// publisher-key lines.
+func TestRunSkillFreeze_NoPublisherDoesNotSurfaceKey(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	src := exampleSource(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, src}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Publisher key:") {
+		t.Errorf("without --publisher the summary must not surface a publisher key:\n%s", stdout.String())
+	}
+}
+
+// TestRunSkillFreeze_StaleCommittedKeyWarns proves the divergence check (issue
+// #2146, item 2): freezing --publisher from a repo path whose committed
+// keys/publisher.pub does NOT match the signing key prints a prominent NON-FATAL
+// stale-key warning and still exits 0.
+func TestRunSkillFreeze_StaleCommittedKeyWarns(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	// Commit an unrelated key so the freshly-derived signing key diverges from it.
+	_, skillDir := exampleSourceInRepo(t, freshPubPEM(t))
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", filepath.Join(skillDir, "SKILL.md")}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("a stale committed key must warn NON-fatally; exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "STALE") {
+		t.Errorf("a diverged committed key must produce a STALE warning:\n%s", out)
+	}
+	if !strings.Contains(out, publisherKeyRepoPath) {
+		t.Errorf("the stale warning must point at the committed key path:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_MatchingCommittedKeyNoWarning proves a committed
+// keys/publisher.pub that matches the signing key produces no stale warning
+// (compared as parsed ed25519 keys, so PEM whitespace never trips it).
+func TestRunSkillFreeze_MatchingCommittedKeyNoWarning(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key, pub := writeSigningKeyWithPub(t)
+	// Seed the committed key with extra surrounding whitespace to prove the
+	// compare ignores PEM whitespace differences.
+	committed := append([]byte("\n\n"), append(pub, '\n')...)
+	_, skillDir := exampleSourceInRepo(t, committed)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", filepath.Join(skillDir, "SKILL.md")}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "STALE") {
+		t.Errorf("a matching committed key must NOT warn:\n%s", out)
+	}
+	if !strings.Contains(out, "matches this signing key") {
+		t.Errorf("a matching committed key should be confirmed:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_NoCommittedKeyHints proves that freezing --publisher from a
+// repo with no committed keys/publisher.pub prints a create hint rather than a
+// warning.
+func TestRunSkillFreeze_NoCommittedKeyHints(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	_, skillDir := exampleSourceInRepo(t, nil) // repo root, no committed key
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", filepath.Join(skillDir, "SKILL.md")}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "STALE") {
+		t.Errorf("no committed key must not warn STALE:\n%s", out)
+	}
+	if !strings.Contains(out, "Commit it as "+publisherKeyRepoPath) {
+		t.Errorf("no committed key must print a create hint:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_InstalledNameNoDivergenceCheck proves freezing --publisher
+// from an installed skill name (no source repo path) surfaces the key but runs
+// no divergence check and never crashes (issue #2146, item 2: skip silently when
+// there is no repo).
+func TestRunSkillFreeze_InstalledNameNoDivergenceCheck(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("freeze from an installed name must succeed; exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "STALE") {
+		t.Errorf("an installed-name freeze has no repo, so no stale warning:\n%s", out)
+	}
+	// The key is still surfaced with a generic commit hint.
+	if !strings.Contains(out, "Publisher key:") {
+		t.Errorf("the surfaced publisher key must still print for an installed-name freeze:\n%s", out)
 	}
 }
 
@@ -1590,14 +1808,14 @@ func TestReadSkillForFreeze_NonSkillFilePath(t *testing.T) {
 	if err := os.WriteFile(notSkill, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readSkillForFreeze(notSkill); err == nil {
+	if _, _, err := readSkillForFreeze(notSkill); err == nil {
 		t.Error("a non-SKILL.md file path must error")
 	}
 }
 
 func TestReadSkillForFreeze_DirectoryWithoutSkill(t *testing.T) {
 	withTempStore(t)
-	if _, err := readSkillForFreeze(t.TempDir()); err == nil {
+	if _, _, err := readSkillForFreeze(t.TempDir()); err == nil {
 		t.Error("a directory with no SKILL.md must error")
 	}
 }


### PR DESCRIPTION
## Summary

Freeze already computes and durably stores the publisher public key (`freeze.Sign` -> `res.PublicKey`, persisted per-version as `signing-key.pub`), but the CLI never surfaced it and never checked it against the repo's committed `keys/publisher.pub` (the path consumers seed via `keyring trust github://owner/repo`; constant `publisherKeyPath="keys/publisher.pub"`). Regenerating the signing key silently orphaned the committed pubkey, and the drift was only caught when a consumer failed the fail-closed publisher-trust gate at launch (issue #2146).

This change, entirely in `cmd/aileron/skill_freeze.go`:

1. **Surface the key.** When `--publisher` is set, the freeze summary prints the stored `signing-key.pub` path and the exact `keys/publisher.pub` target with a one-liner copy hint, so the committed pubkey is a byproduct of freezing rather than a manual afterthought.

2. **Divergence check.** When the freeze source is a filesystem path, freeze walks up from the SKILL.md dir (bounded ascent, stops at the `.git` repo root or 24 levels) to locate an existing committed `keys/publisher.pub`. If found and its parsed ed25519 key differs from `res.PublicKey` (parsed compare, so PEM whitespace never trips it), it prints a prominent **NON-FATAL** stale-key warning plus the fix (recommit the surfaced key, refreeze/republish). If absent, it prints a create hint. Frozen from an installed skill name (no repo path), the check is skipped silently.

Chose warn-on-divergence + surface-the-key over auto-writing into the working tree: auto-write is a riskier side-effect, the plan path is not always the repo root, and freeze-from-installed-name has no repo. The issue names warn-on-divergence as the floor.

The downstream manual runbook note is out of scope for this repo (noted in the issue).

## Test plan

New regression tests in `cmd/aileron/skill_freeze_test.go` (all fail before the fix — the impl change is load-bearing on `readSkillForFreeze`'s new return and the surface call):

- `TestRunSkillFreeze_SurfacesPublisherKey` — summary surfaces the pubkey path + `keys/publisher.pub` target when `--publisher` set.
- `TestRunSkillFreeze_NoPublisherDoesNotSurfaceKey` — no key surfaced without `--publisher`.
- `TestRunSkillFreeze_StaleCommittedKeyWarns` — path source with a stale committed key -> STALE warning, exit 0.
- `TestRunSkillFreeze_MatchingCommittedKeyNoWarning` — matching committed key (with extra PEM whitespace) -> no warning.
- `TestRunSkillFreeze_NoCommittedKeyHints` — repo with no committed key -> create hint.
- `TestRunSkillFreeze_InstalledNameNoDivergenceCheck` — installed-name freeze -> key surfaced, no divergence check, no crash.

`go test ./cmd/aileron/ -cover` passes at 87.1% coverage.

Closes #2146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THFiDrrPxmXLKRBu9Grjy6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `skill freeze --publisher` now displays the signing public-key location and the repository path where it should be committed.
  - Provides a copy command when no committed publisher key is found.
  - Confirms when the committed key matches the signing key.

- **Bug Fixes**
  - Detects stale committed publisher keys and displays a non-fatal warning with the exact recommit command.
  - Rejects filesystem inputs that are not `SKILL.md` files.
  - Handles installed skill names without repository checks or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
