### PR TITLE
feat(webapp): add general audit events feed at /audit/events

### DIFF
--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -3,6 +3,7 @@ import {
 	decideActionApproval,
 	getHubInstallDecision,
 	listRecentMaterialized,
+	listAudit,
 	getAuditByContentHash,
 	getAuditByInvocation,
 	getAuditTrace
@@ -245,6 +246,35 @@ describe('audit wrappers — URL construction and unwrap', () => {
 		expect(url).toContain('limit=25');
 		expect(got).toHaveLength(1);
 		expect(got[0].audit_id).toBe('a1');
+	});
+
+	it('listAudit with no params requests /v1/audit with no query string and returns every event', async () => {
+		fetchSpy.mockResolvedValue(auditResponse([materializedEvent, nonMaterializedEvent]));
+
+		const got = await listAudit();
+
+		const url = auditCall(fetchSpy, '/v1/audit');
+		// The general feed does not narrow to materialized records, so both come back.
+		expect(got).toHaveLength(2);
+		// No filters → bare path, no `?`.
+		expect(url).not.toContain('?');
+	});
+
+	it('listAudit maps camelCase params onto the snake_case wire query, encoding values', async () => {
+		fetchSpy.mockResolvedValue(auditResponse([materializedEvent]));
+
+		await listAudit({
+			connectorFqn: 'github://aileron/slack',
+			class: 'execution.failed',
+			invocationId: 'inv/42',
+			limit: 25
+		});
+
+		const url = auditCall(fetchSpy, '/v1/audit?');
+		expect(url).toContain('connector_fqn=github%3A%2F%2Faileron%2Fslack');
+		expect(url).toContain('class=execution.failed');
+		expect(url).toContain('invocation_id=inv%2F42');
+		expect(url).toContain('limit=25');
 	});
 
 	it('getAuditByContentHash encodes the hash into the content_hash filter', async () => {

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -167,6 +167,46 @@ export async function listRecentMaterialized(limit = 100): Promise<AuditEvent[]>
 	);
 }
 
+/** Filter parameters for a general `GET /v1/audit` listing. Mirrors the
+ *  spec's `ListAuditParams` query set (internal/api/openapi.yaml): every
+ *  field is optional and maps 1:1 to a wire query parameter. Omitted
+ *  fields are left off the query string entirely, so the daemon applies
+ *  its defaults (newest-first, `limit` default 100). */
+export type AuditListParams = {
+	/** RFC3339 lower time bound. */
+	since?: string;
+	auditId?: string;
+	connectorFqn?: string;
+	/** Event class discriminator (e.g. `execution.failed`). */
+	class?: string;
+	outputName?: string;
+	contentHash?: string;
+	invocationId?: string;
+	limit?: number;
+};
+
+/** Lists audit events newest-first with any subset of the daemon's
+ *  supported filters, returning the flat event list. Unlike
+ *  {@link listRecentMaterialized} (which fetches-by-limit then narrows to
+ *  materialized-output records), this is the general feed: it surfaces
+ *  every event class the recorder holds, so the "Audit events" view can
+ *  render approvals, action calls, failures, and bindings alongside
+ *  materialized outputs. */
+export async function listAudit(params: AuditListParams = {}): Promise<AuditEvent[]> {
+	const qs = new URLSearchParams();
+	if (params.since) qs.set('since', params.since);
+	if (params.auditId) qs.set('audit_id', params.auditId);
+	if (params.connectorFqn) qs.set('connector_fqn', params.connectorFqn);
+	if (params.class) qs.set('class', params.class);
+	if (params.outputName) qs.set('output_name', params.outputName);
+	if (params.contentHash) qs.set('content_hash', params.contentHash);
+	if (params.invocationId) qs.set('invocation_id', params.invocationId);
+	if (params.limit !== undefined) qs.set('limit', String(params.limit));
+	const suffix = qs.toString();
+	const resp = await apiFetch<AuditListResponse>(`/v1/audit${suffix ? `?${suffix}` : ''}`);
+	return resp.events ?? [];
+}
+
 /** Resolves the audit event(s) for a single artifact content hash. The
  *  daemon supports the `content_hash` filter on `GET /v1/audit`. */
 export async function getAuditByContentHash(hash: string): Promise<AuditEvent[]> {

--- a/webapp/src/lib/audit/payload.test.ts
+++ b/webapp/src/lib/audit/payload.test.ts
@@ -6,6 +6,9 @@ import {
 	signatureVerified,
 	actorLabel,
 	resolvedInputs,
+	auditPayloadSummary,
+	payloadName,
+	payloadConnector,
 	SIGNATURE_STATUS_VERIFIED
 } from './payload';
 import type { AuditEvent } from '$lib/api';
@@ -122,6 +125,105 @@ describe('actorLabel', () => {
 		expect(
 			actorLabel(evActor(undefined, { 'aileron.actor.identity_label': 'flat@corp' }))
 		).toBe('flat@corp');
+	});
+});
+
+describe('audit event summary (CLI parity)', () => {
+	// Mirrors the Go cases in cmd/aileron/main_test.go
+	// (TestAuditPayloadSummary_PerEventShape) plus the approval shape called
+	// out in #2162, so the webapp feed and the `aileron audit` CLI render the
+	// identical summary line for the same event.
+	function ev(eventType: string, payload: Record<string, unknown>): AuditEvent {
+		return { audit_id: 'x', event_type: eventType, timestamp: 't', payload };
+	}
+
+	describe('payloadName', () => {
+		it('prefers the action name', () => {
+			expect(payloadName(ev('action.installed', { 'aileron.action.name': 'ship-update' }))).toBe(
+				'ship-update'
+			);
+		});
+		it('falls back to the binding name', () => {
+			expect(payloadName(ev('binding.created', { 'aileron.binding.name': 'slack-prod' }))).toBe(
+				'slack-prod'
+			);
+		});
+		it('is empty when neither key is present', () => {
+			expect(payloadName(ev('unknown', {}))).toBe('');
+		});
+	});
+
+	describe('payloadConnector', () => {
+		it('prefers the connector fqn', () => {
+			expect(
+				payloadConnector(ev('binding.created', { 'aileron.connector.fqn': 'github://aileron/slack' }))
+			).toBe('github://aileron/slack');
+		});
+		it('falls back to the action fqn', () => {
+			expect(
+				payloadConnector(ev('action.installed', { 'aileron.action.fqn': 'github://aileron/ship' }))
+			).toBe('github://aileron/ship');
+		});
+		it('reads the nested failure-details connector as a last resort', () => {
+			expect(
+				payloadConnector(
+					ev('execution.failed', { 'aileron.failure.details': { connector: 'github://aileron/x' } })
+				)
+			).toBe('github://aileron/x');
+		});
+		it('is empty when no connector key resolves', () => {
+			expect(payloadConnector(ev('unknown', {}))).toBe('');
+			expect(payloadConnector(ev('execution.failed', { 'aileron.failure.details': 'nope' }))).toBe(
+				''
+			);
+		});
+	});
+
+	describe('auditPayloadSummary', () => {
+		it('renders an action.installed event as name + connector (CLI parity)', () => {
+			expect(
+				auditPayloadSummary(
+					ev('action.installed', {
+						'aileron.action.name': 'ship-update',
+						'aileron.action.fqn': 'github://aileron/ship-update'
+					})
+				)
+			).toBe('name=ship-update connector=github://aileron/ship-update');
+		});
+		it('renders a binding event as connector only (CLI parity)', () => {
+			expect(
+				auditPayloadSummary(ev('binding.created', { 'aileron.connector.fqn': 'github://aileron/slack' }))
+			).toBe('connector=github://aileron/slack');
+		});
+		it('renders an empty summary for an event with no useful keys (CLI parity)', () => {
+			expect(auditPayloadSummary(ev('unknown', {}))).toBe('');
+		});
+		it('renders execution.failed as class (+ connector when present)', () => {
+			expect(
+				auditPayloadSummary(ev('execution.failed', { 'aileron.failure.class': 'timeout' }))
+			).toBe('class=timeout');
+			expect(
+				auditPayloadSummary(
+					ev('execution.failed', {
+						'aileron.failure.class': 'auth',
+						'aileron.failure.details': { connector: 'github://aileron/slack' }
+					})
+				)
+			).toBe('class=auth connector=github://aileron/slack');
+		});
+		it('summarizes an approval.approved connector-action event by name + connector', () => {
+			// An approved connector-action approval carries the gated action's
+			// identity in the OTel-namespaced keys; the feed reads it the same
+			// way the CLI does, yielding a name+connector one-liner.
+			expect(
+				auditPayloadSummary(
+					ev('approval.approved', {
+						'aileron.action.name': 'send_email',
+						'aileron.connector.fqn': 'github://aileron/google'
+					})
+				)
+			).toBe('name=send_email connector=github://aileron/google');
+		});
 	});
 });
 

--- a/webapp/src/lib/audit/payload.ts
+++ b/webapp/src/lib/audit/payload.ts
@@ -223,6 +223,77 @@ export function invocationId(e: AuditEvent): string | undefined {
 	return str(e.payload, 'aileron.invocation.id');
 }
 
+// --- one-line event summary (parity with the CLI) ---
+//
+// The `aileron audit` CLI renders each event as a single
+// timestamp/audit-id/event-type/summary row. The summary column is a
+// human-readable hint pulled from the most identifying payload fields of
+// each event shape. The three functions below are a faithful port of
+// `auditPayloadSummary`, `payloadName`, and `payloadConnector` from
+// cmd/aileron/main.go, so the "Audit events" webapp feed reads the same
+// line the CLI prints for the same event. Payload keys follow the
+// OTel-namespaced audit schema (issue #390).
+
+/** Reads a raw string payload value with no non-empty coercion, matching
+ *  the Go type-assertion semantics the CLI relies on (an empty string is
+ *  a present-but-empty value, distinct from a missing key). Used only by
+ *  the summary port; the accessors above intentionally treat "" as
+ *  absent. */
+function rawStr(payload: Record<string, unknown>, key: string): string {
+	const v = payload[key];
+	return typeof v === 'string' ? v : '';
+}
+
+/** Pulls a human-identifying name from the namespaced payload. Action and
+ *  binding events surface different keys; either resolves to the same
+ *  single-line summary slot. Mirrors `payloadName` in cmd/aileron/main.go. */
+export function payloadName(e: AuditEvent): string {
+	const action = rawStr(e.payload, 'aileron.action.name');
+	if (action) return action;
+	const binding = rawStr(e.payload, 'aileron.binding.name');
+	if (binding) return binding;
+	return '';
+}
+
+/** Pulls the connector FQN backing an event, checking connector, action,
+ *  and nested failure-detail keys in the CLI's order. Mirrors
+ *  `payloadConnector` in cmd/aileron/main.go. */
+export function payloadConnector(e: AuditEvent): string {
+	const conn = rawStr(e.payload, 'aileron.connector.fqn');
+	if (conn) return conn;
+	const actionFqn = rawStr(e.payload, 'aileron.action.fqn');
+	if (actionFqn) return actionFqn;
+	const details = e.payload['aileron.failure.details'];
+	if (details !== null && typeof details === 'object' && !Array.isArray(details)) {
+		const c = (details as Record<string, unknown>)['connector'];
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	return '';
+}
+
+/** Renders a one-line, human-readable hint about an event, pulling the
+ *  most identifying fields from each event shape the recorder emits.
+ *  Faithful port of `auditPayloadSummary` in cmd/aileron/main.go — an
+ *  `execution.failed` event summarizes its class (and connector, if any);
+ *  every other event prefers a name, then a connector, then blank. */
+export function auditPayloadSummary(e: AuditEvent): string {
+	if (e.event_type === 'execution.failed') {
+		const cls = rawStr(e.payload, 'aileron.failure.class');
+		const conn = payloadConnector(e);
+		if (conn) return `class=${cls} connector=${conn}`;
+		return `class=${cls}`;
+	}
+	const name = payloadName(e);
+	if (name) {
+		const conn = payloadConnector(e);
+		if (conn) return `name=${name} connector=${conn}`;
+		return `name=${name}`;
+	}
+	const conn = payloadConnector(e);
+	if (conn) return `connector=${conn}`;
+	return '';
+}
+
 // --- formatting helpers (reused by cards) ---
 
 /** Shortens a `sha256:<hex>` (or bare hex) content hash for card display,

--- a/webapp/src/routes/audit/+page.svelte
+++ b/webapp/src/routes/audit/+page.svelte
@@ -137,7 +137,14 @@
 	<title>Audit — Aileron</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Audit &amp; Provenance</h1>
+<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
+	<h1 class="text-3xl font-extrabold tracking-tight">Audit &amp; Provenance</h1>
+	<a
+		href="/audit/events"
+		data-testid="to-events"
+		class="text-sm text-primary no-underline hover:underline">All audit events →</a
+	>
+</div>
 
 {#if root && graph}
 	<!-- Focused artifact graph / timeline -->

--- a/webapp/src/routes/audit/events/+page.svelte
+++ b/webapp/src/routes/audit/events/+page.svelte
@@ -18,15 +18,24 @@
 	let loading = $state(true);
 	let error = $state('');
 
+	// Guards against a slow earlier load() (e.g. a double-clicked refresh)
+	// resolving after a newer one and overwriting fresher data or clearing
+	// the newer request's loading state. Only the latest invocation applies
+	// its result — mirrors the invocation-id staleness guard on the
+	// provenance view.
+	let loadVersion = 0;
+
 	async function load() {
+		const version = ++loadVersion;
 		loading = true;
 		error = '';
 		try {
-			events = await listAudit();
+			const result = await listAudit();
+			if (version === loadVersion) events = result;
 		} catch (e) {
-			error = e instanceof Error ? e.message : String(e);
+			if (version === loadVersion) error = e instanceof Error ? e.message : String(e);
 		} finally {
-			loading = false;
+			if (version === loadVersion) loading = false;
 		}
 	}
 
@@ -85,7 +94,10 @@
 			</Card.Root>
 		{/each}
 	</div>
-	<div class="mt-4">
-		<Button variant="ghost" size="sm" data-testid="events-refresh" onclick={load}>Refresh</Button>
-	</div>
 {/if}
+
+<div class="mt-4">
+	<Button variant="ghost" size="sm" data-testid="events-refresh" disabled={loading} onclick={load}
+		>Refresh</Button
+	>
+</div>

--- a/webapp/src/routes/audit/events/+page.svelte
+++ b/webapp/src/routes/audit/events/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { listAudit, type AuditEvent } from '$lib/api';
+	import * as p from '$lib/audit/payload';
+
+	// `/audit/events` — the general audit-events feed (Option B, #2162). A
+	// sibling to the artifact-scoped provenance view at `/audit`: where that
+	// view walks a materialized artifact back to its inputs, this one lists
+	// every audit event newest-first, rendering the same
+	// timestamp/audit-id/event-type/summary line the `aileron audit` CLI
+	// prints. The summary column reuses the CLI's `auditPayloadSummary` port
+	// so the two surfaces read identically for the same event.
+
+	let events = $state<AuditEvent[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	async function load() {
+		loading = true;
+		error = '';
+		try {
+			events = await listAudit();
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => {
+		void load();
+	});
+</script>
+
+<svelte:head>
+	<title>Audit events — Aileron</title>
+</svelte:head>
+
+<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
+	<h1 class="text-3xl font-extrabold tracking-tight">Audit events</h1>
+	<a
+		href="/audit"
+		data-testid="to-provenance"
+		class="text-sm text-primary no-underline hover:underline">Provenance &amp; artifacts →</a
+	>
+</div>
+
+<p class="mb-4 text-sm text-muted-foreground">
+	Every audit event the running daemon has recorded, newest first. To walk a
+	materialized artifact back to the launch, steps, and inputs that produced it,
+	use the <a href="/audit" class="text-primary hover:underline">provenance view</a>.
+</p>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading audit events…</p>
+{:else if error}
+	<p class="text-destructive" data-testid="events-error">{error}</p>
+{:else if events.length === 0}
+	<p class="text-muted-foreground" data-testid="events-empty">
+		No audit events recorded yet. Actions, approvals, and Flight Plan launches
+		appear here as the daemon records them.
+	</p>
+{:else}
+	<div class="flex flex-col gap-3" data-testid="events-list">
+		{#each events as event (event.audit_id)}
+			{@const summary = p.auditPayloadSummary(event)}
+			<Card.Root data-testid="event-row">
+				<Card.Header>
+					<div class="flex items-center justify-between gap-2">
+						<span class="font-mono text-xs text-muted-foreground">{event.timestamp}</span>
+						<Badge variant="outline" data-testid="event-type">{event.event_type}</Badge>
+					</div>
+				</Card.Header>
+				<Card.Content>
+					<p class="font-mono text-xs text-muted-foreground" data-testid="event-audit-id">
+						{event.audit_id}
+					</p>
+					{#if summary}
+						<p class="mt-1 text-sm" data-testid="event-summary">{summary}</p>
+					{/if}
+				</Card.Content>
+			</Card.Root>
+		{/each}
+	</div>
+	<div class="mt-4">
+		<Button variant="ghost" size="sm" data-testid="events-refresh" onclick={load}>Refresh</Button>
+	</div>
+{/if}

--- a/webapp/src/routes/audit/events/page.test.ts
+++ b/webapp/src/routes/audit/events/page.test.ts
@@ -110,6 +110,19 @@ describe('Audit events feed — /audit/events', () => {
 		});
 	});
 
+	it('keeps refresh available after an empty result so the feed can recover', async () => {
+		vi.mocked(listAudit).mockResolvedValueOnce([]);
+		render(Page);
+		await screen.findByTestId('events-empty');
+		// Refresh lives outside the state branches, so it is present even
+		// when the feed rendered empty.
+		vi.mocked(listAudit).mockResolvedValueOnce([event({ id: 'evt-1', type: 'action.installed' })]);
+		await fireEvent.click(screen.getByTestId('events-refresh'));
+		await waitFor(() => {
+			expect(screen.getByTestId('events-list')).toBeInTheDocument();
+		});
+	});
+
 	it('links back to the artifact-scoped provenance view', async () => {
 		vi.mocked(listAudit).mockResolvedValue([]);
 		render(Page);

--- a/webapp/src/routes/audit/events/page.test.ts
+++ b/webapp/src/routes/audit/events/page.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	listAudit: vi.fn()
+}));
+
+import Page from './+page.svelte';
+import { listAudit, type AuditEvent } from '$lib/api';
+
+// --- fixtures ---
+
+function event(opts: {
+	id: string;
+	type: string;
+	timestamp?: string;
+	payload?: Record<string, unknown>;
+}): AuditEvent {
+	return {
+		audit_id: opts.id,
+		event_type: opts.type,
+		timestamp: opts.timestamp ?? '2026-07-04T00:00:00Z',
+		payload: opts.payload ?? {}
+	};
+}
+
+beforeEach(() => {
+	vi.mocked(listAudit).mockReset();
+});
+
+describe('Audit events feed — /audit/events', () => {
+	it('lists every event class newest-first with a CLI-parity summary line', async () => {
+		vi.mocked(listAudit).mockResolvedValue([
+			event({
+				id: 'evt-approval',
+				type: 'approval.approved',
+				payload: {
+					'aileron.action.name': 'send_email',
+					'aileron.connector.fqn': 'github://aileron/google'
+				}
+			}),
+			event({
+				id: 'evt-binding',
+				type: 'binding.created',
+				payload: { 'aileron.connector.fqn': 'github://aileron/slack' }
+			}),
+			event({
+				id: 'evt-fail',
+				type: 'execution.failed',
+				payload: { 'aileron.failure.class': 'timeout' }
+			})
+		]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('events-list')).toBeInTheDocument();
+		});
+		// listAudit is called with no filters — the general feed.
+		expect(vi.mocked(listAudit)).toHaveBeenCalledWith();
+
+		const rows = screen.getAllByTestId('event-row');
+		expect(rows.length).toBe(3);
+
+		// The approval row renders the event type, its audit id, and the
+		// name+connector summary the CLI would print for the same event.
+		const approvalRow = rows[0];
+		expect(approvalRow).toHaveTextContent('approval.approved');
+		expect(approvalRow).toHaveTextContent('evt-approval');
+		expect(approvalRow).toHaveTextContent('name=send_email connector=github://aileron/google');
+
+		// A binding event summarizes as connector only; a failure as class.
+		expect(rows[1]).toHaveTextContent('connector=github://aileron/slack');
+		expect(rows[2]).toHaveTextContent('class=timeout');
+	});
+
+	it('omits the summary line for an event with no identifying payload', async () => {
+		vi.mocked(listAudit).mockResolvedValue([event({ id: 'evt-bare', type: 'daemon.started' })]);
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('event-row')).toBeInTheDocument();
+		});
+		expect(screen.queryByTestId('event-summary')).not.toBeInTheDocument();
+	});
+
+	it('shows the empty state when nothing is recorded', async () => {
+		vi.mocked(listAudit).mockResolvedValue([]);
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('events-empty')).toBeInTheDocument();
+		});
+	});
+
+	it('surfaces a listing error', async () => {
+		vi.mocked(listAudit).mockRejectedValue(new Error('audit down'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('events-error')).toHaveTextContent('audit down');
+		});
+	});
+
+	it('re-fetches on refresh', async () => {
+		vi.mocked(listAudit).mockResolvedValue([event({ id: 'evt-1', type: 'action.installed' })]);
+		render(Page);
+		await screen.findByTestId('events-list');
+		expect(vi.mocked(listAudit)).toHaveBeenCalledTimes(1);
+		await fireEvent.click(screen.getByTestId('events-refresh'));
+		await waitFor(() => {
+			expect(vi.mocked(listAudit)).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	it('links back to the artifact-scoped provenance view', async () => {
+		vi.mocked(listAudit).mockResolvedValue([]);
+		render(Page);
+		await screen.findByTestId('events-empty');
+		expect(screen.getByTestId('to-provenance')).toHaveAttribute('href', '/audit');
+	});
+});


### PR DESCRIPTION
## Summary

Implements the Option-B design from #2162: a sibling **Audit events** feed at a new route, leaving the artifact-scoped provenance view at `/audit` unchanged.

- The provenance view (`/audit`) still walks a materialized artifact back to the launch, steps, and inputs that produced it.
- The new feed (`/audit/events`) lists **every** recorded audit event newest-first — approvals, action calls, failures, bindings, and materialized outputs — rendering the same `timestamp / audit-id / event-type / summary` line the `aileron audit` CLI prints.

No new API surface: `GET /v1/audit` already exposes the full filter set via `ListAuditParams`.

### Changes
- **`webapp/src/lib/api.ts`** — new `listAudit(params)` mapping a camelCase filter set onto the daemon's snake_case query params (`since`, `audit_id`, `connector_fqn`, `class`, `output_name`, `content_hash`, `invocation_id`, `limit`). Unlike `listRecentMaterialized` (fetch-by-limit then narrow to materialized), this is the general feed.
- **`webapp/src/lib/audit/payload.ts`** — faithful TS port of `auditPayloadSummary` / `payloadName` / `payloadConnector` from `cmd/aileron/main.go`, so the feed and CLI render identical summary lines for the same event.
- **`webapp/src/routes/audit/events/+page.svelte`** — the new feed, with cross-navigation to/from the provenance view. The `Audit` nav item still lands on `/audit`.
- **`webapp/src/routes/audit/+page.svelte`** — adds an "All audit events →" link into the new feed.

## Test plan
- `task test:webapp` (Vitest) — all 191 existing tests pass plus new coverage:
  - `api.test.ts`: `listAudit` builds the bare `/v1/audit` path with no filters and returns every event; maps + URL-encodes camelCase params onto the snake_case wire query.
  - `payload.test.ts`: `payloadName` / `payloadConnector` / `auditPayloadSummary` parity with the Go cases in `cmd/aileron/main_test.go`, including an `approval.approved` connector-action event shape.
  - `routes/audit/events/page.test.ts`: feed lists event classes with the CLI-parity summary, omits the summary for a bare event, empty state, listing error, refresh re-fetch, and cross-nav link.
- `task lint:webapp` (`svelte-check`) — 0 errors, 0 warnings.
- `pnpm build` (adapter-static) — new route compiles.

Closes #2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLBYARyFTqxhq4vGWdheR5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Audit Events page showing events in newest-first order.
  * Added event timestamps, types, IDs, summaries, loading, empty, and error states.
  * Added a Refresh button to reload audit events.
  * Added navigation from the audit overview to all events.
  * Added filtering support for retrieving audit events.
* **Bug Fixes**
  * Improved audit payload summaries for actions, bindings, failures, and approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->