### PR TITLE
feat(webapp): make approval body preview user-resizable

### DIFF
--- a/webapp/src/lib/components/ApprovalFieldsBlock.svelte
+++ b/webapp/src/lib/components/ApprovalFieldsBlock.svelte
@@ -17,6 +17,14 @@
 	// bearing rule: it draws embedded `\n` characters from the value as
 	// real newlines, which is what the user expects when they read an
 	// email body or commit message in the approval surface.
+	//
+	// The blockquote opens at a small preview height (`h-32`) with a
+	// `min-h-16` floor and `resize-y` so the user can drag the corner to
+	// expand it and read the whole value before authorizing an
+	// irreversible send. `overflow-y-auto` keeps a scrollbar for the
+	// remainder until they resize. There is deliberately no `max-h`: a
+	// cap would stop the drag short of revealing a long body, which is
+	// the exact review gap this affordance closes.
 
 	type Props = {
 		fields: ActionApprovalPreviewField[];
@@ -69,7 +77,7 @@
 			<div class="text-sm italic text-muted-foreground">n/a</div>
 		{:else}
 			<blockquote
-				class="max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded border-l-2 border-border bg-background/60 px-3 py-2 text-sm"
+				class="h-32 min-h-16 resize-y overflow-y-auto whitespace-pre-wrap break-words rounded border-l-2 border-border bg-background/60 px-3 py-2 text-sm"
 			>{field.value ?? ''}</blockquote>
 		{/if}
 	</div>

--- a/webapp/src/routes/approvals/page.test.ts
+++ b/webapp/src/routes/approvals/page.test.ts
@@ -347,6 +347,43 @@ describe('Approvals page — input_fields rendering (ADR-0003 amendment)', () =>
 		expect(blockquote!.textContent).not.toContain('\\n');
 	});
 
+	it('renders the multiline body as a user-resizable preview region', async () => {
+		// The user must be able to read the *entire* body before
+		// authorizing an irreversible send. The blockquote therefore
+		// opens at a small preview height but exposes a vertical resize
+		// handle (`resize-y`) so it can be dragged open to reveal the
+		// whole value, with `overflow-y-auto` scrolling the remainder
+		// until then. A `max-h` cap would stop the drag short of a long
+		// body, so its absence is part of the contract this pins.
+		const body = Array.from({ length: 40 }, (_, i) => `Line ${i + 1}`).join('\n');
+		setupWatcher([
+			{
+				id: 'act-input-resize',
+				kind: 'action' as const,
+				action_name: 'send-email',
+				args: { body },
+				requested_at: '2026-05-04T12:00:00Z',
+				input_fields: [{ label: 'Body', value: body, multiline: true }]
+			}
+		]);
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+		const blockquote = screen
+			.getByTestId('approval-input-multiline')
+			.querySelector('blockquote');
+		expect(blockquote).not.toBeNull();
+		// User-draggable vertical resize handle.
+		expect(blockquote!.className).toContain('resize-y');
+		// Small default preview height with a floor, scrollbar for the
+		// overflow, and no upper cap that would clip a long body.
+		expect(blockquote!.className).toContain('h-32');
+		expect(blockquote!.className).toContain('min-h-16');
+		expect(blockquote!.className).toContain('overflow-y-auto');
+		expect(blockquote!.className).not.toContain('max-h-');
+	});
+
 	it('renders missing required inputs as "n/a"', async () => {
 		setupWatcher([
 			{


### PR DESCRIPTION
## Summary

The Approvals page renders each multiline `[approval.preview]` / `[[inputs]]` field (email **Body**, commit messages, etc.) in a blockquote inside `ApprovalFieldsBlock.svelte`. It was clamped to `max-h-64` with a scrollbar and no way to expand, so reviewing a long body before authorizing an irreversible send was awkward.

This makes that blockquote user-resizable:

- Opens at a small preview height (`h-32`) with a `min-h-16` floor.
- Adds `resize-y` so the user can drag the corner to expand it and read the whole value.
- Keeps `overflow-y-auto` (scrollbar) and `whitespace-pre-wrap` (real newlines) intact.
- Drops the `max-h` cap so the drag isn't clipped short of a long body.

## Scope note

This addresses the aileron-actionable part of #2161 (the resizable body affordance, per the operator's answer 2). The reported body **truncation** (`#` mid-content cutoff) is an upstream google-connector bug — `send-draft` renders `message.snippet` from a `format=metadata` fetch — tracked separately at `ALRubinger/aileron-connector-google#48`. It is intentionally out of scope here.

## Test plan

- Added a regression test in `webapp/src/routes/approvals/page.test.ts` asserting the multiline body blockquote carries `resize-y`, the `h-32`/`min-h-16` preview height, `overflow-y-auto`, and no `max-h-` cap. Fails before the change, passes after.
- `pnpm test` (webapp Vitest): 192 passed.
- `pnpm run check` (svelte-check): 0 errors, 0 warnings.

Closes #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLBYARyFTqxhq4vGWdheR5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiline approval previews can now be resized vertically for easier viewing of longer content.
  * Previews retain scrolling while allowing expansion beyond the previous fixed height.

* **Tests**
  * Added coverage to verify resizing behavior, default preview sizing, scrolling, and the absence of a maximum height limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->