### PR TITLE
fix(freeze): reconcile name-freeze publisher key against the remote

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -138,7 +138,7 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	// byproduct of freezing rather than a manual afterthought, and warn loudly
 	// when an existing committed key in the source repo has diverged from it.
 	if *publisher != "" {
-		surfacePublisherKey(stdout, s.FrozenDir(res.Name, id), srcPath, res.PublicKey)
+		surfacePublisherKey(stdout, s.FrozenDir(res.Name, id), srcPath, *publisher, res.PublicKey)
 	}
 	return 0
 }
@@ -157,26 +157,37 @@ const signingKeyPubFile = "signing-key.pub"
 
 // surfacePublisherKey prints where freeze stored the derived signing-key.pub and
 // the exact repo path a consumer seeds via `keyring trust`, plus a copy hint. It
-// then reconciles against any key already committed in the freeze source repo:
-// when the source was a filesystem path, it walks up from the SKILL.md dir to a
-// bounded repo root looking for a committed keys/publisher.pub. A committed key
-// whose ed25519 bytes differ from the freshly derived key is a STALE-key
-// divergence (the launch trust gate will fail closed for consumers), surfaced as
-// a prominent NON-FATAL warning with the fix. An absent key gets a create hint.
-// When frozen from an installed skill name (srcPath == ""), there is no repo to
-// reconcile, so only the surface + generic recommit hint prints.
-func surfacePublisherKey(stdout io.Writer, frozenDir, srcPath string, derivedPubPEM []byte) {
+// then reconciles the freshly derived key against the publisher's committed
+// keys/publisher.pub. Two reconciliation sources exist, tried in order:
+//
+//  1. A LOCAL committed key in the freeze source repo: when the source was a
+//     filesystem path, it walks up from the SKILL.md dir to a bounded repo root
+//     looking for a committed keys/publisher.pub.
+//  2. When no local key is found (the common freeze-by-installed-name flow, where
+//     srcPath == "" and there is no repo to walk) AND --publisher is a full
+//     per-repo FQN (github://owner/repo, not a bare owner), the REMOTE
+//     keys/publisher.pub is fetched via fetchPublisherKey — the exact bytes
+//     `keyring trust` fetches and consumers seed — so a name-freeze still catches
+//     a stale published key.
+//
+// A committed key whose ed25519 identity differs from the freshly derived key is a
+// STALE-key divergence (the launch trust gate will fail closed for consumers),
+// surfaced as a prominent NON-FATAL warning with the fix; a match prints a
+// confirmation. When neither source yields a key (no local repo, a bare-owner
+// publisher, or a remote fetch failure) the check is skipped non-fatally with a
+// clearer note than a generic recommit hint, so the author knows divergence was
+// NOT checked and should verify it by hand.
+func surfacePublisherKey(stdout io.Writer, frozenDir, srcPath, publisher string, derivedPubPEM []byte) {
 	storedPub := filepath.Join(frozenDir, signingKeyPubFile)
 	fmt.Fprintf(stdout, "  Publisher key: %s\n", storedPub)
 	fmt.Fprintf(stdout, "    Consumers trust this plan by committing it to %q in your repo\n", publisherKeyRepoPath)
 
 	committed, ok := findCommittedPublisherKey(srcPath)
 	if !ok {
-		// No repo path to reconcile (installed-name source) or no committed key
-		// found on the ascent: point the author at the copy that makes the key a
-		// byproduct of freezing.
-		fmt.Fprintf(stdout, "    Commit it as %s:\n", publisherKeyRepoPath)
-		fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, publisherKeyRepoPath)
+		// No LOCAL committed key to reconcile (installed-name source, or none found
+		// on the ascent). Fall back to the REMOTE published key so the primary
+		// freeze-by-installed-name flow is not silently skipped (issue #2148).
+		surfaceRemotePublisherDivergence(stdout, storedPub, publisher, derivedPubPEM)
 		return
 	}
 
@@ -194,6 +205,66 @@ func surfacePublisherKey(stdout io.Writer, frozenDir, srcPath string, derivedPub
 	fmt.Fprintln(stdout, "    Consumers who trusted the committed key will FAIL the launch publisher-trust gate.")
 	fmt.Fprintf(stdout, "    Fix: recommit the surfaced key, then refreeze and republish:\n")
 	fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, committed.path)
+}
+
+// surfaceRemotePublisherDivergence reconciles the freshly derived signing key
+// against the publisher's REMOTE committed keys/publisher.pub when no local repo
+// key was found. It runs only for a full per-repo FQN (github://owner/repo): a
+// bare-owner publisher (github://owner) resolves through the Hub, not a fixed
+// repo path, so there is no single keys/publisher.pub to fetch. The fetch is the
+// same fetchPublisherKey `keyring trust` uses (and stub-testable via the
+// rawGitHubBase / githubAPIBase seams), so a divergence surfaced here is exactly
+// what a consumer would trust. Like freeze's other network I/O (the base-image
+// pull) this is best-effort and NON-FATAL: on a bare-owner publisher or a fetch
+// failure it prints a clear "NOT checked" note and a commit hint rather than
+// failing the freeze.
+func surfaceRemotePublisherDivergence(stdout io.Writer, storedPub, publisher string, derivedPubPEM []byte) {
+	if isBareOwnerAuthority(publisher) {
+		// A bare-owner publisher has no fixed keys/publisher.pub to fetch (Hub
+		// resolution picks the repo). Skip the remote check and say so.
+		surfaceDivergenceNotChecked(stdout, storedPub, publisher, "a bare-owner --publisher resolves the key through the Hub, not a fixed repo")
+		return
+	}
+
+	remote, err := fetchPublisherKey(publisher)
+	if err != nil {
+		// Best-effort, like the base-image pull: a fetch failure (offline, private
+		// repo without a token, no committed key yet) must not fail the freeze.
+		surfaceDivergenceNotChecked(stdout, storedPub, publisher, fmt.Sprintf("fetching %s from %s failed: %v", publisherKeyRepoPath, publisher, err))
+		return
+	}
+
+	derived, err := cstore.ParsePEMPublicKey(derivedPubPEM)
+	if err != nil {
+		// The derived signing-key.pub freeze just emitted should always parse; if
+		// it somehow does not, skip the compare rather than mis-flag a divergence.
+		surfaceDivergenceNotChecked(stdout, storedPub, publisher, fmt.Sprintf("the surfaced signing key could not be parsed for comparison: %v", err))
+		return
+	}
+
+	if derived.Equal(remote) {
+		fmt.Fprintf(stdout, "    Published %s at %s matches this signing key.\n", publisherKeyRepoPath, publisher)
+		return
+	}
+
+	// The published key that consumers seed via `keyring trust` differs from the
+	// freshly derived signing key: every consumer that already trusted it will
+	// fail the fail-closed launch gate. Warn prominently and non-fatally.
+	fmt.Fprintf(stdout, "  WARNING: published %s at %s is STALE: it does not match the signing key just used.\n", publisherKeyRepoPath, publisher)
+	fmt.Fprintln(stdout, "    Consumers who trusted the published key will FAIL the launch publisher-trust gate.")
+	fmt.Fprintf(stdout, "    Fix: commit the surfaced key to %s and republish:\n", publisherKeyRepoPath)
+	fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, publisherKeyRepoPath)
+}
+
+// surfaceDivergenceNotChecked prints the non-fatal fallback when the publisher
+// key could not be reconciled (issue #2148 option 2): it names WHY the check was
+// skipped and still points the author at the commit that makes the key a
+// byproduct of freezing, so a manual verification is possible.
+func surfaceDivergenceNotChecked(stdout io.Writer, storedPub, publisher, reason string) {
+	fmt.Fprintf(stdout, "    NOTE: the committed %s for %s was NOT checked for divergence (%s); verify it matches the surfaced %s.\n",
+		publisherKeyRepoPath, publisher, reason, signingKeyPubFile)
+	fmt.Fprintf(stdout, "    Commit it as %s:\n", publisherKeyRepoPath)
+	fmt.Fprintf(stdout, "      cp %q %s\n", storedPub, publisherKeyRepoPath)
 }
 
 // committedPublisherKey is a committed keys/publisher.pub found on the ascent

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -10,6 +10,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -912,14 +914,19 @@ func TestRunSkillFreeze_NoCommittedKeyHints(t *testing.T) {
 }
 
 // TestRunSkillFreeze_InstalledNameNoDivergenceCheck proves freezing --publisher
-// from an installed skill name (no source repo path) surfaces the key but runs
-// no divergence check and never crashes (issue #2146, item 2: skip silently when
-// there is no repo).
+// from an installed skill name (no source repo path) surfaces the key and, when
+// the REMOTE published key is unreachable (no committed key yet — a 404),
+// prints a non-fatal "NOT checked" note rather than crashing or falsely warning
+// STALE (issue #2148: the name-freeze remote-fallback stays non-fatal on a
+// fetch miss). rawGitHubBase is stubbed to 404 so the test stays hermetic.
 func TestRunSkillFreeze_InstalledNameNoDivergenceCheck(t *testing.T) {
 	storeDir := withTempStore(t)
 	installExample(t, storeDir)
 	stubFreezeResolvers(t, fakeFreezeDigest)
 	key := writeSigningKey(t)
+	// Serve no publisher.pub for acme/plans: fetchPublisherKey 404s, so the
+	// remote reconciliation is skipped non-fatally.
+	withMockGitHubRaw(t, map[string][]byte{})
 
 	var stdout, stderr bytes.Buffer
 	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", "weekly-metrics-digest"}, &stdout, &stderr)
@@ -928,11 +935,112 @@ func TestRunSkillFreeze_InstalledNameNoDivergenceCheck(t *testing.T) {
 	}
 	out := stdout.String()
 	if strings.Contains(out, "STALE") {
-		t.Errorf("an installed-name freeze has no repo, so no stale warning:\n%s", out)
+		t.Errorf("an unreachable remote key must not warn STALE:\n%s", out)
+	}
+	if !strings.Contains(out, "NOT checked") {
+		t.Errorf("a remote fetch miss must print the non-fatal NOT-checked note:\n%s", out)
 	}
 	// The key is still surfaced with a generic commit hint.
 	if !strings.Contains(out, "Publisher key:") {
 		t.Errorf("the surfaced publisher key must still print for an installed-name freeze:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_InstalledNameRemoteStaleWarns is the issue #2148 regression:
+// freezing --publisher github://acme/plans from an installed skill NAME (srcPath
+// == "", so no local repo to walk) must reconcile the derived signing key against
+// the REMOTE committed keys/publisher.pub via fetchPublisherKey. A divergent
+// published key fires the same STALE warning the local-path check emits. Before
+// the fix this check was skipped entirely for name-freezes.
+func TestRunSkillFreeze_InstalledNameRemoteStaleWarns(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	// Publish a DIFFERENT (unrelated) key at acme/plans so the freshly derived
+	// signing key diverges from it. The path mirrors fetchPublisherKey's raw URL.
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/plans/HEAD/keys/publisher.pub": freshPubPEM(t),
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("a stale remote key must warn NON-fatally; exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "STALE") {
+		t.Errorf("a divergent remote key must produce a STALE warning on a name-freeze:\n%s", out)
+	}
+	if !strings.Contains(out, publisherKeyRepoPath) {
+		t.Errorf("the stale warning must point at the committed key path:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_InstalledNameRemoteMatchConfirms proves the agreement path:
+// a name-freeze whose REMOTE published key matches the derived signing key prints
+// a match confirmation and no STALE warning.
+func TestRunSkillFreeze_InstalledNameRemoteMatchConfirms(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key, pub := writeSigningKeyWithPub(t)
+	// Publish the MATCHING key so the derived signing key agrees with the remote.
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/plans/HEAD/keys/publisher.pub": pub,
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme/plans", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "STALE") {
+		t.Errorf("a matching remote key must NOT warn:\n%s", out)
+	}
+	if !strings.Contains(out, "matches this signing key") {
+		t.Errorf("a matching remote key should be confirmed:\n%s", out)
+	}
+}
+
+// TestRunSkillFreeze_InstalledNameBareOwnerSkipsRemote proves a bare-owner
+// --publisher (github://acme) skips the remote fetch entirely (it has no fixed
+// keys/publisher.pub — the Hub resolves the repo) and prints the non-fatal
+// NOT-checked note naming the bare-owner reason.
+func TestRunSkillFreeze_InstalledNameBareOwnerSkipsRemote(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	// Point rawGitHubBase at a server that fails the test if hit: a bare-owner
+	// publisher must never reach the per-repo raw fetch.
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--publisher", "github://acme", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if hit {
+		t.Errorf("a bare-owner publisher must not trigger a per-repo raw fetch")
+	}
+	out := stdout.String()
+	if strings.Contains(out, "STALE") {
+		t.Errorf("a bare-owner publisher must not warn STALE:\n%s", out)
+	}
+	if !strings.Contains(out, "NOT checked") {
+		t.Errorf("a bare-owner publisher must print the NOT-checked note:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

`aileron skill freeze --publisher github://owner/repo` surfaces the derived `signing-key.pub` and warns when a committed `keys/publisher.pub` has diverged (would fail-close the launch publisher-trust gate for every consumer). Before this change, that divergence check only reconciled against a **local** committed key found by walking up from the freeze source's `SKILL.md` dir. For the **primary** publish flow — `install <path>` then `freeze <name>` — the source is an installed skill name, `srcPath == ""`, and there is no local repo to walk, so the check was skipped entirely.

This threads the `--publisher` authority into `surfacePublisherKey`. When no local committed key is found **and** `--publisher` is a full per-repo FQN (`github://owner/repo`), it reconciles the freshly derived signing key against the **remote** `keys/publisher.pub` via the existing `fetchPublisherKey` — the exact bytes `keyring trust` fetches and consumers seed — and emits the same STALE warning on divergence / a match confirmation on agreement.

The fetch is best-effort and **non-fatal**, mirroring freeze's other network I/O (the base-image pull). Fallback (issue's option 2): on a bare-owner publisher (`github://owner`, Hub-resolved, no fixed repo path) or a fetch failure, it prints a clearer "NOT checked" note than the prior generic hint, so the author knows divergence was not verified and can check by hand.

Scope: single file `cmd/aileron/skill_freeze.go` plus tests. No spec/generated-file changes. No behavior change for the local-path freeze flow.

## Test plan

- `go build ./cmd/aileron/` — clean; `go vet` clean; `gofmt` clean.
- `go test ./cmd/aileron/` — pass, coverage 87.1%.
- New regression test `TestRunSkillFreeze_InstalledNameRemoteStaleWarns`: stubs `rawGitHubBase` to serve a divergent key, freezes by installed name with `--publisher github://acme/plans`, asserts STALE fires. **Fails before the fix** (only the generic commit hint printed), passes after.
- New `TestRunSkillFreeze_InstalledNameRemoteMatchConfirms`: matching remote key → confirmation, no STALE.
- New `TestRunSkillFreeze_InstalledNameBareOwnerSkipsRemote`: bare-owner `--publisher` never triggers a per-repo raw fetch, prints the non-fatal NOT-checked note.
- Updated `TestRunSkillFreeze_InstalledNameNoDivergenceCheck`: now stubs a 404 remote and asserts the non-fatal NOT-checked note (kept hermetic; no live network).

Closes #2148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THFiDrrPxmXLKRBu9Grjy6
